### PR TITLE
Send PageViews together with client perf And refactored unit tests

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/PageViewPerformance.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/PageViewPerformance.tests.ts
@@ -26,8 +26,8 @@ class PageViewPerformanceTelemetryTests extends ContractTestHelper {
                     Assert.equal(typeof telemetry.sentRequest, "string");
                     Assert.equal(typeof telemetry.domProcessing, "string");
                 } else {
-                    var check = Microsoft.ApplicationInsights.Telemetry.PageViewPerformance.checkPageLoad();
-                    Assert.equal(undefined, check, "checkPageLoad returns undefined when not available");
+                    var check = Microsoft.ApplicationInsights.Telemetry.PageViewPerformance.isPerformanceTimingSupported();
+                    Assert.equal(false, check, "isPerformanceTimingSupported returns false when not performance timing is not supported");
             }
             }
         });

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -3,7 +3,6 @@
 /// <reference path="../../JavaScriptSDK/Util.ts"/>
 
 class AppInsightsTests extends TestClass {
-
     private getAppInsightsSnippet() {
         var snippet: Microsoft.ApplicationInsights.IConfig = {
             instrumentationKey: "",
@@ -27,6 +26,7 @@ class AppInsightsTests extends TestClass {
     }
 
     public testInitialize() {
+        this.clock.reset();
         Microsoft.ApplicationInsights.Util.setCookie('ai_session', "");
         Microsoft.ApplicationInsights.Util.setCookie('ai_user', "");
         if (window.localStorage) {
@@ -35,6 +35,7 @@ class AppInsightsTests extends TestClass {
     }
 
     public testCleanup() {
+        this.clock.reset();
         Microsoft.ApplicationInsights.Util.setCookie('ai_session', "");
         Microsoft.ApplicationInsights.Util.setCookie('ai_user', "");
         if (window.localStorage) {
@@ -97,10 +98,6 @@ class AppInsightsTests extends TestClass {
 
                 // act
                 test(() => appInsights.trackEvent("testEvent"));
-                test(() => appInsights.trackPageView());
-                test(() => appInsights.trackMetric("testMetric", 0));
-                test(() => appInsights.trackException(new Error()));
-                test(() => appInsights.trackTrace("testTrace"));
 
                 // teardown
                 senderStub.restore();
@@ -118,20 +115,12 @@ class AppInsightsTests extends TestClass {
                 // act
                 appInsights.trackPageView();
 
-                // verify
-                Assert.ok(trackStub.calledOnce, "track was called");
-
                 // act
                 this.clock.tick(100);
 
                 // verify
-                var timingSupported = typeof window != "undefined" && window.performance && window.performance.timing;
-                if (timingSupported) {
-                    Assert.ok(trackStub.calledTwice, "track was called again");
-                } else {
-                    Assert.ok(trackStub.calledOnce, "timing is not supported and track was not called again");
-                }
-
+                Assert.ok(trackStub.calledTwice, "track was called");
+                
                 // teardown
                 trackStub.restore();
             }
@@ -194,11 +183,7 @@ class AppInsightsTests extends TestClass {
 
                 // act
                 test(() => appInsights.trackEvent("testEvent"), Microsoft.ApplicationInsights.Telemetry.Event.envelopeType, Microsoft.ApplicationInsights.Telemetry.Event.dataType);
-                test(() => appInsights.trackPageView(), Microsoft.ApplicationInsights.Telemetry.PageView.envelopeType, Microsoft.ApplicationInsights.Telemetry.PageView.dataType);
-                test(() => appInsights.trackMetric("testMetric", 0), Microsoft.ApplicationInsights.Telemetry.Metric.envelopeType, Microsoft.ApplicationInsights.Telemetry.Metric.dataType);
-                test(() => appInsights.trackException(new Error()), Microsoft.ApplicationInsights.Telemetry.Exception.envelopeType, Microsoft.ApplicationInsights.Telemetry.Exception.dataType);
-                test(() => appInsights.trackTrace("testTrace"), Microsoft.ApplicationInsights.Telemetry.Trace.envelopeType, Microsoft.ApplicationInsights.Telemetry.Trace.dataType);
-
+                
                 // teardown
                 trackStub.restore();
             }
@@ -249,11 +234,7 @@ class AppInsightsTests extends TestClass {
 
                 // act
                 test(() => appInsights.trackEvent("testEvent"));
-                test(() => appInsights.trackPageView());
-                test(() => appInsights.trackMetric("testMetric", 0));
-                test(() => appInsights.trackException(new Error()));
-                test(() => appInsights.trackTrace("testTrace"));
-
+              
                 // teardown
                 trackStub.restore();
             }
@@ -302,11 +283,7 @@ class AppInsightsTests extends TestClass {
 
                 // act
                 test(() => appInsights.trackEvent("testEvent"));
-                test(() => appInsights.trackPageView());
-                test(() => appInsights.trackMetric("testMetric", 0));
-                test(() => appInsights.trackException(new Error()));
-                test(() => appInsights.trackTrace("testTrace"));
-
+               
                 // teardown
                 trackStub.restore();
             }
@@ -335,11 +312,7 @@ class AppInsightsTests extends TestClass {
 
                 // act
                 test(() => appInsights.trackEvent("testEvent"));
-                test(() => appInsights.trackPageView());
-                test(() => appInsights.trackMetric("testMetric", 0));
-                test(() => appInsights.trackException(new Error()));
-                test(() => appInsights.trackTrace("testTrace"));
-
+               
                 // teardown
                 trackStub.restore();
             }
@@ -366,11 +339,7 @@ class AppInsightsTests extends TestClass {
 
                 // act
                 test(() => appInsights.trackEvent("testEvent"));
-                test(() => appInsights.trackPageView());
-                test(() => appInsights.trackMetric("testMetric", 0));
-                test(() => appInsights.trackException(new Error()));
-                test(() => appInsights.trackTrace("testTrace"));
-
+                
                 // teardown
                 trackStub.restore();
             }
@@ -405,11 +374,7 @@ class AppInsightsTests extends TestClass {
 
                 // act
                 test(() => appInsights.trackEvent("testEvent"));
-                test(() => appInsights.trackPageView());
-                test(() => appInsights.trackMetric("testMetric", 0));
-                test(() => appInsights.trackException(new Error()));
-                test(() => appInsights.trackTrace("testTrace"));
-
+                
                 // teardown
                 trackStub.restore();
             }
@@ -436,11 +401,7 @@ class AppInsightsTests extends TestClass {
 
                 // act
                 test(() => appInsights.trackEvent("testEvent"));
-                test(() => appInsights.trackPageView());
-                test(() => appInsights.trackMetric("testMetric", 0));
-                test(() => appInsights.trackException(new Error()));
-                test(() => appInsights.trackTrace("testTrace"));
-
+                
                 // teardown
                 trackStub.restore();
             }
@@ -469,11 +430,7 @@ class AppInsightsTests extends TestClass {
 
                 // act
                 test(() => appInsights.trackEvent("testEvent"));
-                test(() => appInsights.trackPageView());
-                test(() => appInsights.trackMetric("testMetric", 0));
-                test(() => appInsights.trackException(new Error()));
-                test(() => appInsights.trackTrace("testTrace"));
-
+                
                 // teardown
                 trackStub.restore();
             }
@@ -508,11 +465,7 @@ class AppInsightsTests extends TestClass {
 
                 // act
                 test(() => appInsights.trackEvent("testEvent"));
-                test(() => appInsights.trackPageView());
-                test(() => appInsights.trackMetric("testMetric", 0));
-                test(() => appInsights.trackException(new Error()));
-                test(() => appInsights.trackTrace("testTrace"));
-
+                
                 // teardown
                 trackStub.restore();
             }
@@ -535,17 +488,13 @@ class AppInsightsTests extends TestClass {
                     var envelope = this.getFirstResult(action, trackStub);
                     var contextKeys = new AI.ContextTagKeys();
                     Assert.equal("10001", envelope.tags[contextKeys.userAuthUserId], "user.authenticatedId");
-                   
+
                     trackStub.reset();
                 };
 
                 // act
                 test(() => appInsights.trackEvent("testEvent"));
-                test(() => appInsights.trackPageView());
-                test(() => appInsights.trackMetric("testMetric", 0));
-                test(() => appInsights.trackException(new Error()));
-                test(() => appInsights.trackTrace("testTrace"));
-
+                
                 // teardown
                 trackStub.restore();
             }
@@ -575,11 +524,7 @@ class AppInsightsTests extends TestClass {
 
                 // act
                 test(() => appInsights.trackEvent("testEvent"));
-                test(() => appInsights.trackPageView());
-                test(() => appInsights.trackMetric("testMetric", 0));
-                test(() => appInsights.trackException(new Error()));
-                test(() => appInsights.trackTrace("testTrace"));
-
+               
                 // teardown
                 trackStub.restore();
             }
@@ -608,17 +553,13 @@ class AppInsightsTests extends TestClass {
 
                 // act
                 test(() => appInsights.trackEvent("testEvent"));
-                test(() => appInsights.trackPageView());
-                test(() => appInsights.trackMetric("testMetric", 0));
-                test(() => appInsights.trackException(new Error()));
-                test(() => appInsights.trackTrace("testTrace"));
-
+                
                 // teardown
                 trackStub.restore();
             }
         });
 
-         this.testCase({
+        this.testCase({
             name: "AppInsightsTests: clear authID context is applied",
             test: () => {
                 // setup
@@ -637,90 +578,71 @@ class AppInsightsTests extends TestClass {
                     var contextKeys = new AI.ContextTagKeys();
                     Assert.equal(undefined, envelope.tags[contextKeys.userAuthUserId], "user.authenticatedId");
                     Assert.equal(undefined, envelope.tags[contextKeys.userAccountId], "user.accountId");
-                   
+
                     trackStub.reset();
                 };
 
                 // act
                 test(() => appInsights.trackEvent("testEvent"));
-                test(() => appInsights.trackPageView());
-                test(() => appInsights.trackMetric("testMetric", 0));
-                test(() => appInsights.trackException(new Error()));
-                test(() => appInsights.trackTrace("testTrace"));
-
+                
                 // teardown
                 trackStub.restore();
             }
         });
 
         this.testCase({
-            name: "AppInsightsTests: trackPageView sends base data 'immediately' and performance data when available",
+            name: "AppInsightsTests: trackPageView sends base data and performance data when available",
             test: () => {
                 // setup
+                var perfDataAvailable = false;
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
                 appInsights.context._sessionManager._sessionHandler = null;
-                var triggerStub = sinon.stub(appInsights.context._sender, "triggerSend");
-
-                var isAvailable = false;
-                if (window.performance && window.performance.timing) {
-                    isAvailable = true;
-                    this.clock.now = window.performance.timing.navigationStart;
-                }
-
-                var pageLoaded = false;
-                var pageLoadStub = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "checkPageLoad",() => isAvailable ? pageLoaded : undefined);
-
-                // act 
-                appInsights.trackPageView("pagePath");
-                this.clock.tick(99);
-                appInsights.trackTrace("trace");
-
-                // verify
-                Assert.ok(triggerStub.notCalled, "send was called once 100ms after invocation");
-                this.clock.tick(1);
-                Assert.ok(triggerStub.calledOnce, "send was called once 100ms after invocation");
-
-                this.clock.tick(1000);
-                Assert.ok(triggerStub.calledOnce, "trackPageView polls for timing data to become available");
-
-                pageLoaded = true;
-                this.clock.tick(200);
-                if (isAvailable) {
-                    Assert.ok(triggerStub.calledTwice, "send was called again after timing data became available");
-                }
+                var triggerStub = sinon.stub(appInsights.context, "track");
+                var checkPageLoadStub = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "isPerformanceTimingDataReady",() => { return perfDataAvailable; });
 
                 // act
-                triggerStub.reset();
-                pageLoaded = undefined; // this indicates that timing data is not supported by the browser
-                appInsights.trackPageView("pagePath");
+                appInsights.trackPageView();
+
+                // Data not available yet - should not send events
                 this.clock.tick(100);
+                Assert.ok(triggerStub.notCalled, "Data is not yet available hence nothing is sent");
 
-                // verify
-                Assert.ok(triggerStub.calledOnce, "send was called once after sending one metric");
-                this.clock.tick(1000);
-                pageLoaded = true;
-                this.clock.tick(1000);
-                Assert.ok(triggerStub.calledOnce, "trackPageView does not attempt to send timing data if it is not supported");
-
-                // act
-                triggerStub.reset();
-                pageLoaded = false;
-                appInsights.trackPageView("pagePath");
+                // Data becomes available - both page view and client perf should be sent
+                perfDataAvailable = true;
                 this.clock.tick(100);
+                Assert.ok(triggerStub.calledTwice, "Data is available hence both page view and client perf should be sent");
 
-                // verify
-                Assert.ok(triggerStub.calledOnce, "send was called once after sending one metric");
-                this.clock.tick(60000);
-                if (isAvailable) {
-                    Assert.ok(triggerStub.calledTwice, "message is sent after 60s");
-                    pageLoaded = true;
-                    this.clock.tick(200);
-                    Assert.ok(triggerStub.calledTwice, "polling stops after 60s");
-                }
-
-                // teardown
-                pageLoadStub.restore();
                 triggerStub.restore();
+                checkPageLoadStub.restore();
+            }
+        });
+
+        this.testCase({
+            name: "AppInsightsTests: a page view is sent after 60 seconds even if perf data is not available",
+            test: () => {
+                // setup
+                var duration = 0;
+                var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
+                appInsights.context._sessionManager._sessionHandler = null;
+                var triggerStub = sinon.stub(appInsights.context, "track");
+                var checkPageLoadStub = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "isPerformanceTimingDataReady",() => { return false; });
+                var getDurationStub = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "getDuration",() => { return duration; });
+
+                // act
+                appInsights.trackPageView();
+
+                // Data not available yet - should not send events
+                this.clock.tick(100);
+                Assert.ok(triggerStub.notCalled, "Data is not yet available hence nothing is sent");
+
+                // 60 seconds passed, page view is supposed to be sent
+                duration = 60001;
+                this.clock.tick(100);
+                Assert.ok(triggerStub.calledOnce, "60 seconds passed, page view is supposed to be sent");
+
+                triggerStub.restore();
+                checkPageLoadStub.restore();
+                getDurationStub.restore();
             }
         });
 
@@ -736,6 +658,8 @@ class AppInsightsTests extends TestClass {
                 Assert.ok(trackStub.calledOnce, "single exception is tracked");
                 appInsights.trackException(<any>[new Error()]);
                 Assert.ok(trackStub.calledTwice, "array of exceptions is tracked");
+
+                trackStub.restore();
             }
         });
 
@@ -801,17 +725,14 @@ class AppInsightsTests extends TestClass {
             test: () => {
                 var sut = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
                 var dumpSpy = sinon.spy(Microsoft.ApplicationInsights.Util, "dump")
-                try {
-                    var unexpectedError = new Error();
-                    sinon.stub(sut, "trackException").throws(unexpectedError);
+                var unexpectedError = new Error();
+                var stub = sinon.stub(sut, "trackException").throws(unexpectedError);
 
-                    sut._onerror("any message", "any://url", 420, 42, new Error());
+                sut._onerror("any message", "any://url", 420, 42, new Error());
 
-                    Assert.ok(dumpSpy.calledWith(unexpectedError));
-                }
-                finally {
-                    dumpSpy.restore();
-                }
+                Assert.ok(dumpSpy.calledWith(unexpectedError));
+                stub.restore();
+                dumpSpy.restore();
             }
         });
 
