### PR TITLE
- Stop sending "Script error." - Adding try/catch blocks to public api

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Util.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Util.tests.ts
@@ -173,11 +173,11 @@ class UtilTests extends TestClass {
         });
 
         this.testCase({
-            name: "UtilTests: isMeaninglessError",
+            name: "UtilTests: isCrossOriginError",
             test: () => {
-                Assert.ok(Microsoft.ApplicationInsights.Util.isMeaninglessError("Script error.", "", 0, 0, null) === true);
+                Assert.ok(Microsoft.ApplicationInsights.Util.isCrossOriginError("Script error.", "", 0, 0, null) === true);
 
-                Assert.ok(Microsoft.ApplicationInsights.Util.isMeaninglessError("Script error.", "http://microsoft.com", 0, 0, null)
+                Assert.ok(Microsoft.ApplicationInsights.Util.isCrossOriginError("Script error.", "http://microsoft.com", 0, 0, null)
                     === false);
             }
         });

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Util.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Util.tests.ts
@@ -171,6 +171,16 @@ class UtilTests extends TestClass {
                 Assert.ok(Microsoft.ApplicationInsights.Util.stringToBoolOrDefault("TrUe") === true);
             }
         });
+
+        this.testCase({
+            name: "UtilTests: isMeaninglessError",
+            test: () => {
+                Assert.ok(Microsoft.ApplicationInsights.Util.isMeaninglessError("Script error.", "", 0, 0, null) === true);
+
+                Assert.ok(Microsoft.ApplicationInsights.Util.isMeaninglessError("Script error.", "http://microsoft.com", 0, 0, null)
+                    === false);
+            }
+        });
     }
 }
 new UtilTests().registerTests(); 

--- a/JavaScript/JavaScriptSDK/Sender.ts
+++ b/JavaScript/JavaScriptSDK/Sender.ts
@@ -87,13 +87,13 @@ module Microsoft.ApplicationInsights {
         
                 // validate input
                 if (!envelope) {
-                    _InternalLogging.throwInternalUserActionable(LoggingSeverity.WARNING, "Cannot send empty telemetry");
+                    _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "Cannot send empty telemetry");
                     return;
                 }
 
                 // ensure a sender was constructed
                 if (!this._sender) {
-                    _InternalLogging.warn("No sender could be constructed for this environment, payload will be added to buffer." + Serializer.serialize(envelope));
+                    _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "Sender was not initialized");
                     return;
                 }
             

