### PR TITLE
E2e html

### DIFF
--- a/JavaScript/.gitignore
+++ b/JavaScript/.gitignore
@@ -26,5 +26,6 @@ _Chutzpah.*
 /*/E2ETests/ai.js
 /*/E2ETests/sprint*Snippet.js
 /*/E2ETests/testSnippet.js
-/*/E2ETests/*.html
+/*/E2ETests/sprint*.html
+/*/E2ETests/test.html
 /*/Selenium/testPageWithAppInsights.html

--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/DisableTelemetryTests.html
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/DisableTelemetryTests.html
@@ -1,0 +1,24 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="Cache-control" content="no-Cache" />
+    <title>Tests for Application Insights JavaScript API</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/qunit/1.16.0/qunit.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/qunit/1.14.0/qunit.js"></script>
+    <script src="http://sinonjs.org/releases/sinon-1.14.1.js"></script>
+    <script type="text/javascript">
+        window.AIResults = [];
+        QUnit.testDone(function(result) {
+            window.AIResults.push(result);
+        });
+    </script>
+    <script src="sprint70Snippet.js"></script>
+    <script src="DisableTelemetryTests.js"></script>
+</head>
+<body>
+    <div id="qunit"></div>
+    <div id="qunit-fixture"></div>
+    <div id="error-message"></div>
+</body>
+</html>

--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/DisableTelemetryTests.html
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/DisableTelemetryTests.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <meta http-equiv="Cache-control" content="no-Cache" />
     <title>Tests for Application Insights JavaScript API</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/qunit/1.16.0/qunit.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/qunit/1.14.0/qunit.js"></script>
+    <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.18.0.css">
+    <script src="http://code.jquery.com/qunit/qunit-1.18.0.js"></script>
     <script src="http://sinonjs.org/releases/sinon-1.14.1.js"></script>
     <script type="text/javascript">
         window.AIResults = [];
@@ -13,7 +13,7 @@
             window.AIResults.push(result);
         });
     </script>
-    <script src="sprint70Snippet.js"></script>
+    <!--<script src="sprint70Snippet.js"></script>-->
     <script src="DisableTelemetryTests.js"></script>
 </head>
 <body>

