### PR TITLE
Scripterror

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -599,6 +599,37 @@ class AppInsightsTests extends TestClass {
         });
 
         this.testCase({
+            name: "AppInsightsTests: trackException accepts non error arguent and creates a new error itself",
+            test: () => {
+                // setup
+                var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
+                appInsights.context._sessionManager._sessionHandler = null;
+                var trackSpy = sinon.spy(appInsights.context, "track");
+                var senderStub = sinon.stub(appInsights.context._sender, "send");
+                var message : string = "my own error";
+
+                // act
+                appInsights.trackException(<any>message);
+                
+                // assert
+                var envelope = <Microsoft.ApplicationInsights.Telemetry.Common.Envelope>trackSpy.args[0][0]
+                var data = <Microsoft.ApplicationInsights.Telemetry.Common.Data<Microsoft.ApplicationInsights.Telemetry.Exception>>envelope.data;
+                var telemetryItem = <Microsoft.ApplicationInsights.Telemetry.Exception>data.baseData;
+                var exception = telemetryItem.exceptions[0];
+
+                Assert.equal(message, exception.message);
+                Assert.equal("Error", exception.stack);
+                Assert.equal("Error", exception.typeName);
+                Assert.equal("Error", exception.stack);
+                Assert.equal("Error", exception.stack);
+                Assert.equal(null, exception.stack);
+                
+                Assert.ok(senderStub.calledOnce, "single exception is tracked");
+
+            }
+        });
+
+        this.testCase({
             name: "AppInsightsTests: trackMetric batches metrics sent in a hot loop",
             test: () => {
                 // setup

--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/PublicApiTests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/PublicApiTests.ts
@@ -67,7 +67,7 @@ class PublicApiTests extends TestClass {
 
 
         asserts.push(() => Assert.ok(this.successSpy.called, "success"));
-        
+
         this.testCaseAsync({
             name: "TelemetryContext: track event",
             stepDelay: delay,
@@ -77,7 +77,7 @@ class PublicApiTests extends TestClass {
                 }
             ].concat(asserts)
         });
-        
+
         this.testCaseAsync({
             name: "TelemetryContext: track exception",
             stepDelay: delay,
@@ -95,7 +95,17 @@ class PublicApiTests extends TestClass {
                 }
             ].concat(asserts)
         });
-               
+
+        this.testCaseAsync({
+            name: "TelemetryContext: track exception no error object",
+            stepDelay: delay,
+            steps: [
+                () => {
+                    testAi.trackException(<any>"my error");
+                }
+            ].concat(asserts)
+        });
+
         this.testCaseAsync({
             name: "TelemetryContext: track metric",
             stepDelay: delay,
@@ -117,7 +127,7 @@ class PublicApiTests extends TestClass {
                 }
             ].concat(asserts)
         });
-        
+
         this.testCaseAsync({
             name: "TelemetryContext: track page view",
             stepDelay: delay,
@@ -127,7 +137,7 @@ class PublicApiTests extends TestClass {
                 }
             ].concat(asserts)
         });
-        
+
         this.testCaseAsync({
             name: "TelemetryContext: track all types in batch",
             stepDelay: delay,

--- a/JavaScript/JavaScriptSDK/appInsights.ts
+++ b/JavaScript/JavaScriptSDK/appInsights.ts
@@ -315,11 +315,12 @@ module Microsoft.ApplicationInsights {
         * In case of CORS exceptions - construct an exception manually.
         * See this for more info: http://stackoverflow.com/questions/5913978/cryptic-script-error-reported-in-javascript-in-chrome-and-firefox
         */
-        private SendCORSException() {
+        private SendCORSException(properties: any) {
             var exceptionData = Microsoft.ApplicationInsights.Telemetry.Exception.CreateSimpleException(
                 "Script error.", "Error", "unknown", "unknown",
-                "The browser’s same-origin policy prevents us from getting the details of this exception. The exception occurred in a script loaded from an origin different than the web page. For cross-domain error reporting you can use crossorigin attribute together with appropriate CORS HTTP headers. For more information please see http://www.w3.org/TR/cors/.",
+                "The browser’s same- origin policy prevents us from getting the details of this exception.The exception occurred in a script loaded from an origin different than the web page.For cross- domain error reporting you can use crossorigin attribute together with appropriate CORS HTTP headers.For more information please see http://www.w3.org/TR/cors/.",
                 0, null);
+            exceptionData.properties = properties;
 
             var data = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.Exception>(Telemetry.Exception.dataType, exceptionData);
             var envelope = new Telemetry.Common.Envelope(data, Telemetry.Exception.envelopeType);
@@ -336,20 +337,17 @@ module Microsoft.ApplicationInsights {
          */
         public _onerror(message: string, url: string, lineNumber: number, columnNumber: number, error: Error) {
             try {
+                var properties = { url : url ? url : document.URL };
+
                 if (Util.isCrossOriginError(message, url, lineNumber, columnNumber, error)) {
-                    this.SendCORSException();
+                    this.SendCORSException(properties);
                 } else {
                     if (!Util.isError(error)) {
-                        if (!url) {
-                            url = document.URL;
-                        }
-
-                        var stack = "window.onerror@" + url + ":" + lineNumber + ":" + (columnNumber || 0);
+                        var stack = "window.onerror@" + properties.url + ":" + lineNumber + ":" + (columnNumber || 0);
                         error = new Error(message);
                         error["stack"] = stack;
                     }
-
-                    this.trackException(error, null, { message: message, url: url, lineNumber: lineNumber, columnNumber: columnNumber });                    
+                    this.trackException(error, null, properties);
                 }
             } catch (exception) {
                 var errorString =

--- a/JavaScript/JavaScriptSDK/appInsights.ts
+++ b/JavaScript/JavaScriptSDK/appInsights.ts
@@ -340,18 +340,16 @@ module Microsoft.ApplicationInsights {
                     this.SendCORSException();
                 } else {
                     if (!Util.isError(error)) {
-                        // ensure that we have an error object (browser may not pass an error i.e safari)
-                        try {
-                            throw new Error(message);
-                        } catch (exception) {
-                            error = exception;
-                            if (!error["stack"]) {
-                                error["stack"] = "@" + url + ":" + lineNumber + ":" + (columnNumber || 0);
-                            }
+                        if (!url) {
+                            url = document.URL;
                         }
+
+                        var stack = "window.onerror@" + url + ":" + lineNumber + ":" + (columnNumber || 0);
+                        error = new Error(message);
+                        error["stack"] = stack;
                     }
 
-                    this.trackException(error);
+                    this.trackException(error, null, { message: message, url: url, lineNumber: lineNumber, columnNumber: columnNumber });                    
                 }
             } catch (exception) {
                 var errorString =


### PR DESCRIPTION
1) Removing ai.0.js from script error stack.
2) Reporting document url as a custom properties to make script error more user friendly. This might go away once we implement operation name for javascript.