### PR TITLE
Fix bug with sending expired session ids

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Context/Session.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Context/Session.tests.ts
@@ -166,7 +166,8 @@ class SessionContextTests extends TestClass {
                 // A more sophisticated approach of emulating document.cookie is needed to support multiple cookies
                 Microsoft.ApplicationInsights.Util["document"] = this.generateEmulatedCookieStore();
 
-                var user = new Microsoft.ApplicationInsights.Context.User(undefined);
+                // Initialize our user and session cookies, as well as local storage
+                new Microsoft.ApplicationInsights.Context.User(undefined);
                 var sessionManager = new Microsoft.ApplicationInsights.Context._SessionManager(null,() => { });
                 sessionManager.update();
                 sessionManager.backup();
@@ -174,6 +175,7 @@ class SessionContextTests extends TestClass {
 
                 // Lose the session cookie but not the user cookie
                 Microsoft.ApplicationInsights.Util["document"].cookie = "ai_session=; expires=Thu, 01 Jan 1970 00:00:01 GMT;";
+                new Microsoft.ApplicationInsights.Context.User(undefined);
                 var sessionManager = new Microsoft.ApplicationInsights.Context._SessionManager(null,() => { });
                 sessionManager.update();
                 sessionManager.backup();
@@ -192,6 +194,7 @@ class SessionContextTests extends TestClass {
                 // Local storage and non-local storage should act the same
                 Microsoft.ApplicationInsights.Util["document"].cookie = "ai_session=; expires=Thu, 01 Jan 1970 00:00:01 GMT;";
                 Microsoft.ApplicationInsights.Util["document"].cookie = "ai_user=; expires=Thu, 01 Jan 1970 00:00:01 GMT;";
+                new Microsoft.ApplicationInsights.Context.User(undefined);
                 var sessionManager = new Microsoft.ApplicationInsights.Context._SessionManager(null,() => { });
                 sessionManager.update();
                 sessionManager.backup();

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Context/Session.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Context/Session.tests.ts
@@ -49,7 +49,7 @@ class SessionContextTests extends TestClass {
                 // no cookie, isNew should be true
                 Microsoft.ApplicationInsights.Util["document"] = <any>{
                     cookie: ""
-                };                
+                };
 
                 var sessionManager = new Microsoft.ApplicationInsights.Context._SessionManager(null, () => { });
                 

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Initialization.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Initialization.tests.ts
@@ -209,7 +209,7 @@ class InitializationTests extends TestClass {
                 var appInsightsLocal = init.loadAppInsights();
                 
                 // Act
-                init.addFlushBeforeUnload(appInsightsLocal);
+                init.addHousekeepingBeforeUnload(appInsightsLocal);
                 
                 // Assert
                 Assert.ok(addEventHandlerStub.calledOnce);

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Util.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Util.tests.ts
@@ -5,6 +5,84 @@ class UtilTests extends TestClass {
 
     public registerTests() {
         var Util = Microsoft.ApplicationInsights.Util;
+
+        this.testCase({
+            name: "UtilTests: getStorage with available storage",
+            test: () => {
+                var storage = this.getMockStorage();
+                var getStorageObjectStub = sinon.stub(Microsoft.ApplicationInsights.Util, "_getStorageObject",() => storage);
+
+                storage["test"] = "A";
+
+                Assert.equal("A", Util.getStorage("test"), "getStorage should return value of getItem for known keys");
+                Assert.equal(undefined, Util.getStorage("another"), "getStorage should return value of getItem for unknown keys");
+
+                getStorageObjectStub.restore();
+            }
+        });
+
+        this.testCase({
+            name: "UtilTests: getStorage with no storage support",
+            test: () => {
+                var storage = undefined;
+                var getStorageObjectStub = sinon.stub(Microsoft.ApplicationInsights.Util, "_getStorageObject",() => storage);
+
+                Assert.equal(null, Util.getStorage("test"), "getStorage should return null when storage is unavailable");
+
+                getStorageObjectStub.restore();
+            }
+        });
+
+        this.testCase({
+            name: "UtilTests: setStorage with available storage",
+            test: () => {
+                var storage = this.getMockStorage();
+                var getStorageObjectStub = sinon.stub(Microsoft.ApplicationInsights.Util, "_getStorageObject",() => storage);
+
+                Assert.ok(Util.setStorage("test","A"), "setStorage should return true if storage is available for writes");
+
+                getStorageObjectStub.restore();
+            }
+        });
+
+        this.testCase({
+            name: "UtilTests: setStorage with no storage support",
+            test: () => {
+                var storage = undefined;
+                var getStorageObjectStub = sinon.stub(Microsoft.ApplicationInsights.Util, "_getStorageObject",() => storage);
+
+                Assert.ok(!Util.setStorage("test", "A"), "setStorage should return false if storage is unavailable for writes");
+
+                getStorageObjectStub.restore();
+            }
+        });
+
+        this.testCase({
+            name: "UtilTests: removeStorage with available storage",
+            test: () => {
+                var storage = this.getMockStorage();
+                var getStorageObjectStub = sinon.stub(Microsoft.ApplicationInsights.Util, "_getStorageObject",() => storage);
+
+                storage["test"] = "A";
+
+                Assert.ok(Util.removeStorage("test"), "removeStorage should return true if storage is available for writes");
+                Assert.deepEqual(undefined, storage["test"], "removeStorage should remove items from storage");
+
+                getStorageObjectStub.restore();
+            }
+        });
+
+        this.testCase({
+            name: "UtilTests: removeStorage with no storage support",
+            test: () => {
+                var storage = undefined;
+                var getStorageObjectStub = sinon.stub(Microsoft.ApplicationInsights.Util, "_getStorageObject",() => storage);
+
+                Assert.ok(!Util.removeStorage("test"), "removeStorage should return false if storage is unavailable for writes");
+
+                getStorageObjectStub.restore();
+            }
+        });
         
         this.testCase({
             name: "UtilTests: isArray",
@@ -273,6 +351,14 @@ class UtilTests extends TestClass {
                 Assert.equal(false, returnValue, 'Event handler was attached for illegal callback');
             }
         });
+    }
+
+    private getMockStorage() {
+        var storage = <any>{};
+        storage.getItem = (name) => storage[name];
+        storage.setItem = (name, value) => (storage[name] = value);
+        storage.removeItem = (name, value) => (storage[name] = undefined);
+        return storage;
     }
 }
 new UtilTests().registerTests(); 

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Util.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Util.tests.ts
@@ -94,10 +94,11 @@ class UtilTests extends TestClass {
         this.testCase({
             name: "UtilTests: new GUID",
             test: () => {
-                sinon.stub(Math, "random",() => 0);
+                var randomStub = sinon.stub(Math, "random",() => 0);
                 var expected = "00000000-0000-4000-8000-000000000000";
                 var actual = Util.newGuid();
                 Assert.equal(expected, actual, "expected guid was generated");
+                randomStub.restore();
             }
         });
 

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -29,11 +29,17 @@ class AppInsightsTests extends TestClass {
     public testInitialize() {
         Microsoft.ApplicationInsights.Util.setCookie('ai_session', "");
         Microsoft.ApplicationInsights.Util.setCookie('ai_user', "");
+        if (window.localStorage) {
+            window.localStorage.clear();
+        }
     }
 
     public testCleanup() {
         Microsoft.ApplicationInsights.Util.setCookie('ai_session', "");
         Microsoft.ApplicationInsights.Util.setCookie('ai_user', "");
+        if (window.localStorage) {
+            window.localStorage.clear();
+        }
     }
 
     public registerTests() {

--- a/JavaScript/JavaScriptSDK/Context/Session.ts
+++ b/JavaScript/JavaScriptSDK/Context/Session.ts
@@ -130,7 +130,7 @@ module Microsoft.ApplicationInsights.Context {
                     this.automaticSession.renewalDate = this.automaticSession.renewalDate > 0 ? this.automaticSession.renewalDate : 0;
                 }
             } catch (e) {
-                    _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.WARNING, "Error parsing ai_session cookie, session will be reset: " + Util.dump(e));
+                _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.WARNING, "Error parsing ai_session cookie, session will be reset: " + Util.dump(e));
             }
 
             if (this.automaticSession.renewalDate == 0) {

--- a/JavaScript/JavaScriptSDK/Context/Session.ts
+++ b/JavaScript/JavaScriptSDK/Context/Session.ts
@@ -94,9 +94,9 @@ module Microsoft.ApplicationInsights.Context {
             } else {
                 // We might have session data in local storage
                 // This would only occur when the cookie is missing if the session expired or the user actively deleted the cookie
-                // In either case, this data is useful
+                // In either case, the local storage copy can be used to recover the lost data
                 if (window.localStorage && localStorage['ai_session']) {
-                    this.initializeAutomaticSessionWithData(localStorage['ai_session']);
+                    this.initializeAutomaticSessionWithData(localStorage['ai_session'].split("|"));
                 }
             }
 
@@ -174,7 +174,7 @@ module Microsoft.ApplicationInsights.Context {
             // Browsers that don't support local storage won't be able to end sessions cleanly from the client
             // The server will notice this and end the sessions itself, with loss of accurate session duration
             if (window.localStorage) {
-                localStorage['ai_session'] = [guid, acq, renewal];
+                localStorage['ai_session'] = [guid, acq, renewal].join('|');
             }
         }
     }

--- a/JavaScript/JavaScriptSDK/Context/Session.ts
+++ b/JavaScript/JavaScriptSDK/Context/Session.ts
@@ -99,14 +99,10 @@ module Microsoft.ApplicationInsights.Context {
                 // There's no cookie, but we might have session data in local storage
                 // This can happen if the session expired or the user actively deleted the cookie
                 // We only want to recover data if the cookie is missing from expiry. We should respect the user's wishes if the cookie was deleted actively.
-                // We can verify which was the case by looking for the persistent user cookie.
+                // The User class handles this for us and deletes our local storage object if the persistent user cookie was removed.
                 var userCookie = Util.getCookie('ai_user');
-                var hasUserCookie = (userCookie && typeof userCookie.split === "function");
-                if (window.localStorage && localStorage['ai_session'] && hasUserCookie) {
+                if (window.localStorage && localStorage['ai_session']) {
                     this.initializeAutomaticSessionWithData(localStorage['ai_session'].split("|"));
-                } else if (window.localStorage && localStorage['ai_session'] && !hasUserCookie) {
-                    // The user actively removed our cookies. We should clear ourselves from local storage
-                    localStorage.removeItem('ai_session');
                 }
             }
 

--- a/JavaScript/JavaScriptSDK/Context/Session.ts
+++ b/JavaScript/JavaScriptSDK/Context/Session.ts
@@ -169,7 +169,7 @@ module Microsoft.ApplicationInsights.Context {
             }
 
             // If this browser does not support local storage, fire an internal log to keep track of it at this point
-            if (!Util._getStorageObject()) {
+            if (!Util.canUseLocalStorage()) {
                 _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "Browser does not support local storage. Session durations will be inaccurate.");
             }
         }

--- a/JavaScript/JavaScriptSDK/Context/User.ts
+++ b/JavaScript/JavaScriptSDK/Context/User.ts
@@ -51,6 +51,12 @@ module Microsoft.ApplicationInsights.Context {
                 date.setTime(date.getTime() + 31536000000);
                 var newCookie = [this.id, acqStr];
                 Util.setCookie('ai_user', newCookie.join('|') + ';expires=' + date.toUTCString());
+
+                // If we have an ai_session in local storage this means the user actively removed our cookies.
+                // We should respect their wishes and clear ourselves from local storage
+                if (window.localStorage && localStorage['ai_session']) {
+                    localStorage.removeItem('ai_session');
+                }
             }
 
             this.accountId = accountId;

--- a/JavaScript/JavaScriptSDK/Context/User.ts
+++ b/JavaScript/JavaScriptSDK/Context/User.ts
@@ -54,9 +54,7 @@ module Microsoft.ApplicationInsights.Context {
 
                 // If we have an ai_session in local storage this means the user actively removed our cookies.
                 // We should respect their wishes and clear ourselves from local storage
-                if (window.localStorage && localStorage['ai_session']) {
-                    localStorage.removeItem('ai_session');
-                }
+                Util.removeStorage('ai_session');
             }
 
             this.accountId = accountId;

--- a/JavaScript/JavaScriptSDK/Init.ts
+++ b/JavaScript/JavaScriptSDK/Init.ts
@@ -26,7 +26,7 @@ function initializeAppInsights() {
 
             init.pollInteralLogs(appInsightsLocal);
 
-            init.addFlushBeforeUnload(appInsightsLocal);
+            init.addHousekeepingBeforeUnload(appInsightsLocal);
         }
     }
 }

--- a/JavaScript/JavaScriptSDK/Initialization.ts
+++ b/JavaScript/JavaScriptSDK/Initialization.ts
@@ -109,26 +109,25 @@ module Microsoft.ApplicationInsights {
             }, this.config.diagnosticLogInterval);
         }
         
