### PR TITLE
Fix for onError exceptions and temporary fix for chutzpah tests

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/chutzpah.json
+++ b/JavaScript/JavaScriptSDK.Tests/chutzpah.json
@@ -1,9 +1,11 @@
 ﻿{
-	"Framework": "qunit",
+    "Framework": "qunit",
     "References": [
         { "Path": "External/Sinon-1.7.3.js" },
         { "Path": "Selenium/JSLitmus.js" },
-        { "Path": "E2ETests/testSnippet.js" }
+        { "Path": "E2ETests/testSnippet.js" },
+        { "Path": "Selenium/checkinTests.js" }
     ],
-    "CodeCoverageExcludes": ["*Tests*"]
+    "EnableTestFileBatching": true,
+    "CodeCoverageExcludes": [ "*Tests*" ]
 }

--- a/JavaScript/JavaScriptSDK/appInsights.ts
+++ b/JavaScript/JavaScriptSDK/appInsights.ts
@@ -264,20 +264,32 @@ module Microsoft.ApplicationInsights {
             this.context._sender.triggerSend();
         }
 
+        /**
+         * The custom error handler for Application Insights
+         * @param {string} message - The error message
+         * @param {string} url - The url where the error was raised
+         * @param {number} lineNumber - The line number where the error was raised
+         * @param {number} columnNumber - The column number for the line where the error was raised
+         * @param {Error}  error - The Error object
+         */
         public _onerror(message: string, url: string, lineNumber: number, columnNumber: number, error: Error) {
-            if (!Util.isError(error)) {
-                // ensure that we have an error object (browser may not pass an error i.e safari)
-                try {
-                    throw new Error(message);
-                } catch (exception) {
-                    error = exception;
-                    if (!error["stack"]) {
-                        error["stack"] = "@" + url + ":" + lineNumber + ":" + (columnNumber || 0);
+            try {
+                if (!Util.isError(error)) {
+                    // ensure that we have an error object (browser may not pass an error i.e safari)
+                    try {
+                        throw new Error(message);
+                    } catch (exception) {
+                        error = exception;
+                        if (!error["stack"]) {
+                            error["stack"] = "@" + url + ":" + lineNumber + ":" + (columnNumber || 0);
+                        }
                     }
                 }
-            }
 
-            this.trackException(error);
+                this.trackException(error);
+            } catch (exception) {
+                _InternalLogging.warn("_onerror threw an exception: " + JSON.stringify(exception) + " while logging error: " + error.name + ", " + error.message);
+            }
         }
     }
 


### PR DESCRIPTION
This fixes address two issues -
1. Fix the exception that was being thrown by the _onError function.
2. Temporary fix for running chutzpah tests. We can now run all the tests in one batch. We cannot run individual tests yet. We will be fixing that in a next update.