### PR TITLE
Addressing "Script error" issue

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Util.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Util.tests.ts
@@ -34,14 +34,14 @@ class UtilTests extends TestClass {
                 // mock cookies
                 ((document) => {
                     var cookies = {};
-                    document.__defineGetter__('cookie', () => {
+                    document.__defineGetter__('cookie',() => {
                         var output = [];
                         for (var cookieName in cookies) {
                             output.push(cookieName + "=" + cookies[cookieName]);
                         }
                         return output.join(";");
                     });
-                    document.__defineSetter__('cookie', (s) => {
+                    document.__defineSetter__('cookie',(s) => {
                         var indexOfSeparator = s.indexOf("=");
                         var key = s.substr(0, indexOfSeparator);
                         var value = s.substring(indexOfSeparator + 1);
@@ -93,7 +93,7 @@ class UtilTests extends TestClass {
         this.testCase({
             name: "UtilTests: new GUID",
             test: () => {
-                sinon.stub(Math, "random", () => 0);
+                sinon.stub(Math, "random",() => 0);
                 var expected = "00000000-0000-4000-8000-000000000000";
                 var actual = Microsoft.ApplicationInsights.Util.newGuid();
                 Assert.equal(expected, actual, "expected guid was generated");
@@ -163,12 +163,22 @@ class UtilTests extends TestClass {
                 Assert.ok(Microsoft.ApplicationInsights.Util.stringToBoolOrDefault(null) === false);
                 Assert.ok(Microsoft.ApplicationInsights.Util.stringToBoolOrDefault("") === false);
                 Assert.ok(Microsoft.ApplicationInsights.Util.stringToBoolOrDefault("asdf") === false);
-                Assert.ok(Microsoft.ApplicationInsights.Util.stringToBoolOrDefault(0) === false);                
+                Assert.ok(Microsoft.ApplicationInsights.Util.stringToBoolOrDefault(0) === false);
                 Assert.ok(Microsoft.ApplicationInsights.Util.stringToBoolOrDefault({ asfd: "sdf" }) === false);
                 Assert.ok(Microsoft.ApplicationInsights.Util.stringToBoolOrDefault(new Object()) === false);
 
                 Assert.ok(Microsoft.ApplicationInsights.Util.stringToBoolOrDefault("true") === true);
                 Assert.ok(Microsoft.ApplicationInsights.Util.stringToBoolOrDefault("TrUe") === true);
+            }
+        });
+
+        this.testCase({
+            name: "UtilTests: isCrossOriginError",
+            test: () => {
+                Assert.ok(Microsoft.ApplicationInsights.Util.isCrossOriginError("Script error.", "", 0, 0, null) === true);
+
+                Assert.ok(Microsoft.ApplicationInsights.Util.isCrossOriginError("Script error.", "http://microsoft.com", 0, 0, null)
+                    === false);
             }
         });
     }

--- a/JavaScript/JavaScriptSDK/Util.ts
+++ b/JavaScript/JavaScriptSDK/Util.ts
@@ -135,5 +135,17 @@
 
             return hour + ":" + min + ":" + sec + "." + ms;
         }
+   
+        /**		
+        * Checks if error has no meaningful data inside. Ususally such errors are received by window.onerror when error		
+        * happens in a script from other domain (cross origin, CORS).		
+        */
+        public static isCrossOriginError(message: string, url: string, lineNumber: number, columnNumber: number, error: Error): boolean {		
+            return (message == "Script error." || message == "Script error")
+                    && url == ""
+                    && lineNumber == 0
+                    && columnNumber == 0
+                    && error == null;
+        }		
     }
 }

--- a/JavaScript/JavaScriptSDK/appInsights.ts
+++ b/JavaScript/JavaScriptSDK/appInsights.ts
@@ -318,7 +318,7 @@ module Microsoft.ApplicationInsights {
         private SendCORSException() {
             var exceptionData = Microsoft.ApplicationInsights.Telemetry.Exception.CreateSimpleException(
                 "Script error.", "Error", "unknown", "unknown",
-                "There is no details for this exception because it violated browser’s same-origin policy. For cross-domain error reporting you can use crossorigtin attribute together with appropriate CORS HTTP headers. For more information please see http://www.w3.org/TR/cors/",
+                "The browser’s same-origin policy prevents us from getting the details of this exception. The exception occurred in a script loaded from an origin different than the web page. For cross-domain error reporting you can use crossorigin attribute together with appropriate CORS HTTP headers. For more information please see http://www.w3.org/TR/cors/.",
                 0, null);
 
             var data = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.Exception>(Telemetry.Exception.dataType, exceptionData);

--- a/JavaScript/JavaScriptSDK/appInsights.ts
+++ b/JavaScript/JavaScriptSDK/appInsights.ts
@@ -65,7 +65,7 @@ module Microsoft.ApplicationInsights {
                 emitLineDelimitedJson: () => this.config.emitLineDelimitedJson,
                 maxBatchSizeInBytes: () => this.config.maxBatchSizeInBytes,
                 maxBatchInterval: () => this.config.maxBatchInterval,
-                disableTelemetry: () => this.config.disableTelemetry                
+                disableTelemetry: () => this.config.disableTelemetry
             }
 
             this.context = new ApplicationInsights.TelemetryContext(configGetters);
@@ -312,6 +312,21 @@ module Microsoft.ApplicationInsights {
         }
 
         /**
+        * In case of CORS exceptions - construct an exception manually.
+        * See this for more info: http://stackoverflow.com/questions/5913978/cryptic-script-error-reported-in-javascript-in-chrome-and-firefox
+        */
+        private SendCORSException() {
+            var exceptionData = Microsoft.ApplicationInsights.Telemetry.Exception.CreateSimpleException(
+                "Script error.", "Error", "unknown", "unknown",
+                "There is no details for this exception because it violated browser’s same-origin policy. For cross-domain error reporting you can use crossorigtin attribute together with appropriate CORS HTTP headers. For more information please see http://www.w3.org/TR/cors/",
+                0, null);
+
+            var data = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.Exception>(Telemetry.Exception.dataType, exceptionData);
+            var envelope = new Telemetry.Common.Envelope(data, Telemetry.Exception.envelopeType);
+            this.context.track(envelope);
+        }
+
+        /**
          * The custom error handler for Application Insights
          * @param {string} message - The error message
          * @param {string} url - The url where the error was raised
@@ -321,21 +336,28 @@ module Microsoft.ApplicationInsights {
          */
         public _onerror(message: string, url: string, lineNumber: number, columnNumber: number, error: Error) {
             try {
-                if (!Util.isError(error)) {
-                    // ensure that we have an error object (browser may not pass an error i.e safari)
-                    try {
-                        throw new Error(message);
-                    } catch (exception) {
-                        error = exception;
-                        if (!error["stack"]) {
-                            error["stack"] = "@" + url + ":" + lineNumber + ":" + (columnNumber || 0);
+                if (Util.isCrossOriginError(message, url, lineNumber, columnNumber, error)) {
+                    this.SendCORSException();
+                } else {
+                    if (!Util.isError(error)) {
+                        // ensure that we have an error object (browser may not pass an error i.e safari)
+                        try {
+                            throw new Error(message);
+                        } catch (exception) {
+                            error = exception;
+                            if (!error["stack"]) {
+                                error["stack"] = "@" + url + ":" + lineNumber + ":" + (columnNumber || 0);
+                            }
                         }
+
+                        this.trackException(error);
                     }
                 }
-
-                this.trackException(error);
             } catch (exception) {
-                _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "_onerror threw an exception: " + JSON.stringify(exception) + " while logging error: " + error.name + ", " + error.message);
+                var errorString =
+                    error ? (error.name + ", " + error.message) : "null";
+
+                _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "_onerror threw an exception: " + JSON.stringify(exception) + " while logging error: " + errorString);
             }
         }
     }


### PR DESCRIPTION
There's not much we can do about "Script error" issue. It happens with the script from domain different from web page is throwing the error. In this case all data about the exception get's cleaned before we receive it.
The only reasonable fix is to provide a meaningful explanation to users.
We also used to show ai.0.js in file name which is incorrect - that was changed to "unknown"