@@ -820,19 +741,17 @@ class AppInsightsTests extends TestClass {
             test: () => {
                 var sut = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
                 var dumpSpy = sinon.spy(Microsoft.ApplicationInsights.Util, "dump")
-                try {
-                    var unexpectedError = new Error("my cool message");
-                    sinon.stub(sut, "trackException").throws(unexpectedError);
+                var unexpectedError = new Error("my cool message");
+                var stub = sinon.stub(sut, "trackException").throws(unexpectedError);
 
-                    sut._onerror("any message", "any://url", 420, 42, new Error());
+                sut._onerror("any message", "any://url", 420, 42, new Error());
 
-                    Assert.ok(dumpSpy.returnValues[0].indexOf("stack: ") != -1);
-                    Assert.ok(dumpSpy.returnValues[0].indexOf("message: 'my cool message'") != -1);
-                    Assert.ok(dumpSpy.returnValues[0].indexOf("name: 'Error'") != -1);
-                }
-                finally {
-                    dumpSpy.restore();
-                }
+                Assert.ok(dumpSpy.returnValues[0].indexOf("stack: ") != -1);
+                Assert.ok(dumpSpy.returnValues[0].indexOf("message: 'my cool message'") != -1);
+                Assert.ok(dumpSpy.returnValues[0].indexOf("name: 'Error'") != -1);
+
+                stub.restore();
+                dumpSpy.restore();
             }
         });
 
