### PR TITLE
Measuring domProcessing from responseEnd

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/PageViewPerformance.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/PageViewPerformance.tests.ts
@@ -56,7 +56,6 @@ class PageViewPerformanceTelemetryTests extends ContractTestHelper {
                 timing.requestStart = 11;
                 timing.responseStart = 30;
                 timing.responseEnd = 42;
-                timing.domLoading = 52;
                 timing.loadEventEnd = 60;
 
                 var timingSpy = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "getPerformanceTiming",() => {
@@ -73,7 +72,7 @@ class PageViewPerformanceTelemetryTests extends ContractTestHelper {
                 Assert.equal(Microsoft.ApplicationInsights.Util.msToTimeSpan(9), data.networkConnect);
                 Assert.equal(Microsoft.ApplicationInsights.Util.msToTimeSpan(19), data.sentRequest);
                 Assert.equal(Microsoft.ApplicationInsights.Util.msToTimeSpan(12), data.receivedResponse);
-                Assert.equal(Microsoft.ApplicationInsights.Util.msToTimeSpan(8), data.domProcessing);
+                Assert.equal(Microsoft.ApplicationInsights.Util.msToTimeSpan(18), data.domProcessing);
 
                 timingSpy.restore();
             }
@@ -89,7 +88,6 @@ class PageViewPerformanceTelemetryTests extends ContractTestHelper {
                 timing.requestStart = 11;
                 timing.responseStart = 30;
                 timing.responseEnd = 42;
-                timing.domLoading = 52;
                 timing.loadEventEnd = 60;
 
                 var timingSpy = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "getPerformanceTiming",() => {
@@ -111,7 +109,7 @@ class PageViewPerformanceTelemetryTests extends ContractTestHelper {
                 Assert.equal(undefined, data.receivedResponse);
                 Assert.equal(undefined, data.domProcessing);
 
-                Assert.equal("client performance math error:59 < 39 + 19 + 12 + 8", actualLoggedMessage);
+                Assert.equal("client performance math error:59 < 39 + 19 + 12 + 18", actualLoggedMessage);
 
                 timingSpy.restore();
                 loggingSpy.restore();

--- a/JavaScript/JavaScriptSDK/Telemetry/PageViewPerformance.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/PageViewPerformance.ts
@@ -44,10 +44,10 @@ module Microsoft.ApplicationInsights.Telemetry {
              *  |             ||-requestStart
              *  |             ||             |-responseStart
              *  |             ||             |              |-responseEnd
-             *  |             ||             |              ||-domLoading
-             *  |             ||             |              ||         |-loadEventEnd
-             *  |---network---||---request---|---response---||---dom---|
-             *  |--------------------------total-----------------------|
+             *  |             ||             |              |
+             *  |             ||             |              |         |-loadEventEnd
+             *  |---network---||---request---|---response---|---dom---|
+             *  |--------------------------total----------------------|
              */
             var timing = PageViewPerformance.getPerformanceTiming();
             if (timing) {
@@ -55,7 +55,7 @@ module Microsoft.ApplicationInsights.Telemetry {
                 var network = PageViewPerformance.getDuration(timing.navigationStart, timing.connectEnd);
                 var request = PageViewPerformance.getDuration(timing.requestStart, timing.responseStart);
                 var response = PageViewPerformance.getDuration(timing.responseStart, timing.responseEnd);
-                var dom = PageViewPerformance.getDuration(timing.domLoading, timing.loadEventEnd);
+                var dom = PageViewPerformance.getDuration(timing.responseEnd, timing.loadEventEnd);
 
 
                 if (total == 0) {


### PR DESCRIPTION
Some modern browsers (specifically Chrome, but  sometimes IE 10 too) issues domLoading event before responseEnd event, so responseStart->responseEnd interval overlaps with domLoading->loadEventEnd interval causing subcomponent times to be larger than navigationStart->loadEventEnd total, causing user confusion when they look in the UI. To account for this situation I'm changing the measurement of domProcessing  interval to start with responseEnd event.