--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/DisableTelemetryTests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/DisableTelemetryTests.ts
@@ -35,11 +35,6 @@ class DisableTelemetryTests extends TestClass {
         config.maxBatchInterval = 1000;
         config.endpointUrl = "https://dc.services.visualstudio.com/v2/track";
         config.instrumentationKey = "89330895-7c53-4315-a242-85d136ad9c16";
-        /*
-        // uncomment this to target prod instead of int
-        snippet.endpointUrl = "http://dc.services.visualstudio.com/v2/track";
-        snippet.instrumentationKey = "89330895-7c53-4315-a242-85d136ad9c16";
-        */
 
         var delay = config.maxBatchInterval + 10;
 

--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/PublicApiTests.html
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/PublicApiTests.html
@@ -1,0 +1,23 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="Cache-control" content="no-Cache" />
+    <title>Tests for Application Insights JavaScript API</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/qunit/1.16.0/qunit.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/qunit/1.14.0/qunit.js"></script>
+    <script src="http://sinonjs.org/releases/sinon-1.14.1.js"></script>
+    <script type="text/javascript">
+        window.AIResults = [];
+        QUnit.testDone(function(result) {
+            window.AIResults.push(result);
+        });
+    </script>
+    <script src="PublicApiTests.js"></script>
+</head>
+<body>
+    <div id="qunit"></div>
+    <div id="qunit-fixture"></div>
+    <div id="error-message"></div>
+</body>
+</html>

--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/PublicApiTests.html
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/PublicApiTests.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <meta http-equiv="Cache-control" content="no-Cache" />
     <title>Tests for Application Insights JavaScript API</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/qunit/1.16.0/qunit.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/qunit/1.14.0/qunit.js"></script>
+    <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.18.0.css">
+    <script src="http://code.jquery.com/qunit/qunit-1.18.0.js"></script>
     <script src="http://sinonjs.org/releases/sinon-1.14.1.js"></script>
     <script type="text/javascript">
         window.AIResults = [];

--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/PublicApiTests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/PublicApiTests.ts
@@ -57,7 +57,6 @@ class PublicApiTests extends TestClass {
             Assert.ok(true, message);
             console.log(message);
 
-            // calling start() causes sinon to resume and ends the async test
             if (this.successSpy.called) {
                 boilerPlateAsserts();
                 this.testCleanup();

--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/PublicApiTests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/PublicApiTests.ts
@@ -1,5 +1,6 @@
 ﻿/// <reference path="..\TestFramework\Common.ts" />
 /// <reference path="../../javascriptsdk/appinsights.ts" />
+/// <reference path="../../javascriptsdk/initialization.ts" />
 
 class PublicApiTests extends TestClass {
 
@@ -28,16 +29,13 @@ class PublicApiTests extends TestClass {
     }
 
     public registerTests() {
-        var snippet = window["appInsights"];
+        var config = Microsoft.ApplicationInsights.Initialization.getDefaultConfig();
+        config.maxBatchInterval = 1000;
+        config.endpointUrl = "https://dc.services.visualstudio.com/v2/track";
+        config.instrumentationKey = "89330895-7c53-4315-a242-85d136ad9c16";
 
-        /*
-        // uncomment this to target prod instead of int
-        snippet.endpointUrl = "http://dc.services.visualstudio.com/v2/track";
-        snippet.instrumentationKey = "89330895-7c53-4315-a242-85d136ad9c16";
-        */
-
-        var delay = snippet.config.maxBatchInterval + 100;
-        var testAi = new Microsoft.ApplicationInsights.AppInsights(snippet.config);
+        var delay = config.maxBatchInterval + 100;
+        var testAi = new Microsoft.ApplicationInsights.AppInsights(config);
         // disable session state event:
         testAi.context._sessionManager._sessionHandler = null;
 
@@ -54,27 +52,23 @@ class PublicApiTests extends TestClass {
         }
 
         var asserts = [];
-        var pollingCount = 100;
-        for (var i = 0; i < pollingCount; i++) {
-            asserts.push(() => {
-                var message = "polling: " + new Date().toISOString();
-                Assert.ok(true, message);
-                console.log(message);
+        asserts.push(() => {
+            var message = "polling: " + new Date().toISOString();
+            Assert.ok(true, message);
+            console.log(message);
 
-                // calling start() causes sinon to resume and ends the async test
-                if (this.successSpy.called) {
-                    boilerPlateAsserts();
-                    this.testCleanup();
-                    start();
-                } else if (this.errorSpy.called || this.loggingSpy.called) {
-                    boilerPlateAsserts();
-                    start();
-                }
-            });
-        }
+            // calling start() causes sinon to resume and ends the async test
+            if (this.successSpy.called) {
+                boilerPlateAsserts();
+                this.testCleanup();
+            } else if (this.errorSpy.called || this.loggingSpy.called) {
+                boilerPlateAsserts();
+            }
+        });
+
 
         asserts.push(() => Assert.ok(this.successSpy.called, "success"));
-
+        
         this.testCaseAsync({
             name: "TelemetryContext: track event",
             stepDelay: delay,
@@ -84,7 +78,7 @@ class PublicApiTests extends TestClass {
                 }
             ].concat(asserts)
         });
-
+        
         this.testCaseAsync({
             name: "TelemetryContext: track exception",
             stepDelay: delay,
@@ -102,7 +96,7 @@ class PublicApiTests extends TestClass {
                 }
             ].concat(asserts)
         });
-
+               
         this.testCaseAsync({
             name: "TelemetryContext: track metric",
             stepDelay: delay,
@@ -124,7 +118,7 @@ class PublicApiTests extends TestClass {
                 }
             ].concat(asserts)
         });
-
+        
         this.testCaseAsync({
             name: "TelemetryContext: track page view",
             stepDelay: delay,
@@ -134,7 +128,7 @@ class PublicApiTests extends TestClass {
                 }
             ].concat(asserts)
         });
-
+        
         this.testCaseAsync({
             name: "TelemetryContext: track all types in batch",
             stepDelay: delay,

--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/SanitizerE2ETests.html
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/SanitizerE2ETests.html
@@ -1,0 +1,23 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="Cache-control" content="no-Cache" />
+    <title>Tests for Application Insights JavaScript API</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/qunit/1.16.0/qunit.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/qunit/1.14.0/qunit.js"></script>
+    <script src="http://sinonjs.org/releases/sinon-1.14.1.js"></script>
+    <script type="text/javascript">
+        window.AIResults = [];
+        QUnit.testDone(function(result) {
+            window.AIResults.push(result);
+        });
+    </script>
+    <script src="SanitizerE2ETests.js"></script>
+</head>
+<body>
+    <div id="qunit"></div>
+    <div id="qunit-fixture"></div>
+    <div id="error-message"></div>
+</body>
+</html>

--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/SanitizerE2ETests.html
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/SanitizerE2ETests.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <meta http-equiv="Cache-control" content="no-Cache" />
     <title>Tests for Application Insights JavaScript API</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/qunit/1.16.0/qunit.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/qunit/1.14.0/qunit.js"></script>
+    <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.18.0.css">
+    <script src="http://code.jquery.com/qunit/qunit-1.18.0.js"></script>
     <script src="http://sinonjs.org/releases/sinon-1.14.1.js"></script>
     <script type="text/javascript">
         window.AIResults = [];

--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/SanitizerE2ETests.html
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/SanitizerE2ETests.html
@@ -13,7 +13,7 @@
             window.AIResults.push(result);
         });
     </script>
-    <script src="SanitizerE2ETests.js"></script>
+    <script src="SanitizerE2E.Tests.js"></script>
 </head>
 <body>
     <div id="qunit"></div>

--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/autoCollection.tests.html
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/autoCollection.tests.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <meta http-equiv="Cache-control" content="no-Cache" />
     <title>Tests for Application Insights JavaScript API</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/qunit/1.16.0/qunit.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/qunit/1.14.0/qunit.js"></script>
+    <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.18.0.css">
+    <script src="http://code.jquery.com/qunit/qunit-1.18.0.js"></script>
     <script src="http://sinonjs.org/releases/sinon-1.14.1.js"></script>
     <script type="text/javascript">
         window.AIResults = [];

--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/autoCollection.tests.html
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/autoCollection.tests.html
@@ -1,0 +1,23 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="Cache-control" content="no-Cache" />
+    <title>Tests for Application Insights JavaScript API</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/qunit/1.16.0/qunit.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/qunit/1.14.0/qunit.js"></script>
+    <script src="http://sinonjs.org/releases/sinon-1.14.1.js"></script>
+    <script type="text/javascript">
+        window.AIResults = [];
+        QUnit.testDone(function(result) {
+            window.AIResults.push(result);
+        });
+    </script>
+    <script src="autoCollection.tests.js"></script>
+</head>
+<body>
+    <div id="qunit"></div>
+    <div id="qunit-fixture"></div>
+    <div id="error-message"></div>
+</body>
+</html>

--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/autoCollection.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/autoCollection.tests.ts
@@ -21,7 +21,7 @@ class AutoCollectionTests extends TestClass {
     }
 
     public registerTests() {
-        var delay = 100;
+        var delay = 5000;
 
         //var errorDomSpy = this.getListener("errorDom");
         this.testCaseAsync({
@@ -41,7 +41,7 @@ class AutoCollectionTests extends TestClass {
                 ], 1);
             }))
         });