@@ -842,20 +761,17 @@ class AppInsightsTests extends TestClass {
                 var sut = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
                 var throwInternalNonUserActionableSpy = sinon.spy(Microsoft.ApplicationInsights._InternalLogging, "throwInternalNonUserActionable");
                 var dumpStub = sinon.stub(Microsoft.ApplicationInsights.Util, "dump");
-                try {
-                    sinon.stub(sut, "trackException").throws(new Error());
-                    var expectedErrorDump: string = "test error";
-                    dumpStub.returns(expectedErrorDump);
+                var stub = sinon.stub(sut, "trackException").throws(new Error());
+                var expectedErrorDump: string = "test error";
+                dumpStub.returns(expectedErrorDump);
 
-                    sut._onerror("any message", "any://url", 420, 42, new Error());
+                sut._onerror("any message", "any://url", 420, 42, new Error());
 
-                    var logMessage: string = throwInternalNonUserActionableSpy.getCall(0).args[1];
-                    Assert.notEqual(-1, logMessage.indexOf(expectedErrorDump));
-                }
-                finally {
-                    dumpStub.restore();
-                    throwInternalNonUserActionableSpy.restore();
-                }
+                var logMessage: string = throwInternalNonUserActionableSpy.getCall(0).args[1];
+                Assert.notEqual(-1, logMessage.indexOf(expectedErrorDump));
+                stub.restore();
+                dumpStub.restore();
+                throwInternalNonUserActionableSpy.restore();
             }
         });
 
