### PR TITLE
Remove logic of filtering out "Script error."

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Util.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Util.tests.ts
@@ -171,16 +171,6 @@ class UtilTests extends TestClass {
                 Assert.ok(Microsoft.ApplicationInsights.Util.stringToBoolOrDefault("TrUe") === true);
             }
         });
-
-        this.testCase({
-            name: "UtilTests: isCrossOriginError",
-            test: () => {
-                Assert.ok(Microsoft.ApplicationInsights.Util.isCrossOriginError("Script error.", "", 0, 0, null) === true);
-
-                Assert.ok(Microsoft.ApplicationInsights.Util.isCrossOriginError("Script error.", "http://microsoft.com", 0, 0, null)
-                    === false);
-            }
-        });
     }
 }
 new UtilTests().registerTests(); 

--- a/JavaScript/JavaScriptSDK/Util.ts
+++ b/JavaScript/JavaScriptSDK/Util.ts
@@ -78,19 +78,7 @@
         public static isError(obj: any): boolean {
             return Object.prototype.toString.call(obj) === "[object Error]";
         }
-
-        /**
-        * Checks if error has no meaningful data inside. Ususally such errors are received by window.onerror when error
-        * happens in a script from other domain (cross origin, CORS).
-        */
-        public static isCrossOriginError(message: string, url: string, lineNumber: number, columnNumber: number, error: Error): boolean {
-            return message == "Script error."
-                && url == ""
-                && lineNumber == 0
-                && columnNumber == 0
-                && error == null;
-        }
-
+        
         /**
          * Check if an object is of type Date
          */

--- a/JavaScript/JavaScriptSDK/appInsights.ts
+++ b/JavaScript/JavaScriptSDK/appInsights.ts
@@ -321,9 +321,6 @@ module Microsoft.ApplicationInsights {
          */
         public _onerror(message: string, url: string, lineNumber: number, columnNumber: number, error: Error) {
             try {
-                // filtering out "Script error." errors with no details - CORS case. 
-                if (Util.isCrossOriginError(message, url, lineNumber, columnNumber, error)) return;
-
                 if (!Util.isError(error)) {
                     // ensure that we have an error object (browser may not pass an error i.e safari)
                     try {


### PR DESCRIPTION
Based on telemetry looks like all problems currently come from our own script and I just wrapped all our code with try/catch which should give us real exceptions with details. Also the logic being removed is far from ideal because it works only for safari.