--- a/JavaScript/JavaScriptSDK/Sender.ts
+++ b/JavaScript/JavaScriptSDK/Sender.ts
@@ -78,42 +78,45 @@ module Microsoft.ApplicationInsights {
          * Add a telemetry item to the send buffer
          */
         public send(envelope: Telemetry.Common.Envelope) {
-            
-            // if master off switch is set, don't send any data
-            if (this._config.disableTelemetry()) {
-                // Do not send/save data
-                return;
-            }
+            try {
+                // if master off switch is set, don't send any data
+                if (this._config.disableTelemetry()) {
+                    // Do not send/save data
+                    return;
+                }
         
-            // validate input
-            if (!envelope) {
-                _InternalLogging.throwInternalUserActionable(LoggingSeverity.WARNING, "Cannot send empty telemetry");
-                return;
-            }
+                // validate input
+                if (!envelope) {
+                    _InternalLogging.throwInternalUserActionable(LoggingSeverity.WARNING, "Cannot send empty telemetry");
+                    return;
+                }
 
-            // ensure a sender was constructed
-            if (!this._sender) {
-                _InternalLogging.warn("No sender could be constructed for this environment, payload will be added to buffer." + Serializer.serialize(envelope));
-                return;
-            }
+                // ensure a sender was constructed
+                if (!this._sender) {
+                    _InternalLogging.warn("No sender could be constructed for this environment, payload will be added to buffer." + Serializer.serialize(envelope));
+                    return;
+                }
             
-            // check if the incoming payload is too large, truncate if necessary
-            var payload: string = Serializer.serialize(envelope);
+                // check if the incoming payload is too large, truncate if necessary
+                var payload: string = Serializer.serialize(envelope);
             
-            // flush if we would exceet the max-size limit by adding this item
-            if (this._getSizeInBytes(this._buffer) + payload.length > this._config.maxBatchSizeInBytes()) {
-                this.triggerSend();
-            }
-
-            // enqueue the payload
-            this._buffer.push(payload);
-
-            // ensure an invocation timeout is set
-            if (!this._timeoutHandle) {
-                this._timeoutHandle = setTimeout(() => {
-                    this._timeoutHandle = null;
+                // flush if we would exceet the max-size limit by adding this item
+                if (this._getSizeInBytes(this._buffer) + payload.length > this._config.maxBatchSizeInBytes()) {
                     this.triggerSend();
-                }, this._config.maxBatchInterval());
+                }
+
+                // enqueue the payload
+                this._buffer.push(payload);
+
+                // ensure an invocation timeout is set
+                if (!this._timeoutHandle) {
+                    this._timeoutHandle = setTimeout(() => {
+                        this._timeoutHandle = null;
+                        this.triggerSend();
+                    }, this._config.maxBatchInterval());
+                }
+            } catch (e) {
+                _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "trackPageView failed: " + JSON.stringify(e));
             }
         }
 
@@ -135,28 +138,31 @@ module Microsoft.ApplicationInsights {
          * Immediately sennd buffered data
          */
         public triggerSend() {
+            try {
+                // Send data only if disableTelemetry is false
+                if (!this._config.disableTelemetry()) {
 
-            // Send data only if disableTelemetry is false
-            if (!this._config.disableTelemetry()) {
+                    if (this._buffer.length) {
+                        // compose an array of payloads
+                        var batch = this._config.emitLineDelimitedJson() ?
+                            this._buffer.join("\n") :
+                            "[" + this._buffer.join(",") + "]";
 
-                if (this._buffer.length) {
-                    // compose an array of payloads
-                    var batch = this._config.emitLineDelimitedJson() ?
-                        this._buffer.join("\n"):
-                        "[" + this._buffer.join(",") + "]";
+                        // invoke send
+                        this._sender(batch);
+                    }
 
-                    // invoke send
-                    this._sender(batch);
+                    // update lastSend time to enable throttling
+                    this._lastSend = +new Date;
                 }
 
-                // update lastSend time to enable throttling
-                this._lastSend = +new Date;
+                // clear buffer
+                this._buffer.length = 0;
+                clearTimeout(this._timeoutHandle);
+                this._timeoutHandle = null;
+            } catch (e) {
+                _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "trackPageView failed: " + JSON.stringify(e));
             }
-
-            // clear buffer
-            this._buffer.length = 0;
-            clearTimeout(this._timeoutHandle);
-            this._timeoutHandle = null;
         }
 
         /**

--- a/JavaScript/JavaScriptSDK/Util.ts
+++ b/JavaScript/JavaScriptSDK/Util.ts
@@ -83,7 +83,7 @@
         * Checks if error has no meaningful data inside. Ususally such errors are received by window.onerror when error
         * happens in a script from other domain (cross origin, CORS).
         */
-        public static isMeaninglessError(message: string, url: string, lineNumber: number, columnNumber: number, error: Error): boolean {
+        public static isCrossOriginError(message: string, url: string, lineNumber: number, columnNumber: number, error: Error): boolean {
             return message == "Script error."
                 && url == ""
                 && lineNumber == 0

--- a/JavaScript/JavaScriptSDK/Util.ts
+++ b/JavaScript/JavaScriptSDK/Util.ts
@@ -80,6 +80,18 @@
         }
 
         /**
+        * Checks if error has no meaningful data inside. Ususally such errors are received by window.onerror when error
+        * happens in a script from other domain (cross origin, CORS).
+        */
+        public static isMeaninglessError(message: string, url: string, lineNumber: number, columnNumber: number, error: Error): boolean {
+            return message == "Script error."
+                && url == ""
+                && lineNumber == 0
+                && columnNumber == 0
+                && error == null;
+        }
+
+        /**
          * Check if an object is of type Date
          */
         public static isDate(obj: any): boolean {

--- a/JavaScript/JavaScriptSDK/appInsights.ts
+++ b/JavaScript/JavaScriptSDK/appInsights.ts
@@ -322,7 +322,7 @@ module Microsoft.ApplicationInsights {
         public _onerror(message: string, url: string, lineNumber: number, columnNumber: number, error: Error) {
             try {
                 // filtering out "Script error." errors with no details - CORS case. 
-                if (Util.isMeaninglessError(message, url, lineNumber, columnNumber, error)) return;
+                if (Util.isCrossOriginError(message, url, lineNumber, columnNumber, error)) return;
 
                 if (!Util.isError(error)) {
                     // ensure that we have an error object (browser may not pass an error i.e safari)

--- a/JavaScript/JavaScriptSDK/appInsights.ts
+++ b/JavaScript/JavaScriptSDK/appInsights.ts
@@ -97,11 +97,15 @@ module Microsoft.ApplicationInsights {
          * @param   name  A string that idenfities this item, unique within this HTML document. Defaults to the document title.
          */
         public startTrackPage(name?: string) {
-            if (typeof name !== "string") {
-                name = window.document && window.document.title || "";
-            }
+            try {
+                if (typeof name !== "string") {
+                    name = window.document && window.document.title || "";
+                }
 
-            this._pageTracking.start(name);
+                this._pageTracking.start(name);
+            } catch (e) {
+                _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "startTrackPage failed: " + JSON.stringify(e));
+            }
         }
 
         /**
@@ -112,15 +116,19 @@ module Microsoft.ApplicationInsights {
          * @param   measurements    map[string, number] - metrics associated with this page, displayed in Metrics Explorer on the portal. Defaults to empty.
          */
         public stopTrackPage(name?: string, url?: string, properties?: Object, measurements?: Object) {
-            if (typeof name !== "string") {
-                name = window.document && window.document.title || "";
-            }
+            try {
+                if (typeof name !== "string") {
+                    name = window.document && window.document.title || "";
+                }
 
-            if (typeof url !== "string") {
-                url = window.location && window.location.href || "";
-            }
+                if (typeof url !== "string") {
+                    url = window.location && window.location.href || "";
+                }
 
-            this._pageTracking.stop(name, url, properties, measurements);
+                this._pageTracking.stop(name, url, properties, measurements);
+            } catch (e) {
+                _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "stopTrackPage failed: " + JSON.stringify(e));
+            }
         }
 
         /**
@@ -131,54 +139,62 @@ module Microsoft.ApplicationInsights {
          * @param   measurements    map[string, number] - metrics associated with this page, displayed in Metrics Explorer on the portal. Defaults to empty.
          */
         public trackPageView(name?: string, url?: string, properties?: Object, measurements?: Object) {
-            // ensure we have valid values for the required fields
-            if (typeof name !== "string") {
-                name = window.document && window.document.title || "";
-            }
+            try {
+                // ensure we have valid values for the required fields
+                if (typeof name !== "string") {
+                    name = window.document && window.document.title || "";
+                }
 
-            if (typeof url !== "string") {
-                url = window.location && window.location.href || "";
-            }
+                if (typeof url !== "string") {
+                    url = window.location && window.location.href || "";
+                }
 
-            var durationMs = 0;
-            // check if timing data is available
-            if (Telemetry.PageViewPerformance.checkPageLoad() !== undefined) {
-                // compute current duration (navigation start to now) for the pageViewTelemetry
-                var startTime = window.performance.timing.navigationStart;
-                durationMs = Telemetry.PageViewPerformance.getDuration(startTime, +new Date);
-
-                // poll for page load completion and send page view performance data when ready
-                var handle = setInterval(() => {
-                    // abort this check if we have not finished loading after 1 minute
+                var durationMs = 0;
+                // check if timing data is available
+                if (Telemetry.PageViewPerformance.checkPageLoad() !== undefined) {
+                    // compute current duration (navigation start to now) for the pageViewTelemetry
+                    var startTime = window.performance.timing.navigationStart;
                     durationMs = Telemetry.PageViewPerformance.getDuration(startTime, +new Date);
-                    var timingDataReady = Telemetry.PageViewPerformance.checkPageLoad();
-                    var timeoutReached = durationMs > 60000;
-                    if (timeoutReached || timingDataReady) {
-                        clearInterval(handle);
-                        durationMs = Telemetry.PageViewPerformance.getDuration(startTime, +new Date);
 
-                        var pageViewPerformance = new Telemetry.PageViewPerformance(name, url, durationMs, properties, measurements);
-                        if (pageViewPerformance.isValid) {
-                            var pageViewPerformanceData = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.PageViewPerformance>(
-                                Telemetry.PageViewPerformance.dataType, pageViewPerformance);
-                            var pageViewPerformanceEnvelope = new Telemetry.Common.Envelope(pageViewPerformanceData, Telemetry.PageViewPerformance.envelopeType);
-                            this.context.track(pageViewPerformanceEnvelope);
-                            this.context._sender.triggerSend();
+                    // poll for page load completion and send page view performance data when ready
+                    var handle = setInterval(() => {
+                        try {
+                            // abort this check if we have not finished loading after 1 minute
+                            durationMs = Telemetry.PageViewPerformance.getDuration(startTime, +new Date);
+                            var timingDataReady = Telemetry.PageViewPerformance.checkPageLoad();
+                            var timeoutReached = durationMs > 60000;
+                            if (timeoutReached || timingDataReady) {
+                                clearInterval(handle);
+                                durationMs = Telemetry.PageViewPerformance.getDuration(startTime, +new Date);
+
+                                var pageViewPerformance = new Telemetry.PageViewPerformance(name, url, durationMs, properties, measurements);
+                                if (pageViewPerformance.isValid) {
+                                    var pageViewPerformanceData = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.PageViewPerformance>(
+                                        Telemetry.PageViewPerformance.dataType, pageViewPerformance);
+                                    var pageViewPerformanceEnvelope = new Telemetry.Common.Envelope(pageViewPerformanceData, Telemetry.PageViewPerformance.envelopeType);
+                                    this.context.track(pageViewPerformanceEnvelope);
+                                    this.context._sender.triggerSend();
+                                }
+                            }
+                        } catch (e) {
+                            _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "trackPageView failed on page load calculation: " + JSON.stringify(e));
                         }
-                    }
+                    }, 100);
+                }
+
+                // track the initial page view
+                var pageView = new Telemetry.PageView(name, url, durationMs, properties, measurements);
+                var pageViewData = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.PageView>(Telemetry.PageView.dataType, pageView);
+                var pageViewEnvelope = new Telemetry.Common.Envelope(pageViewData, Telemetry.PageView.envelopeType);
+
+                this.context.track(pageViewEnvelope);
+                setTimeout(() => {
+                    // fire this event as soon as initial code execution completes in case the user navigates away
+                    this.context._sender.triggerSend();
                 }, 100);
+            } catch (e) {
+                _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "trackPageView failed: " + JSON.stringify(e));
             }
-
-            // track the initial page view
-            var pageView = new Telemetry.PageView(name, url, durationMs, properties, measurements);
-            var pageViewData = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.PageView>(Telemetry.PageView.dataType, pageView);
-            var pageViewEnvelope = new Telemetry.Common.Envelope(pageViewData, Telemetry.PageView.envelopeType);
-
-            this.context.track(pageViewEnvelope);
-            setTimeout(() => {
-                // fire this event as soon as initial code execution completes in case the user navigates away
-                this.context._sender.triggerSend();
-            }, 100);
         }
 
         /**
@@ -186,7 +202,11 @@ module Microsoft.ApplicationInsights {
          * @param   name    A string that identifies this event uniquely within the document.
          */
         public startTrackEvent(name: string) {
-            this._eventTracking.start(name);
+            try {
+                this._eventTracking.start(name);
+            } catch (e) {
+                _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "startTrackEvent failed: " + JSON.stringify(e));
+            }
         }
 
         /** 
@@ -196,7 +216,11 @@ module Microsoft.ApplicationInsights {
          * @param   measurements    map[string, number] - metrics associated with this event, displayed in Metrics Explorer on the portal. Defaults to empty.
          */
         public stopTrackEvent(name: string, properties?: Object, measurements?: Object) {
-            this._eventTracking.stop(name, undefined, properties, measurements);
+            try {
+                this._eventTracking.stop(name, undefined, properties, measurements);
+            } catch (e) {
+                _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "stopTrackEvent failed: " + JSON.stringify(e));
+            }
         }
 
         /** 
@@ -206,10 +230,14 @@ module Microsoft.ApplicationInsights {
          * @param   measurements    map[string, number] - metrics associated with this event, displayed in Metrics Explorer on the portal. Defaults to empty.
          */
         public trackEvent(name: string, properties?: Object, measurements?: Object) {
-            var eventTelemetry = new Telemetry.Event(name, properties, measurements);
-            var data = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.Event>(Telemetry.Event.dataType, eventTelemetry);
-            var envelope = new Telemetry.Common.Envelope(data, Telemetry.Event.envelopeType);
-            this.context.track(envelope);
+            try {
+                var eventTelemetry = new Telemetry.Event(name, properties, measurements);
+                var data = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.Event>(Telemetry.Event.dataType, eventTelemetry);
+                var envelope = new Telemetry.Common.Envelope(data, Telemetry.Event.envelopeType);
+                this.context.track(envelope);
+            } catch (e) {
+                _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "trackEvent failed: " + JSON.stringify(e));
+            }
         }
 
         /**
@@ -219,19 +247,23 @@ module Microsoft.ApplicationInsights {
          * @param   measurements    map[string, number] - metrics associated with this event, displayed in Metrics Explorer on the portal. Defaults to empty.
          */
         public trackException(exception: Error, handledAt?: string, properties?: Object, measurements?: Object) {
-            if (!Util.isError(exception)) {
-                // ensure that we have an error object (user could pass a string/message)
-                try {
-                    throw new Error(<any>exception);
-                } catch (error) {
-                    exception = error;
+            try {
+                if (!Util.isError(exception)) {
+                    // ensure that we have an error object (user could pass a string/message)
+                    try {
+                        throw new Error(<any>exception);
+                    } catch (error) {
+                        exception = error;
+                    }
                 }
-            }
 
-            var exceptionTelemetry = new Telemetry.Exception(exception, handledAt, properties, measurements);
-            var data = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.Exception>(Telemetry.Exception.dataType, exceptionTelemetry);
-            var envelope = new Telemetry.Common.Envelope(data, Telemetry.Exception.envelopeType);
-            this.context.track(envelope);
+                var exceptionTelemetry = new Telemetry.Exception(exception, handledAt, properties, measurements);
+                var data = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.Exception>(Telemetry.Exception.dataType, exceptionTelemetry);
+                var envelope = new Telemetry.Common.Envelope(data, Telemetry.Exception.envelopeType);
+                this.context.track(envelope);
+            } catch (e) {
+                _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "trackException failed: " + JSON.stringify(e));
+            }
         }
 
         /**
@@ -245,27 +277,38 @@ module Microsoft.ApplicationInsights {
          * @param   max The largest measurement in the sample. Defaults to the average.
          */
         public trackMetric(name: string, average: number, sampleCount?: number, min?: number, max?: number) {
+            try {
+                var telemetry = new Telemetry.Metric(name, average, sampleCount, min, max);
+                var data = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.Metric>(Telemetry.Metric.dataType, telemetry);
+                var envelope = new Telemetry.Common.Envelope(data, Telemetry.Metric.envelopeType);
 
-            var telemetry = new Telemetry.Metric(name, average, sampleCount, min, max);
-            var data = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.Metric>(Telemetry.Metric.dataType, telemetry);
-            var envelope = new Telemetry.Common.Envelope(data, Telemetry.Metric.envelopeType);
-
-            this.context.track(envelope);
+                this.context.track(envelope);
+            } catch (e) {
+                _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "trackMetric failed: " + JSON.stringify(e));
+            }
         }
 
         public trackTrace(message: string, properties?: Object) {
-            var telemetry = new Telemetry.Trace(message, properties);
-            var data = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.Trace>(Telemetry.Trace.dataType, telemetry);
-            var envelope = new Telemetry.Common.Envelope(data, Telemetry.Trace.envelopeType);
+            try {
+                var telemetry = new Telemetry.Trace(message, properties);
+                var data = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.Trace>(Telemetry.Trace.dataType, telemetry);
+                var envelope = new Telemetry.Common.Envelope(data, Telemetry.Trace.envelopeType);
 
-            this.context.track(envelope);
+                this.context.track(envelope);
+            } catch (e) {
+                _InternalLogging.warn("trackTrace failed: " + JSON.stringify(e));
+            }
         }
 
         /**
          * Immediately send all queued telemetry.
          */
         public flush() {
-            this.context._sender.triggerSend();
+            try {
+                this.context._sender.triggerSend();
+            } catch (e) {
+                _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "flush failed: " + JSON.stringify(e));
+            }
         }
 
         /**
@@ -278,6 +321,9 @@ module Microsoft.ApplicationInsights {
          */
         public _onerror(message: string, url: string, lineNumber: number, columnNumber: number, error: Error) {
             try {
+                // filtering out "Script error." errors with no details - CORS case. 
+                if (Util.isMeaninglessError(message, url, lineNumber, columnNumber, error)) return;
+
                 if (!Util.isError(error)) {
                     // ensure that we have an error object (browser may not pass an error i.e safari)
                     try {
@@ -292,7 +338,7 @@ module Microsoft.ApplicationInsights {
 
                 this.trackException(error);
             } catch (exception) {
-                _InternalLogging.warn("_onerror threw an exception: " + JSON.stringify(exception) + " while logging error: " + error.name + ", " + error.message);
+                _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "_onerror threw an exception: " + JSON.stringify(exception) + " while logging error: " + error.name + ", " + error.message);
             }
         }
     }


### PR DESCRIPTION
Because of CORS some users are getting "Script error." with no details (url/stack trace/file name). This is not actionable. In this fix "Script error." 's are filtered out.
For our own exceptions (coming from the script on CDN - ai.0.js) a tracing has been added to report meaningful errors when they happen. Otherwise we have the same "Script error." problem.