-
+        
         //var errorScriptGlobalSpy = this.getListener("errorScriptGlobal");
         this.testCaseAsync({
             name: "AutoCollection: errorScriptGlobal",
@@ -153,6 +153,7 @@ class AutoCollectionTests extends TestClass {
                 ], 5);
             }))
         });
+        
     }
 
     private getListener(address): SinonSpy {
@@ -179,23 +180,16 @@ class AutoCollectionTests extends TestClass {
         return iframe;
     }
 
-    private poll(func: () => boolean, count: number = 25) {
+    private poll(func: () => boolean, count: number = 1) {
         var polling = [];
         for (var i = 0; i < count; i++) {
             polling.push(() => {
                 if (func()) {
                     Assert.ok(true, "validated, stopping poll cycle");
-                    start();
                     this.testCleanup();
                 }
             });
-        }
-
-        polling.push(() => {
-            Assert.ok(false, "timeout reached");
-            start();
-            this.testCleanup();
-        });
+        }     
 
         return polling;
     }

--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/snippetTests.html
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/snippetTests.html
@@ -1,0 +1,23 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="Cache-control" content="no-Cache" />
+    <title>Tests for Application Insights JavaScript API</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/qunit/1.16.0/qunit.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/qunit/1.14.0/qunit.js"></script>
+    <script src="http://sinonjs.org/releases/sinon-1.14.1.js"></script>
+    <script type="text/javascript">
+        window.AIResults = [];
+        QUnit.testDone(function(result) {
+            window.AIResults.push(result);
+        });
+    </script>
+    <script src="snippet.tests.js"></script>
+</head>
+<body>
+    <div id="qunit"></div>
+    <div id="qunit-fixture"></div>
+    <div id="error-message"></div>
+</body>
+</html>

--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/snippetTests.html
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/snippetTests.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <meta http-equiv="Cache-control" content="no-Cache" />
     <title>Tests for Application Insights JavaScript API</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/qunit/1.16.0/qunit.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/qunit/1.14.0/qunit.js"></script>
+    <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.18.0.css">
+    <script src="http://code.jquery.com/qunit/qunit-1.18.0.js"></script>
     <script src="http://sinonjs.org/releases/sinon-1.14.1.js"></script>
     <script type="text/javascript">
         window.AIResults = [];

--- a/JavaScript/JavaScriptSDK.Tests/JavaScriptSDK.Tests.csproj
+++ b/JavaScript/JavaScriptSDK.Tests/JavaScriptSDK.Tests.csproj
@@ -73,6 +73,11 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="E2ETests\PostBuild.ps1" />
+    <Content Include="E2ETests\snippetTests.html" />
+    <Content Include="E2ETests\DisableTelemetryTests.html" />
+    <Content Include="E2ETests\SanitizerE2ETests.html" />
+    <Content Include="E2ETests\PublicApiTests.html" />
+    <Content Include="E2ETests\autoCollection.tests.html" />
     <Content Include="E2ETests\autoCollectionTemplates\instrumentation.js" />
     <Content Include="E2ETests\standalone\legacySnippet.js" />
     <Content Include="E2ETests\ai.js">
@@ -175,16 +180,11 @@
     <TypeScriptCompile Include="Contracts\Generated\PageViewPerfData.unittests.ts" />
     <TypeScriptCompile Include="Contracts\Generated\SessionStateData.unittests.ts" />
     <TypeScriptCompile Include="Contracts\Generated\StackFrame.unittests.ts" />
-    <TypeScriptCompile Include="E2ETests\autoCollection.tests.ts" />
-    <TypeScriptCompile Include="E2ETests\DisableTelemetryTests.ts" />
-    <TypeScriptCompile Include="E2ETests\SanitizerE2E.tests.ts" />
-    <TypeScriptCompile Include="E2ETests\snippet.tests.ts" />
     <TypeScriptCompile Include="External\jquery.d.ts" />
     <TypeScriptCompile Include="Performance\api.perftests.ts" />
     <TypeScriptCompile Include="Performance\pageLoad.perftests.ts" />
     <TypeScriptCompile Include="Performance\serializer.perftests.ts" />
     <TypeScriptCompile Include="TestFramework\ContractTestHelper.ts" />
-    <TypeScriptCompile Include="E2ETests\PublicApiTests.ts" />
     <TypeScriptCompile Include="CheckinTests\Logging.tests.ts" />
     <TypeScriptCompile Include="CheckinTests\Sender.tests.ts" />
     <TypeScriptCompile Include="CheckinTests\Serializer.tests.ts" />
@@ -200,6 +200,31 @@
     <TypeScriptCompile Include="TestFramework\PerformanceTestHelper.ts" />
   </ItemGroup>
   <ItemGroup>
+    <AutoCollectionTests Include="E2ETests\autoCollection.tests.ts" />
+    <Content Include="E2ETests\autoCollection.tests.js">
+      <DependentUpon>autoCollection.tests.ts</DependentUpon>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <PublicApiTests Include="E2ETests\PublicApiTests.ts" />
+    <Content Include="E2ETests\PublicApiTests.js">
+      <DependentUpon>PublicApiTests.ts</DependentUpon>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <SanitizerE2ETests Include="E2ETests\SanitizerE2E.tests.ts" />
+    <Content Include="E2ETests\SanitizerE2E.tests.js">
+      <DependentUpon>SanitizerE2E.tests.ts</DependentUpon>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <SnippetTests Include="E2ETests\snippet.tests.ts" />
+    <Content Include="E2ETests\snippet.tests.js">
+      <DependentUpon>snippet.tests.ts</DependentUpon>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <DisableTelemetryTests Include="E2ETests\DisableTelemetryTests.ts" />
+    <Content Include="E2ETests\DisableTelemetryTests.js">
+      <DependentUpon>DisableTelemetryTests.ts</DependentUpon>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <SeleniumCheckinTests Include="Selenium\checkinTests.ts" />
     <SeleniumPerformance Include="Selenium\performanceTests.ts" />
     <Content Include="Selenium\checkinTests.js">
@@ -220,6 +245,11 @@
     <Message Text="Compiling TypeScript files" />
     <Exec Command="tsc --module CommonJS @(SeleniumCheckinTests ->'&quot;%(fullpath)&quot;', ' ') --out Selenium\checkinTests.js" />
     <Exec Command="tsc --module CommonJS @(SeleniumPerformance ->'&quot;%(fullpath)&quot;', ' ') --out Selenium\performanceTests.js" />
+    <Exec Command="tsc --module CommonJS @(AutoCollectionTests ->'&quot;%(fullpath)&quot;', ' ') --out E2ETests\autoCollection.tests.js" />
+    <Exec Command="tsc --module CommonJS @(PublicApiTests ->'&quot;%(fullpath)&quot;', ' ') --out E2ETests\PublicApiTests.js" />
+    <Exec Command="tsc --module CommonJS @(SanitizerE2ETests ->'&quot;%(fullpath)&quot;', ' ') --out E2ETests\SanitizerE2E.tests.js" />
+    <Exec Command="tsc --module CommonJS @(SnippetTests ->'&quot;%(fullpath)&quot;', ' ') --out E2ETests\snippet.tests.js" />
+    <Exec Command="tsc --module CommonJS @(DisableTelemetryTests ->'&quot;%(fullpath)&quot;', ' ') --out E2ETests\DisableTelemetryTests.js" />
     <Exec Command="Powershell.exe -ExecutionPolicy ByPass -File &quot;$(ProjectDir)E2ETests\PostBuild.ps1&quot; -projectDir $(ProjectDir)" />
   </Target>
   <PropertyGroup>

--- a/JavaScript/JavaScriptSDK.Tests/TestFramework/TestClass.ts
+++ b/JavaScript/JavaScriptSDK.Tests/TestFramework/TestClass.ts
@@ -41,7 +41,9 @@ class TestClass {
         }
 
         // Create a wrapper around the test method so we can do test initilization and cleanup.
-        var testMethod = () => {
+        var testMethod = (assert) => {
+            var done = assert.async();
+
             // Save off the instance of the currently running suite.
             TestClass.currentTestClass = this;
 
@@ -57,20 +59,18 @@ class TestClass {
                         try {
                             step.call(this);
                         } catch (e) {
-                            start();
                             this._testCompleted();
                             Assert.ok(false, e.toString());
+                            done();
                             return;
                         }
-                        
+
                         setTimeout(() => {
-                            if (QUnit.config["semaphore"] > 0) {
-                                trigger();
-                            }
+                            trigger();
                         }, testInfo.stepDelay);
 
                     } else {
-                        start();
+                        done();
                         this._testCompleted();
                     }
                 };
@@ -84,7 +84,7 @@ class TestClass {
         };
 
         // Register the test with QUnit
-        QUnit.asyncTest(testInfo.name, testMethod);
+        QUnit.test(testInfo.name, testMethod);
     }
 
     /** Register a Javascript unit testcase. */

--- a/JavaScript/JavaScriptSDK/Sender.ts
+++ b/JavaScript/JavaScriptSDK/Sender.ts
@@ -224,6 +224,7 @@ module Microsoft.ApplicationInsights {
          */
         public static _onSuccess(payload: string) {
             // no-op, used in tests
+            console.log("_onSuccess called");
         }
     }
 

--- a/JavaScript/JavaScriptSDK/Sender.ts
+++ b/JavaScript/JavaScriptSDK/Sender.ts
@@ -224,7 +224,6 @@ module Microsoft.ApplicationInsights {
          */
         public static _onSuccess(payload: string) {
             // no-op, used in tests
-            console.log("_onSuccess called");
         }
     }
 


### PR DESCRIPTION
Changing E2E tests to make them runnable in browser. Running with chutzpah got broken with new chutzpah version.
Snippet tests are still to be fixed.

Changes:
- created qunit's test harness htmls 1 per each test class
- made each e2e test class compile in a single js file
- switched from deprecated qunit.asyncTest to qunit.test + assert.async
- removed polling loop as our delay is guaranteed to be greater than our sender's batch interval