### PR TITLE
Polling assert

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/PublicApiTests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/PublicApiTests.ts
@@ -65,7 +65,7 @@ class PublicApiTests extends TestClass {
             }
         });
         
-        asserts.push(PollingAssert.startPollingAssert(() => {
+        asserts.push(PollingAssert.createPollingAssert(() => {
                 Assert.ok(true, "* checking success spy " + new Date().toISOString());
                 return this.successSpy.called;
             }, "sender succeeded")

--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/PublicApiTests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/PublicApiTests.ts
@@ -30,7 +30,7 @@ class PublicApiTests extends TestClass {
 
     public registerTests() {
         var config = Microsoft.ApplicationInsights.Initialization.getDefaultConfig();
-        config.maxBatchInterval = 1000;
+        config.maxBatchInterval = 100;
         config.endpointUrl = "https://dc.services.visualstudio.com/v2/track";
         config.instrumentationKey = "89330895-7c53-4315-a242-85d136ad9c16";
 
@@ -65,12 +65,11 @@ class PublicApiTests extends TestClass {
             }
         });
         
-        asserts.push(() => {
-            PollingAssert.startPollingAssert(() => {
-                console.log("* checking success spy " + new Date().toISOString());
+        asserts.push(PollingAssert.startPollingAssert(() => {
+                Assert.ok(true, "* checking success spy " + new Date().toISOString());
                 return this.successSpy.called;
-            }, "sender succeeded");
-        });
+            }, "sender succeeded")
+        );
 
         this.testCaseAsync({
             name: "TelemetryContext: track event",

--- a/JavaScript/JavaScriptSDK.Tests/TestFramework/PollingAssert.ts
+++ b/JavaScript/JavaScriptSDK.Tests/TestFramework/PollingAssert.ts
@@ -1,4 +1,5 @@
 /// <reference path="..\External\qunit.d.ts" />
+/// <reference path="testclass.ts" />
 
 class PollingAssert {
     /*
@@ -10,15 +11,23 @@ class PollingAssert {
     */
     public static startPollingAssert(assertionFunctionReturnsBoolean, assertDescription: string, timeoutSeconds: number = 30, pollIntervalMs: number = 500) {
         var timeout = new Date(new Date().getTime() + timeoutSeconds * 1000);
-        var polling = () => {
-            if (assertionFunctionReturnsBoolean.apply()) {
-                Assert.ok(true, assertDescription);
-            } else if (timeout < new Date()) {
-                Assert.ok(false, "assert didn't succeed for " + timeout + " seconds: " + assertDescription);
-            } else {
-                setTimeout(polling, pollIntervalMs);
+        var pollingAssert = (nextTestStep) => {
+            var polling = () => {
+                if (assertionFunctionReturnsBoolean.apply()) {
+                    Assert.ok(true, assertDescription);
+                    nextTestStep();
+                } else if (timeout < new Date()) {
+                    Assert.ok(false, "assert didn't succeed for " + timeout + " seconds: " + assertDescription);
+                    nextTestStep();
+                } else {
+                    setTimeout(polling, pollIntervalMs);
+                }
             }
+            setTimeout(polling, pollIntervalMs);
         }
-        setTimeout(polling, pollIntervalMs);
+
+        pollingAssert[TestClass.isPollingStepFlag] = true;
+
+        return pollingAssert;
     }
 }

--- a/JavaScript/JavaScriptSDK.Tests/TestFramework/PollingAssert.ts
+++ b/JavaScript/JavaScriptSDK.Tests/TestFramework/PollingAssert.ts
@@ -9,7 +9,7 @@ class PollingAssert {
     * @timeoutSeconds - timeout in seconds after which assert is considered failed
     * @pollIntervalMs - polling interval in milliseconds
     */
-    public static startPollingAssert(assertionFunctionReturnsBoolean, assertDescription: string, timeoutSeconds: number = 30, pollIntervalMs: number = 500) {
+    public static createPollingAssert(assertionFunctionReturnsBoolean, assertDescription: string, timeoutSeconds: number = 30, pollIntervalMs: number = 500) {
         var timeout = new Date(new Date().getTime() + timeoutSeconds * 1000);
         var pollingAssert = (nextTestStep) => {
             var polling = () => {

--- a/JavaScript/JavaScriptSDK.Tests/TestFramework/PollingAssert.ts
+++ b/JavaScript/JavaScriptSDK.Tests/TestFramework/PollingAssert.ts
@@ -9,11 +9,11 @@ class PollingAssert {
     * @timeoutSeconds - timeout in seconds after which assert is considered failed
     * @pollIntervalMs - polling interval in milliseconds
     */
-    public static createPollingAssert(assertionFunctionReturnsBoolean, assertDescription: string, timeoutSeconds: number = 30, pollIntervalMs: number = 500) {
+    public static createPollingAssert(assertionFunctionReturnsBoolean: () => boolean, assertDescription: string, timeoutSeconds: number = 30, pollIntervalMs: number = 500) {
         var timeout = new Date(new Date().getTime() + timeoutSeconds * 1000);
         var pollingAssert = (nextTestStep) => {
             var polling = () => {
-                if (assertionFunctionReturnsBoolean.apply()) {
+                if (assertionFunctionReturnsBoolean.apply(this)) {
                     Assert.ok(true, assertDescription);
                     nextTestStep();
                 } else if (timeout < new Date()) {

--- a/JavaScript/JavaScriptSDK.Tests/TestFramework/PollingAssert.ts
+++ b/JavaScript/JavaScriptSDK.Tests/TestFramework/PollingAssert.ts
@@ -2,12 +2,13 @@
 /// <reference path="testclass.ts" />
 
 class PollingAssert {
-    /*
+    /**
     * Starts polling assertion function for a period of time after which it's considered failed.
-    * @assertionFunctionReturnsBoolean - funciton returning true if condition passes and false if condition fails. Assert will be done on this function's result.
-    * @assertDescription - message shown with assert
-    * @timeoutSeconds - timeout in seconds after which assert is considered failed
-    * @pollIntervalMs - polling interval in milliseconds
+    * @param {() => boolean} assertionFunctionReturnsBoolean - funciton returning true if condition passes and false if condition fails. Assertion will be done on this function's result.
+    * @param {string} assertDescription - message shown with the assertion
+    * @param {number} timeoutSeconds - timeout in seconds after which assertion fails
+    * @param {number} pollIntervalMs - polling interval in milliseconds
+    * @returns {(nextTestStep) => void} callback which will be invoked by the TestClass
     */
     public static createPollingAssert(assertionFunctionReturnsBoolean: () => boolean, assertDescription: string, timeoutSeconds: number = 30, pollIntervalMs: number = 500) {
         var timeout = new Date(new Date().getTime() + timeoutSeconds * 1000);

--- a/JavaScript/JavaScriptSDK.Tests/TestFramework/TestClass.ts
+++ b/JavaScript/JavaScriptSDK.Tests/TestFramework/TestClass.ts
@@ -58,12 +58,17 @@ class TestClass {
                     if (steps.length) {
                         var step = steps.shift();
                         
+                        // The callback which activates the next test step. 
                         var nextTestStepTrigger = () => {
                             setTimeout(() => {
                                 trigger();
                             }, testInfo.stepDelay);
                         };
 
+                        // There 2 types of test steps - simple and polling.
+                        // Upon completion of the simple test step the next test step will be called.
+                        // In case of polling test step the next test step is passed to the polling test step, and
+                        // it is responsibility of the polling test step to call the next test step.
                         try {
                             if (step[TestClass.isPollingStepFlag]) {
                                 step.call(this, nextTestStepTrigger);
@@ -74,11 +79,16 @@ class TestClass {
                         } catch (e) {
                             this._testCompleted();
                             Assert.ok(false, e.toString());
+
+                            // done is QUnit callback indicating the end of the test
                             done();
+
                             return;
                         }
                     } else {
                         this._testCompleted();
+
+                        // done is QUnit callback indicating the end of the test
                         done();
                     }
                 };
@@ -87,6 +97,8 @@ class TestClass {
             } catch (ex) {
                 Assert.ok(false, "Unexpected Exception: " + ex);
                 this._testCompleted(true);
+
+                // done is QUnit callback indicating the end of the test
                 done();
             }
         };


### PR DESCRIPTION
This is an extension of the fix I made recently: https://github.com/Microsoft/ApplicationInsights-JS/commit/23674bddde2cc42d1031746ea030f6a3681cb55a

Polling assert is a new kind of assert that:
- executes asyncronously (by timeout) for a specific amount of time (rather than loop cycles)
- stops other test steps from executing
- takes a callback to the next test step to execute after if finishes itself

The disclaimer is that we're going to do incremental improvements - need to apply this patter across other tests. 