### PR TITLE
Don't send client perf events when total is 0; bump up sdk version

### DIFF
--- a/JavaScript/JavaScriptSDK/appInsights.ts
+++ b/JavaScript/JavaScriptSDK/appInsights.ts
@@ -6,7 +6,7 @@
 module Microsoft.ApplicationInsights {
     "use strict";
 
-    export var Version = "0.15.0.0";
+    export var Version = "0.15.20150528.2";
 
     export interface IConfig {
         instrumentationKey: string;


### PR DESCRIPTION
0 is considered invalid and shouldn't be reported. Otherwise it impacts aggregations shown in UI.