### PR TITLE
Improve diagnostics of unexpected exceptions in AppInsights._onerror

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Util.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Util.tests.ts
@@ -181,6 +181,30 @@ class UtilTests extends TestClass {
                     === false);
             }
         });
+
+        this.testCase({
+            name: "Util.dump returns string that includes information about object type",
+            test: () => {
+                var object: any = new Error();
+
+                var result: string = Microsoft.ApplicationInsights.Util.dump(object);
+
+                var toStringRepresentation = Object.prototype.toString.call(object);
+                Assert.notEqual(-1, result.indexOf(toStringRepresentation));
+            }
+        });
+
+        this.testCase({
+            name: "Util.dump returns string that includes information about object property values",
+            test: () => {
+                var object: any = { "property": "value" };
+
+                var result: string = Microsoft.ApplicationInsights.Util.dump(object);
+
+                var jsonRepresentation: string = JSON.stringify(object);
+                Assert.notEqual(-1, result.indexOf(jsonRepresentation));
+            }
+        });
     }
 }
 new UtilTests().registerTests(); 

--- a/JavaScript/JavaScriptSDK/Util.ts
+++ b/JavaScript/JavaScriptSDK/Util.ts
@@ -148,5 +148,14 @@
                 && columnNumber == 0
                 && error == null;
         }
+
+        /**
+        * Returns string representation of an object suitable for diagnostics logging.
+        */
+        public static dump(object: any): string {
+            var objectTypeDump: string = Object.prototype.toString.call(object);
+            var propertyValueDump: string = JSON.stringify(object);
+            return objectTypeDump + propertyValueDump;
+        }
     }
 }

--- a/JavaScript/JavaScriptSDK/appInsights.ts
+++ b/JavaScript/JavaScriptSDK/appInsights.ts
@@ -357,7 +357,9 @@ module Microsoft.ApplicationInsights {
                 var errorString =
                     error ? (error.name + ", " + error.message) : "null";
 
-                _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "_onerror threw an exception: " + JSON.stringify(exception) + " while logging error, error will not be collected: " + errorString);
+                var exceptionDump: string = Util.dump(exception);
+
+                _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "_onerror threw " + exceptionDump + " while logging error, error will not be collected: " + errorString);
             }
         }
     }


### PR DESCRIPTION
This pull request attempts to improve diagnostics information we log in `AppInsithgs._onerror` method when encountering unexpected exceptions to help us understand the cause of the following error: 

```
AI (Internal): _onerror threw an exception: {} while logging error: null
```

In addition to dumping the names and the properties of the unexpected exception, the `_onerror` method now also writes `toString` representation of the exception object. 