-        /**
-         * Adds the ability to flush all data before the page unloads.
-         * 
-         * Note: This approach tries to push an async request with all the pending events onbeforeunload.
-         * Firefox does not respect this. Other browsers DO push out the call with < 100% hit rate.
-         * Telemetry here will help us analyze how effective this approach is.
-         * Another approach would be to make this call sync with a acceptable timeout to reduce the 
-         * impact on user experience.
-         * 
-         * @param {AppInsights} appInsightsInstance - The instance of ApplicationInsights
-         */
-        public addFlushBeforeUnload(appInsightsInstance: AppInsights): void {
+        public addHousekeepingBeforeUnload(appInsightsInstance: AppInsights): void {
             // Add callback to push events when the user navigates away
 
             if ('onbeforeunload' in window) {             
-                var flushAllEvents = function() {
+                var performHousekeeping = function () {
+                    // Adds the ability to flush all data before the page unloads.
+                    // Note: This approach tries to push an async request with all the pending events onbeforeunload.
+                    // Firefox does not respect this.Other browsers DO push out the call with < 100% hit rate.
+                    // Telemetry here will help us analyze how effective this approach is.
+                    // Another approach would be to make this call sync with a acceptable timeout to reduce the 
+                    // impact on user experience.
                     appInsightsInstance.context._sender.triggerSend();
+
+                    // Back up the current session to local storage
+                    // This lets us close expired sessions after the cookies themselves expire
+                    appInsightsInstance.context._sessionManager.backup();
                 };
                 
-                if (!Microsoft.ApplicationInsights.Util.addEventHandler('beforeunload', flushAllEvents)) {
+                if (!Microsoft.ApplicationInsights.Util.addEventHandler('beforeunload', performHousekeeping)) {
                     Microsoft.ApplicationInsights._InternalLogging.throwInternalNonUserActionable(Microsoft.ApplicationInsights.LoggingSeverity.CRITICAL, 'Could not add handler for beforeunload');
                 }
             }

--- a/JavaScript/JavaScriptSDK/Util.ts
+++ b/JavaScript/JavaScriptSDK/Util.ts
@@ -5,10 +5,7 @@ module Microsoft.ApplicationInsights {
         private static document: any = typeof document !== "undefined" ? document : {};
         public static NotSpecified = "not_specified";
 
-        /*
-         * helper methods to access local storage
-         */
-        public static _getStorageObject():Storage {
+        private static _getStorageObject(): Storage {
             if (window.localStorage) {
                 return window.localStorage;
             } else {
@@ -16,6 +13,21 @@ module Microsoft.ApplicationInsights {
             }
         }
 
+        /**
+         *  Check if the browser supports local storage.
+         *
+         *  @returns {boolean} True if local storage is supported.
+         */
+        public static canUseLocalStorage(): boolean {
+            return !!Util._getStorageObject();
+        }
+
+        /**
+         *  Get an object from the browser's local storage
+         *
+         *  @param {string} name - the name of the object to get from storage
+         *  @returns {string} The contents of the storage object with the given name. Null if storage is not supported.
+         */
         public static getStorage(name:string):string {
             var storage = Util._getStorageObject();
             if (storage !== null) {
@@ -28,6 +40,13 @@ module Microsoft.ApplicationInsights {
             return null;
         }
 
+        /**
+         *  Set the contents of an object in the browser's local storage
+         *
+         *  @param {string} name - the name of the object to set in storage
+         *  @param {string} data - the contents of the object to set in storage
+         *  @returns {boolean} True if the storage object could be written.
+         */
         public static setStorage(name:string, data:string):boolean {
             var storage = Util._getStorageObject();
             if (storage !== null) {
@@ -41,6 +60,12 @@ module Microsoft.ApplicationInsights {
             return false;
         }
 
+        /**
+         *  Remove an object from the browser's local storage
+         *
+         *  @param {string} name - the name of the object to remove from storage
+         *  @returns {boolean} True if the storage object could be removed.
+         */
         public static removeStorage(name: string):boolean {
             var storage = Util._getStorageObject();
             if (storage !== null) {

--- a/JavaScript/JavaScriptSDK/Util.ts
+++ b/JavaScript/JavaScriptSDK/Util.ts
@@ -34,7 +34,7 @@ module Microsoft.ApplicationInsights {
                 try {
                     return storage.getItem(name);
                 } catch (e) {
-                    _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.WARNING, "Browser failed read of local storage.");
+                    _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "Browser failed read of local storage.");
                 }
             }
             return null;
@@ -54,7 +54,7 @@ module Microsoft.ApplicationInsights {
                     storage.setItem(name, data);
                     return true;
                 } catch (e) {
-                    _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.WARNING, "Browser failed write to local storage.");
+                    _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "Browser failed write to local storage.");
                 }
             }
             return false;
@@ -73,7 +73,7 @@ module Microsoft.ApplicationInsights {
                     storage.removeItem(name);
                     return true;
                 } catch (e) {
-                    _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.WARNING, "Browser failed removal of local storage item.");
+                    _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "Browser failed removal of local storage item.");
                 }
             }
             return false;

--- a/JavaScript/JavaScriptSDK/Util.ts
+++ b/JavaScript/JavaScriptSDK/Util.ts
@@ -1,9 +1,59 @@
-﻿module Microsoft.ApplicationInsights {
+﻿/// <reference path="./logging.ts" />
+module Microsoft.ApplicationInsights {
 
     export class Util {
         private static document: any = typeof document !== "undefined" ? document : {};
-
         public static NotSpecified = "not_specified";
+
+        /*
+         * helper methods to access local storage
+         */
+        public static _getStorageObject():Storage {
+            if (window.localStorage) {
+                return window.localStorage;
+            } else {
+                return null;
+            }
+        }
+
+        public static getStorage(name:string):string {
+            var storage = Util._getStorageObject();
+            if (storage !== null) {
+                try {
+                    return storage.getItem(name);
+                } catch (e) {
+                    _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.WARNING, "Browser failed read of local storage.");
+                }
+            }
+            return null;
+        }
+
+        public static setStorage(name:string, data:string):boolean {
+            var storage = Util._getStorageObject();
+            if (storage !== null) {
+                try {
+                    storage.setItem(name, data);
+                    return true;
+                } catch (e) {
+                    _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.WARNING, "Browser failed write to local storage.");
+                }
+            }
+            return false;
+        }
+
+        public static removeStorage(name: string):boolean {
+            var storage = Util._getStorageObject();
+            if (storage !== null) {
+                try {
+                    storage.removeItem(name);
+                    return true;
+                } catch (e) {
+                    _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.WARNING, "Browser failed removal of local storage item.");
+                }
+            }
+            return false;
+        }
+
         /**
          * helper method to set userId and sessionId cookie
          */


### PR DESCRIPTION
These changes fix a bug where we incorrectly send the wrong session id on the first request after a session has expired due to the session cookie persisting for a very long time. 

Most of the additions are to fix a bug that pops up after expiring the session cookie where we need to keep the old session id to terminate the session.