@@ -864,16 +780,18 @@ class AppInsightsTests extends TestClass {
             test: () => {
                 // prepare
                 var sut = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
-                var trackExceptionSpy = sinon.spy(sut.context, "track");                
+                var trackSpy = sinon.spy(sut.context, "track");                
 
                 // act
                 sut._onerror("Script error.", "", 0, 0, null);
 
                 // assert
-                Assert.equal(document.URL,(<any>trackExceptionSpy.args[0][0]).data.baseData.properties.url);
+                Assert.equal(document.URL,(<any>trackSpy.args[0][0]).data.baseData.properties.url);
+
+                trackSpy.restore();
             }
         });
-        
+
         this.testCase({
             name: "AppInsights._onerror adds document URL in case of no CORS error",
             test: () => {
@@ -888,6 +806,8 @@ class AppInsightsTests extends TestClass {
                 // assert
                 // properties are passed as a 3rd parameter
                 Assert.equal(document.URL,(<any>trackExceptionSpy.args[0][2]).url);
+
+                trackExceptionSpy.restore();
             }
         });
 
@@ -913,19 +833,18 @@ class AppInsightsTests extends TestClass {
             // setup
             var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
             appInsights.context._sessionManager._sessionHandler = null;
-            var trackStub = sinon.stub(appInsights.context._sender, "send");
+            var stub = sinon.stub(appInsights, "trackPageViewInternal");
 
             // act
             trackAction(appInsights);
             
             // verify
-            Assert.ok(trackStub.calledOnce, "track was called");
-            Assert.ok(trackStub.args.length > 0, "args > 0");
-            var data = <Microsoft.ApplicationInsights.Telemetry.Common.Envelope>trackStub.args[0][0].data.baseData;
+            Assert.ok(stub.called);
+            var data = stub.args[0];
             validateAction(data);
 
             // teardown
-            trackStub.restore();
+            stub.restore();
         }
 
 
@@ -934,11 +853,10 @@ class AppInsightsTests extends TestClass {
             test: () => {
                 var trackAction = (ai) => ai.trackPageView();
                 var validateAction = (data) => {
-                    Assert.notEqual(testValues.name, data.name);
-                    Assert.notEqual(testValues.url, data.url);
-                    Assert.notEqual(Microsoft.ApplicationInsights.Util.msToTimeSpan(testValues.duration), data.duration);
-                    Assert.notEqual(testValues.properties, data.properties);
-                    Assert.notEqual(testValues.measurements, data.measurements);
+                    Assert.notEqual(testValues.name, data[0]);
+                    Assert.notEqual(testValues.url, data[1]);
+                    Assert.notEqual(testValues.properties, data[2]);
+                    Assert.notEqual(testValues.measurements, data[3]);
                 };
 
                 test(trackAction, validateAction);
@@ -951,11 +869,10 @@ class AppInsightsTests extends TestClass {
                 var trackAction = (ai) => ai.trackPageView(testValues.name);
 
                 var validateAction = (data) => {
-                    Assert.equal(testValues.name, data.name);
-                    Assert.notEqual(testValues.url, data.url);
-                    Assert.notEqual(Microsoft.ApplicationInsights.Util.msToTimeSpan(testValues.duration), data.duration);
-                    Assert.notEqual(testValues.properties, data.properties);
-                    Assert.notEqual(testValues.measurements, data.measurements);
+                    Assert.equal(testValues.name, data[0]);
+                    Assert.notEqual(testValues.url, data[1]);
+                    Assert.notEqual(testValues.properties, data[2]);
+                    Assert.notEqual(testValues.measurements, data[3]);
                 };
 
                 test(trackAction, validateAction);
@@ -968,11 +885,10 @@ class AppInsightsTests extends TestClass {
                 var trackAction = (ai) => ai.trackPageView(testValues.name, null, testValues.properties);
 
                 var validateAction = (data) => {
-                    Assert.equal(testValues.name, data.name);
-                    Assert.notEqual(testValues.url, data.url);
-                    Assert.notEqual(Microsoft.ApplicationInsights.Util.msToTimeSpan(testValues.duration), data.duration);
-                    Assert.deepEqual(testValues.properties, data.properties);
-                    Assert.notEqual(testValues.measurements, data.measurements);
+                    Assert.equal(testValues.name, data[0]);
+                    Assert.notEqual(testValues.url, data[1]);
+                    Assert.deepEqual(testValues.properties, data[2]);
+                    Assert.notEqual(testValues.measurements, data[3]);
                 };
 
                 test(trackAction, validateAction);
@@ -985,11 +901,10 @@ class AppInsightsTests extends TestClass {
                 var trackAction = (ai) => ai.trackPageView(testValues.name, testValues.url);
 
                 var validateAction = (data) => {
-                    Assert.equal(testValues.name, data.name);
-                    Assert.equal(testValues.url, data.url);
-                    Assert.notEqual(Microsoft.ApplicationInsights.Util.msToTimeSpan(testValues.duration), data.duration);
-                    Assert.notEqual(testValues.properties, data.properties);
-                    Assert.notEqual(testValues.measurements, data.measurements);
+                    Assert.equal(testValues.name, data[0]);
+                    Assert.equal(testValues.url, data[1]);
+                    Assert.notEqual(testValues.properties, data[2]);
+                    Assert.notEqual(testValues.measurements, data[3]);
                 };
 
                 test(trackAction, validateAction);
@@ -1002,11 +917,10 @@ class AppInsightsTests extends TestClass {
                 var trackAction = (ai) => ai.trackPageView(testValues.name, null, testValues.properties, testValues.measurements);
 
                 var validateAction = (data) => {
-                    Assert.equal(testValues.name, data.name);
-                    Assert.notEqual(testValues.url, data.url);
-                    Assert.notEqual(Microsoft.ApplicationInsights.Util.msToTimeSpan(testValues.duration), data.duration);
-                    Assert.deepEqual(testValues.properties, data.properties);
-                    Assert.deepEqual(testValues.measurements, data.measurements);
+                    Assert.equal(testValues.name, data[0]);
+                    Assert.notEqual(testValues.url, data[1]);
+                    Assert.deepEqual(testValues.properties, data[2]);
+                    Assert.deepEqual(testValues.measurements, data[3]);
                 };
 
                 test(trackAction, validateAction);
@@ -1019,11 +933,10 @@ class AppInsightsTests extends TestClass {
                 var trackAction = (ai) => ai.trackPageView(testValues.name, testValues.url, testValues.properties);
 
                 var validateAction = (data) => {
-                    Assert.equal(testValues.name, data.name);
-                    Assert.equal(testValues.url, data.url);
-                    Assert.notEqual(Microsoft.ApplicationInsights.Util.msToTimeSpan(testValues.duration), data.duration);
-                    Assert.deepEqual(testValues.properties, data.properties);
-                    Assert.notEqual(testValues.measurements, data.measurements);
+                    Assert.equal(testValues.name, data[0]);
+                    Assert.equal(testValues.url, data[1]);
+                    Assert.deepEqual(testValues.properties, data[2]);
+                    Assert.notEqual(testValues.measurements, data[3]);
                 };
 
                 test(trackAction, validateAction);
@@ -1037,11 +950,10 @@ class AppInsightsTests extends TestClass {
                 var trackAction = (ai) => ai.trackPageView(testValues.name, testValues.url, testValues.properties, testValues.measurements);
 
                 var validateAction = (data) => {
-                    Assert.equal(testValues.name, data.name);
-                    Assert.equal(testValues.url, data.url);
-                    Assert.notEqual(Microsoft.ApplicationInsights.Util.msToTimeSpan(testValues.duration), data.duration);
-                    Assert.deepEqual(testValues.properties, data.properties);
-                    Assert.deepEqual(testValues.measurements, data.measurements);
+                    Assert.equal(testValues.name, data[0]);
+                    Assert.equal(testValues.url, data[1]);
+                    Assert.deepEqual(testValues.properties, data[2]);
+                    Assert.deepEqual(testValues.measurements, data[3]);
                 };
 
                 test(trackAction, validateAction);
@@ -1064,6 +976,28 @@ class AppInsightsTests extends TestClass {
         };
 
         this.testCase({
+            name: "Timing Tests: Start/StopPageView pass correct duration",
+            test: () => {
+                // setup
+                var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
+                var spy = sinon.spy(appInsights, "sendPageViewInternal");
+
+                // act
+                appInsights.startTrackPage();
+                this.clock.tick(testValues.duration);
+                appInsights.stopTrackPage();
+
+                // verify
+                Assert.ok(spy.calledOnce, "stop track page view sent data");
+                var actualDuration = spy.args[0][2];
+                Assert.equal(testValues.duration, actualDuration, "duration is calculated and sent correctly");
+
+                // teardown                
+                spy.restore();
+            }
+        });
+
+        this.testCase({
             name: "Timing Tests: Start/StopPageView tracks single page view with no parameters",
             test: () => {
                 // setup
@@ -1082,7 +1016,6 @@ class AppInsightsTests extends TestClass {
                 var telemetry = <Microsoft.ApplicationInsights.Telemetry.PageView>trackStub.args[0][0].data.baseData;
                 Assert.notEqual(testValues.name, telemetry.name);
                 Assert.notEqual(testValues.url, telemetry.url);
-                Assert.equal(Microsoft.ApplicationInsights.Util.msToTimeSpan(testValues.duration), telemetry.duration);
                 Assert.notEqual(testValues.properties, telemetry.properties);
                 Assert.notEqual(testValues.measurements, telemetry.measurements);
 
@@ -1110,7 +1043,6 @@ class AppInsightsTests extends TestClass {
                 var telemetry = <Microsoft.ApplicationInsights.Telemetry.PageView>trackStub.args[0][0].data.baseData;
                 Assert.equal(testValues.name, telemetry.name);
                 Assert.equal(testValues.url, telemetry.url);
-                Assert.equal(Microsoft.ApplicationInsights.Util.msToTimeSpan(testValues.duration), telemetry.duration);
                 Assert.deepEqual(testValues.properties, telemetry.properties);
                 Assert.deepEqual(testValues.measurements, telemetry.measurements);
 
@@ -1125,7 +1057,6 @@ class AppInsightsTests extends TestClass {
                 telemetry = <Microsoft.ApplicationInsights.Telemetry.PageView>trackStub.args[0][0].data.baseData;
                 Assert.equal(testValues.name, telemetry.name);
                 Assert.equal(testValues.url, telemetry.url);
-                Assert.equal(Microsoft.ApplicationInsights.Util.msToTimeSpan(testValues.duration), telemetry.duration);
                 Assert.deepEqual(testValues.properties, telemetry.properties);
                 Assert.deepEqual(testValues.measurements, telemetry.measurements);
 
@@ -1161,7 +1092,6 @@ class AppInsightsTests extends TestClass {
                 var telemetry = <Microsoft.ApplicationInsights.Telemetry.PageView>trackStub.args[0][0].data.baseData;
                 Assert.notEqual(testValues.name, telemetry.name);
                 Assert.notEqual(testValues.url, telemetry.url);
-                Assert.equal(Microsoft.ApplicationInsights.Util.msToTimeSpan(testValues.duration), telemetry.duration);
                 Assert.notEqual(testValues.properties, telemetry.properties);
                 Assert.notEqual(testValues.measurements, telemetry.measurements);
 
@@ -1169,7 +1099,6 @@ class AppInsightsTests extends TestClass {
                 telemetry = <Microsoft.ApplicationInsights.Telemetry.PageView>trackStub.args[1][0].data.baseData;
                 Assert.equal(testValues.name, telemetry.name);
                 Assert.equal(testValues.url, telemetry.url);
-                Assert.equal(Microsoft.ApplicationInsights.Util.msToTimeSpan(3 * testValues.duration), telemetry.duration);
                 Assert.deepEqual(testValues.properties, telemetry.properties);
                 Assert.deepEqual(testValues.measurements, telemetry.measurements);
 

--- a/JavaScript/JavaScriptSDK/Telemetry/PageViewPerformance.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/PageViewPerformance.ts
@@ -107,13 +107,20 @@ module Microsoft.ApplicationInsights.Telemetry {
         }
 
         /**
-         * Returns undefined if not available, true if ready, false otherwise
+        * Returns true is window performance timing API is supported, false otherwise.
+        */
+        public static isPerformanceTimingSupported() {
+            return typeof window != "undefined" && window.performance && window.performance.timing;
+        }
+
+        /**
+         * As page loads different parts of performance timing numbers get set. When all of them are set we can report it.
+         * Returns true if ready, false otherwise.
          */
-        public static checkPageLoad() {
-            var status = undefined;
-            if (typeof window != "undefined" && window.performance && window.performance.timing) {
-                var timing = window.performance.timing;
-                status = timing.domainLookupStart > 0
+        public static isPerformanceTimingDataReady() {
+            var timing = window.performance.timing;
+
+            return timing.domainLookupStart > 0
                 && timing.navigationStart > 0
                 && timing.responseStart > 0
                 && timing.requestStart > 0
@@ -121,14 +128,11 @@ module Microsoft.ApplicationInsights.Telemetry {
                 && timing.responseEnd > 0
                 && timing.connectEnd > 0
                 && timing.domLoading > 0;
-            }
-
-            return status;
         }
 
         public static getDuration(start: any, end: any): number {
             var duration = 0;
-            if (!(isNaN(start) || isNaN(end) || start === 0 || end === 0)) {
+            if (!(isNaN(start) || isNaN(end))) {
                 duration = Math.max(end - start, 0);
             }
 

--- a/JavaScript/JavaScriptSDK/appInsights.ts
+++ b/JavaScript/JavaScriptSDK/appInsights.ts
@@ -82,13 +82,17 @@ module Microsoft.ApplicationInsights {
 
             // initialize page view timing
             this._pageTracking = new Timing("trackPageView");
-            this._pageTracking.action = (name?: string, url?: string, duration?: number, properties?: Object, measurements?: Object) => {
-                var pageView = new Telemetry.PageView(name, url, duration, properties, measurements);
-                var data = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.PageView>(Telemetry.PageView.dataType, pageView);
-                var envelope = new Telemetry.Common.Envelope(data, Telemetry.PageView.envelopeType);
-
-                this.context.track(envelope);
+            this._pageTracking.action = (name, url, duration, properties, measurements) => {
+                this.sendPageViewInternal(name, url, duration, properties, measurements);
             }
+        }
+
+        private sendPageViewInternal(name?: string, url?: string, duration?: number, properties?: Object, measurements?: Object) {
+            var pageView = new Telemetry.PageView(name, url, duration, properties, measurements);
+            var data = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.PageView>(Telemetry.PageView.dataType, pageView);
+            var envelope = new Telemetry.Common.Envelope(data, Telemetry.PageView.envelopeType);
+
+            this.context.track(envelope);
         }
 
         /**
@@ -149,51 +153,51 @@ module Microsoft.ApplicationInsights {
                     url = window.location && window.location.href || "";
                 }
 
-                var durationMs = 0;
-                // check if timing data is available
-                if (Telemetry.PageViewPerformance.checkPageLoad() !== undefined) {
-                    // compute current duration (navigation start to now) for the pageViewTelemetry
-                    var startTime = window.performance.timing.navigationStart;
-                    durationMs = Telemetry.PageViewPerformance.getDuration(startTime, +new Date);
-
-                    // poll for page load completion and send page view performance data when ready
-                    var handle = setInterval(() => {
-                        try {
-                            // abort this check if we have not finished loading after 1 minute
-                            durationMs = Telemetry.PageViewPerformance.getDuration(startTime, +new Date);
-                            var timingDataReady = Telemetry.PageViewPerformance.checkPageLoad();
-                            var timeoutReached = durationMs > 60000;
-                            if (timeoutReached || timingDataReady) {
-                                clearInterval(handle);
-                                durationMs = Telemetry.PageViewPerformance.getDuration(startTime, +new Date);
-
-                                var pageViewPerformance = new Telemetry.PageViewPerformance(name, url, durationMs, properties, measurements);
-                                if (pageViewPerformance.isValid) {
-                                    var pageViewPerformanceData = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.PageViewPerformance>(
-                                        Telemetry.PageViewPerformance.dataType, pageViewPerformance);
-                                    var pageViewPerformanceEnvelope = new Telemetry.Common.Envelope(pageViewPerformanceData, Telemetry.PageViewPerformance.envelopeType);
-                                    this.context.track(pageViewPerformanceEnvelope);
-                                    this.context._sender.triggerSend();
-                                }
-                            }
-                        } catch (e) {
-                            _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "trackPageView failed on page load calculation: " + Util.dump(e));
-                        }
-                    }, 100);
-                }
-
-                // track the initial page view
-                var pageView = new Telemetry.PageView(name, url, durationMs, properties, measurements);
-                var pageViewData = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.PageView>(Telemetry.PageView.dataType, pageView);
-                var pageViewEnvelope = new Telemetry.Common.Envelope(pageViewData, Telemetry.PageView.envelopeType);
-
-                this.context.track(pageViewEnvelope);
-                setTimeout(() => {
-                    // fire this event as soon as initial code execution completes in case the user navigates away
-                    this.context._sender.triggerSend();
-                }, 100);
+                this.trackPageViewInternal(name, url, properties, measurements);
             } catch (e) {
                 _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "trackPageView failed, page view will not be collected: " + Util.dump(e));
+            }
+        }
+
+        private trackPageViewInternal(name?: string, url?: string, properties?: Object, measurements?: Object) {
+            var durationMs = 0;
+            // check if timing data is available
+            if (Telemetry.PageViewPerformance.isPerformanceTimingSupported()) {
+                // compute current duration (navigation start to now) for the pageViewTelemetry
+                var startTime = window.performance.timing.navigationStart;
+                durationMs = Telemetry.PageViewPerformance.getDuration(startTime, +new Date);
+
+                // poll for page load completion and send page view performance data when ready
+                var handle = setInterval(() => {
+                    try {
+                        // abort this check if we have not finished loading after 1 minute
+                        durationMs = Telemetry.PageViewPerformance.getDuration(startTime, +new Date);
+                        var timingDataReady = Telemetry.PageViewPerformance.isPerformanceTimingDataReady();
+                        var timeoutReached = durationMs > 60000;
+                        if (timeoutReached || timingDataReady) {
+                            clearInterval(handle);
+                            durationMs = Telemetry.PageViewPerformance.getDuration(startTime, +new Date);
+
+                            // Sending page view when navigation timing (i.e. client perf data) is ready.
+                            // We used to report page view duration separtely and it caused confusion - 
+                            // how is that different from client perf duration?
+                            // So we made these 2 metrics to have the same value (by reporting it at the same time).
+                            this.sendPageViewInternal(name, url, durationMs, properties, measurements);
+
+                            var pageViewPerformance = new Telemetry.PageViewPerformance(name, url, durationMs, properties, measurements);
+                            if (pageViewPerformance.isValid) {
+                                var pageViewPerformanceData = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.PageViewPerformance>(
+                                    Telemetry.PageViewPerformance.dataType, pageViewPerformance);
+                                var pageViewPerformanceEnvelope = new Telemetry.Common.Envelope(pageViewPerformanceData, Telemetry.PageViewPerformance.envelopeType);
+                                this.context.track(pageViewPerformanceEnvelope);
+                            }
+
+                            this.context._sender.triggerSend();
+                        }
+                    } catch (e) {
+                        _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "trackPageView failed on page load calculation: " + Util.dump(e));
+                    }
+                }, 100);
             }
         }
 
@@ -368,7 +372,7 @@ module Microsoft.ApplicationInsights {
          */
         public _onerror(message: string, url: string, lineNumber: number, columnNumber: number, error: Error) {
             try {
-                var properties = { url : url ? url : document.URL };
+                var properties = { url: url ? url : document.URL };
 
                 if (Util.isCrossOriginError(message, url, lineNumber, columnNumber, error)) {
                     this.SendCORSException(properties);
@@ -389,7 +393,7 @@ module Microsoft.ApplicationInsights {
                 _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "_onerror threw " + exceptionDump + " while logging error, error will not be collected: " + errorString);
             }
         }
- 
+
     }
 
     /**
@@ -419,14 +423,14 @@ module Microsoft.ApplicationInsights {
 
         public stop(name: string, url: string, properties?: Object, measurements?: Object) {
             var start = this._events[name];
-            if (start) {
+            if (isNaN(start)) {
+                _InternalLogging.throwInternalUserActionable(
+                LoggingSeverity.WARNING,
+                "stop" + this._name + " was called without a corresponding start" + this._name + " . Event name is '" + name + "'");
+            } else {
                 var end = +new Date;
                 var duration = Telemetry.PageViewPerformance.getDuration(start, end);
-                this.action(name, url, duration, properties, measurements);
-            } else {
-                _InternalLogging.throwInternalUserActionable(
-                    LoggingSeverity.WARNING,
-                    "stop" + this._name + " was called without a corresponding start" + this._name + " . Event name is '" + name + "'");
+                this.action(name, url, duration, properties, measurements);                
             }
 
             delete this._events[name];


### PR DESCRIPTION
PageView used to be sent synchronously when user does trackPageView(). Now we're changing it to send together with client perf (when page is loaded), i.e. asynchronously. This required changing/refactoring lots of tests.