### PR TITLE
Add RunTestsInBrowser.ps1 script for running check-in tests in a browser

### DIFF
--- a/JavaScript/Microsoft.ApplicationInsights.JavaScript.sln
+++ b/JavaScript/Microsoft.ApplicationInsights.JavaScript.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+VisualStudioVersion = 12.0.40418.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.JavaScript", "NuGet.JavaScript\NuGet.JavaScript.csproj", "{7C2662E9-96D3-473A-B0DD-55A80343A237}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -15,6 +15,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\.nuget\NuGet.targets = ..\.nuget\NuGet.targets
 		..\Package.targets = ..\Package.targets
 		PostTestScript.cmd = PostTestScript.cmd
+		..\RunTestsInBrowser.ps1 = ..\RunTestsInBrowser.ps1
+		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JavaScriptSDK", "JavaScriptSDK\JavaScriptSDK.csproj", "{49ECFE69-8C92-4FA7-A7C3-CDB957C71654}"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@
 * Open Visual Studio solution (devenv JavaScript\Microsoft.ApplicationInsights.JavaScript.sln)
 * Build solution in Visual Studio
 
+## To run check-in tests
+* `powershell "& .\RunTestsInBrowser.ps1"` to run `Tests.html` in a browser
+* Don't forget to build the solution after changing TypeScript files
+* Refresh Tests.html in the browser to re-run tests
+
 ## Performance testing results
 
 For this release, we added a perfResults.txt.csv file that documents the history of performance measurements of the code in the master branch to share with the community the performance of the JavaScript SDK.

--- a/RunTestsInBrowser.ps1
+++ b/RunTestsInBrowser.ps1
@@ -1,0 +1,10 @@
+# This script starts IIS Express and opens the Tests.html in a browser to host QUnit test runner
+# - Run this script: > powershell "& .\RunTestsInBrowser.ps1"
+# - Build the solution after changing TypeScript source files to regenerate JavaScript 
+# - Refresh Tests.html in the browser to run the JavaScript tests 
+
+$iisExpress = Join-Path ${Env:ProgramFiles(x86)} "IIS Express\iisexpress.exe"
+$testsPath = Join-Path (Get-Location) "JavaScript\JavaScriptSDK.Tests\Selenium"
+$port = (Get-NetTCPConnection | Where-Object {$_.LocalAddress -eq "127.0.0.1" -or $_.LocalAddress -eq "::" } | Measure-Object -property LocalPort -max).Maximum + 1
+Start-Process "$iisExpress" -Args ("/path:$testsPath", "/port:$port")
+Start-Process "http://localhost:$port/Tests.html"


### PR DESCRIPTION
This removes the need to setup the Selenium folder as an app in local IIS.