### PR TITLE
Fixing bug 309973: Only sending PageViewPerformance object that has valid subcomponents.…

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/PageViewPerformance.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/PageViewPerformance.tests.ts
@@ -17,6 +17,7 @@ class PageViewPerformanceTelemetryTests extends ContractTestHelper {
             test: () => {
 
                 var telemetry = new Microsoft.ApplicationInsights.Telemetry.PageViewPerformance("name", "url", 0);
+                Assert.equal(true, telemetry.isValid);
 
                 var isAvailable = window.performance && window.performance.timing; // safari doesn't support this
                 if (isAvailable) {
@@ -36,6 +37,7 @@ class PageViewPerformanceTelemetryTests extends ContractTestHelper {
             name: name + "PageViewPerformanceTelemetry has correct serialization contract",
             test: () => {
                 var telemetry = new Microsoft.ApplicationInsights.Telemetry.PageViewPerformance("name", "url", 0);
+                Assert.equal(true, telemetry.isValid);
 
                 Assert.equal("boolean", typeof telemetry.aiDataContract.perfTotal, "perfTotal is set in data contract");
                 Assert.equal("boolean", typeof telemetry.aiDataContract.networkConnect, "networkConnect is set in data contract");
@@ -65,6 +67,8 @@ class PageViewPerformanceTelemetryTests extends ContractTestHelper {
 
 
                 var telemetry = new Microsoft.ApplicationInsights.Telemetry.PageViewPerformance("name", "url", 0);
+                Assert.equal(true, telemetry.isValid);
+
                 var data = telemetry;
 
                 Assert.equal(Microsoft.ApplicationInsights.Util.msToTimeSpan(59), data.perfTotal);
@@ -99,6 +103,8 @@ class PageViewPerformanceTelemetryTests extends ContractTestHelper {
 
 
                 var telemetry = new Microsoft.ApplicationInsights.Telemetry.PageViewPerformance("name", "url", 0);
+                Assert.equal(false, telemetry.isValid);
+
                 var data = telemetry;
 
                 Assert.equal(undefined, data.perfTotal);
@@ -106,6 +112,7 @@ class PageViewPerformanceTelemetryTests extends ContractTestHelper {
                 Assert.equal(undefined, data.sentRequest);
                 Assert.equal(undefined, data.receivedResponse);
                 Assert.equal(undefined, data.domProcessing);
+
                 Assert.equal("client performance math error:59 < 39 + 19 + 12 + 8", actualLoggedMessage);
 
                 timingSpy.restore();

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/PageViewPerformance.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/PageViewPerformance.tests.ts
@@ -17,7 +17,6 @@ class PageViewPerformanceTelemetryTests extends ContractTestHelper {
             test: () => {
 
                 var telemetry = new Microsoft.ApplicationInsights.Telemetry.PageViewPerformance("name", "url", 0);
-                Assert.equal(true, telemetry.isValid);
 
                 var isAvailable = window.performance && window.performance.timing; // safari doesn't support this
                 if (isAvailable) {
@@ -37,7 +36,6 @@ class PageViewPerformanceTelemetryTests extends ContractTestHelper {
             name: name + "PageViewPerformanceTelemetry has correct serialization contract",
             test: () => {
                 var telemetry = new Microsoft.ApplicationInsights.Telemetry.PageViewPerformance("name", "url", 0);
-                Assert.equal(true, telemetry.isValid);
 
                 Assert.equal("boolean", typeof telemetry.aiDataContract.perfTotal, "perfTotal is set in data contract");
                 Assert.equal("boolean", typeof telemetry.aiDataContract.networkConnect, "networkConnect is set in data contract");

--- a/JavaScript/JavaScriptSDK/appInsights.ts
+++ b/JavaScript/JavaScriptSDK/appInsights.ts
@@ -158,11 +158,13 @@ module Microsoft.ApplicationInsights {
                         durationMs = Telemetry.PageViewPerformance.getDuration(startTime, +new Date);
 
                         var pageViewPerformance = new Telemetry.PageViewPerformance(name, url, durationMs, properties, measurements);
-                        var pageViewPerformanceData = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.PageViewPerformance>(
-                            Telemetry.PageViewPerformance.dataType, pageViewPerformance);
-                        var pageViewPerformanceEnvelope = new Telemetry.Common.Envelope(pageViewPerformanceData, Telemetry.PageViewPerformance.envelopeType);
-                        this.context.track(pageViewPerformanceEnvelope);
-                        this.context._sender.triggerSend();
+                        if (pageViewPerformance.isValid) {
+                            var pageViewPerformanceData = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.PageViewPerformance>(
+                                Telemetry.PageViewPerformance.dataType, pageViewPerformance);
+                            var pageViewPerformanceEnvelope = new Telemetry.Common.Envelope(pageViewPerformanceData, Telemetry.PageViewPerformance.envelopeType);
+                            this.context.track(pageViewPerformanceEnvelope);
+                            this.context._sender.triggerSend();
+                        }
                     }
                 }, 100);
             }


### PR DESCRIPTION
… We are already checking for validity on PageViewPerformance telemetry items, however we were sending all them including invalid ones.