### PR TITLE
Telemetry initializer

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Initialization.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Initialization.tests.ts
@@ -25,7 +25,8 @@ class InitializationTests extends TestClass {
             disableTelemetry: false,
             verboseLogging: true,
             diagnosticLogInterval: 1,
-            properties: null
+            properties: null,
+            measurements: null
         };
 
         // set default values

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Initialization.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Initialization.tests.ts
@@ -26,8 +26,6 @@ class InitializationTests extends TestClass {
             verboseLogging: true,
             diagnosticLogInterval: 1,
             autoTrackPageVisitTime: false,
-            properties: null,
-            measurements: null
         };
 
         // set default values

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Initialization.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Initialization.tests.ts
@@ -24,7 +24,8 @@ class InitializationTests extends TestClass {
             autoCollectErrors: false,
             disableTelemetry: false,
             verboseLogging: true,
-            diagnosticLogInterval: 1
+            diagnosticLogInterval: 1,
+            properties: null
         };
 
         // set default values

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/TelemetryContext.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/TelemetryContext.tests.ts
@@ -20,13 +20,7 @@ class TelemetryContextTests extends TestClass {
             emitLineDelimitedJson: () => false,
             maxBatchSizeInBytes: () => 1000000,
             maxBatchInterval: () => 1,
-            disableTelemetry: () => false,
-            properties: () => {
-                return { prop1: "val1", prop2: "val2" };
-            },
-            measurements: () => {
-                return { m1: 100, m2: 200 };
-            }
+            disableTelemetry: () => false
         }
 
         this._telemetryContext = new Microsoft.ApplicationInsights.TelemetryContext(this._config);

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/TelemetryContext.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/TelemetryContext.tests.ts
@@ -20,7 +20,8 @@ class TelemetryContextTests extends TestClass {
             emitLineDelimitedJson: () => false,
             maxBatchSizeInBytes: () => 1000000,
             maxBatchInterval: () => 1,
-            disableTelemetry: () => false
+            disableTelemetry: () => false,
+            properties: () => { return { prop1: "val1", prop2: "val2" }; }
         }
 
         this._telemetryContext = new Microsoft.ApplicationInsights.TelemetryContext(this._config);
@@ -66,6 +67,17 @@ class TelemetryContextTests extends TestClass {
                 var contextKeys = new AI.ContextTagKeys();
                 Assert.equal("101", env.tags[contextKeys.sessionId], "session.id");
                 Assert.equal(true, env.tags[contextKeys.sessionIsFirst], "session.isFirst");
+            }
+        });
+
+        this.testCase({
+            name: "TelemetryContext: properties initialized correctly",
+            test: () => {
+                // act
+                var telemetryContext = new Microsoft.ApplicationInsights.TelemetryContext(this._config);
+
+                // verify
+                Assert.deepEqual(this._config.properties(), telemetryContext.properties);
             }
         });
 
@@ -126,10 +138,10 @@ class TelemetryContextTests extends TestClass {
                     // teardown
                     this._telemetryContext.properties = null;
                 }
-            });        
+            });
     }
 
-    private getTestEventEnvelope(properties?:Object) {
+    private getTestEventEnvelope(properties?: Object) {
         var event = new Microsoft.ApplicationInsights.Telemetry.Event('Test Event', properties);
         var eventData = new Microsoft.ApplicationInsights.Telemetry.Common.Data<Microsoft.ApplicationInsights.Telemetry.Event>(Microsoft.ApplicationInsights.Telemetry.Event.dataType, event);
         var eventEnvelope = new Microsoft.ApplicationInsights.Telemetry.Common.Envelope(eventData, Microsoft.ApplicationInsights.Telemetry.Event.envelopeType);

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/TelemetryContext.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/TelemetryContext.tests.ts
@@ -223,12 +223,11 @@ class TelemetryContextTests extends TestClass {
                 var telemetryInitializer = {
                     onInitializeTelemetry: (envelope) => { }
                 }
-
-                this._telemetryContext.onInitializeTelemetry = <any>telemetryInitializer.onInitializeTelemetry;
                 var spy = sinon.spy(telemetryInitializer, "onInitializeTelemetry");
+                this._telemetryContext.onInitializeTelemetry = <any>telemetryInitializer.onInitializeTelemetry;
                     
                 // act
-                this._telemetryContext.track(eventEnvelope);
+                (<any>this._telemetryContext)._track(eventEnvelope);
 
                 // verify
                 Assert.ok(spy.calledOnce, "telemetryInitializer was called");
@@ -254,19 +253,19 @@ class TelemetryContextTests extends TestClass {
                 }
 
                 this._telemetryContext.onInitializeTelemetry = <any>telemetryInitializer.onInitializeTelemetry;
-                var spy = sinon.spy(this._telemetryContext._sender, "send");
+                var stub = sinon.stub(this._telemetryContext._sender, "send");
                     
                 // act
-                this._telemetryContext.track(eventEnvelope);
+                (<any>this._telemetryContext)._track(eventEnvelope);
 
                 // verify
-                Assert.ok(spy.calledOnce, "sender was called");
-                Assert.ok(eventEnvelope === spy.args[0][0]);
+                Assert.ok(stub.calledOnce, "sender was called");
+                Assert.ok(eventEnvelope === stub.args[0][0]);
                 Assert.equal(nameOverride,
-                    (<Microsoft.ApplicationInsights.Telemetry.Common.Envelope>spy.args[0][0]).name);
+                    (<Microsoft.ApplicationInsights.Telemetry.Common.Envelope>stub.args[0][0]).name);
 
                 // teardown
-                spy.restore();
+                stub.restore();
                 this._telemetryContext.onInitializeTelemetry = undefined;
             }
         });
@@ -275,17 +274,17 @@ class TelemetryContextTests extends TestClass {
             name: "TelemetryContext: onInitializeTelemetry is null means envelope goes straight to the sender",
             test: () => {
                 var eventEnvelope = this.getTestEventEnvelope();
-                var spy = sinon.spy(this._telemetryContext._sender, "send");
+                var stub = sinon.stub(this._telemetryContext._sender, "send");
                     
                 // act
-                this._telemetryContext.track(eventEnvelope);
+                (<any>this._telemetryContext)._track(eventEnvelope);
 
                 // verify
-                Assert.ok(spy.calledOnce, "sender was called");
-                Assert.ok(eventEnvelope === spy.args[0][0]);
+                Assert.ok(stub.calledOnce, "sender was called");
+                Assert.ok(eventEnvelope === stub.args[0][0]);
 
                 // teardown
-                spy.restore();
+                stub.restore();
             }
         });
 
@@ -300,16 +299,16 @@ class TelemetryContextTests extends TestClass {
                 }
 
                 this._telemetryContext.onInitializeTelemetry = <any>telemetryInitializer.onInitializeTelemetry;
-                var spy = sinon.spy(this._telemetryContext._sender, "send");
+                var stub = sinon.stub(this._telemetryContext._sender, "send");
                     
                 // act
-                this._telemetryContext.track(eventEnvelope);
+                (<any>this._telemetryContext)._track(eventEnvelope);
 
                 // verify
-                Assert.ok(spy.notCalled, "sender should not be called");
+                Assert.ok(stub.notCalled, "sender should not be called");
                 
                 // teardown
-                spy.restore();
+                stub.restore();
                 this._telemetryContext.onInitializeTelemetry = undefined;
             }
         });

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/TelemetryContext.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/TelemetryContext.tests.ts
@@ -77,7 +77,7 @@ class TelemetryContextTests extends TestClass {
                 var telemetryInitializer = {
                     initializer: (envelope) => { }
                 }
-                var spy = sinon.spy(telemetryInitializer, "onBeforeSendTelemetry");
+                var spy = sinon.spy(telemetryInitializer, "initializer");
                 this._telemetryContext.addTelemetryInitializer(<any>telemetryInitializer.initializer);
                     
                 // act
@@ -155,6 +155,7 @@ class TelemetryContextTests extends TestClass {
                             Microsoft.ApplicationInsights.Telemetry.Event.envelopeType) {
                             var telemetryItem = (<any>envelope.data).baseData;
                             telemetryItem.name = "my name";
+                            telemetryItem.properties = telemetryItem.properties || {};
                             telemetryItem.properties["prop1"] = "val1";
                         }
                     }
@@ -169,8 +170,8 @@ class TelemetryContextTests extends TestClass {
                 // verify
                 Assert.ok(stub.calledOnce, "sender should be called");
                 Assert.equal("my device id", (<any>stub.args[0][0]).deviceId);
-                Assert.equal("my name", (<any>stub.args[0][0]).baseData.name);
-                Assert.equal("val1", (<any>stub.args[0][0]).baseData.properties["prop1"]);
+                Assert.equal("my name", (<any>stub.args[0][0]).data.baseData.name);
+                Assert.equal("val1", (<any>stub.args[0][0]).data.baseData.properties["prop1"]);
                 
                 // teardown
                 stub.restore();

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -19,7 +19,8 @@ class AppInsightsTests extends TestClass {
             disableTelemetry: false,
             verboseLogging: false,
             diagnosticLogInterval: 1000,
-            properties: null
+            properties: null,
+            measurements: null
         };
 
         // set default values

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -1374,7 +1374,7 @@ class AppInsightsTests extends TestClass {
                     var senderStub = sinon.stub(appInsights.context._sender, "send");
 
                     // act
-                    appInsights.context.properties = [{ prop1: "val1" }];
+                    appInsights.context.properties = { prop1: "val1" };
                     appInsights.trackEvent("my event");
 
                     // validate

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -1363,6 +1363,28 @@ class AppInsightsTests extends TestClass {
                 resetInternalMessageCountStub.restore();
             }
         });
+
+        this.testCase(
+            {
+                name: "TelemetryInitializer: properties added to telemetry",
+                test: () => {
+                    // setup
+                    var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
+                    appInsights.context._sessionManager._sessionHandler = null;
+                    var senderStub = sinon.stub(appInsights.context._sender, "send");
+
+                    // act
+                    appInsights.context.properties = [{ prop1: "val1" }];
+                    appInsights.trackEvent("my event");
+
+                    // validate
+                    var telemetry = <Microsoft.ApplicationInsights.Telemetry.Event>senderStub.args[0][0].data.baseData;
+                    Assert.equal(telemetry.properties["prop1"], "val1");
+
+                    // teardown
+                    senderStub.restore();
+                }
+            });
     }
 
     private getFirstResult(action: string, trackStub: SinonStub, skipSessionState?: boolean) {

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -19,9 +19,7 @@ class AppInsightsTests extends TestClass {
             disableTelemetry: false,
             verboseLogging: false,
             diagnosticLogInterval: 1000,
-            autoTrackPageVisitTime: false,
-            properties: null,
-            measurements: null
+            autoTrackPageVisitTime: false
         };
 
         // set default values

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -18,7 +18,8 @@ class AppInsightsTests extends TestClass {
             autoCollectErrors: false,
             disableTelemetry: false,
             verboseLogging: false,
-            diagnosticLogInterval: 1000
+            diagnosticLogInterval: 1000,
+            properties: null
         };
 
         // set default values

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -1363,28 +1363,6 @@ class AppInsightsTests extends TestClass {
                 resetInternalMessageCountStub.restore();
             }
         });
-
-        this.testCase(
-            {
-                name: "TelemetryInitializer: properties added to telemetry",
-                test: () => {
-                    // setup
-                    var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
-                    appInsights.context._sessionManager._sessionHandler = null;
-                    var senderStub = sinon.stub(appInsights.context._sender, "send");
-
-                    // act
-                    appInsights.context.properties = { prop1: "val1" };
-                    appInsights.trackEvent("my event");
-
-                    // validate
-                    var telemetry = <Microsoft.ApplicationInsights.Telemetry.Event>senderStub.args[0][0].data.baseData;
-                    Assert.equal(telemetry.properties["prop1"], "val1");
-
-                    // teardown
-                    senderStub.restore();
-                }
-            });
     }
 
     private getFirstResult(action: string, trackStub: SinonStub, skipSessionState?: boolean) {

--- a/JavaScript/JavaScriptSDK.Tests/Selenium/Tests.html
+++ b/JavaScript/JavaScriptSDK.Tests/Selenium/Tests.html
@@ -6,7 +6,7 @@
     <title>Tests for Application Insights JavaScript API</title>
     <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.18.0.css">
     <script src="http://code.jquery.com/qunit/qunit-1.18.0.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/sinon.js/1.7.3/sinon.js"></script>
+    <script src="http://cdnjs.cloudflare.com/ajax/libs/sinon.js/1.7.3/sinon.js"></script>
     <script type="text/javascript">
         window.AIResults = [];
         QUnit.testDone(function(result) {

--- a/JavaScript/JavaScriptSDK/Telemetry/PageView.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/PageView.ts
@@ -15,7 +15,7 @@ module Microsoft.ApplicationInsights.Telemetry {
             url: false,
             duration: false,
             properties: false,
-            measurement: false
+            measurements: false
         }
 
         /**

--- a/JavaScript/JavaScriptSDK/Telemetry/PageViewPerformance.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/PageViewPerformance.ts
@@ -21,7 +21,7 @@ module Microsoft.ApplicationInsights.Telemetry {
             receivedResponse: false,
             domProcessing: false,
             properties: false,
-            measurement: false
+            measurements: false
         };
 
         /**

--- a/JavaScript/JavaScriptSDK/TelemetryContext.ts
+++ b/JavaScript/JavaScriptSDK/TelemetryContext.ts
@@ -17,6 +17,7 @@ module Microsoft.ApplicationInsights {
         accountId: () => string;
         sessionRenewalMs: () => number;
         sessionExpirationMs: () => number;
+        properties: () => Object;
     }
 
     export class TelemetryContext {
@@ -90,6 +91,7 @@ module Microsoft.ApplicationInsights {
                 this.operation = new Context.Operation();
                 this.session = new Context.Session();
                 this.sample = new Context.Sample();
+                this.properties = config.properties();
             }
         }
 
@@ -155,7 +157,7 @@ module Microsoft.ApplicationInsights {
         }
 
         private _applyCustomProperties(envelope: Microsoft.Telemetry.Envelope) {
-            if (this.properties) {
+            if (this.properties && envelope && envelope.data && (<any>envelope.data).baseData) {
                 var telemetryItem = (<any>envelope.data).baseData;
                 telemetryItem.properties = telemetryItem.properties || {};
                 Object.getOwnPropertyNames(this.properties).forEach((val, index, array) => {
@@ -165,7 +167,6 @@ module Microsoft.ApplicationInsights {
                 });
             }
         }
-
 
         private _applyApplicationContext(envelope: Microsoft.Telemetry.Envelope, appContext: Microsoft.ApplicationInsights.Context.Application) {
             if (appContext) {

--- a/JavaScript/JavaScriptSDK/TelemetryContext.ts
+++ b/JavaScript/JavaScriptSDK/TelemetryContext.ts
@@ -65,10 +65,15 @@ module Microsoft.ApplicationInsights {
         public session: Context.Session;
 
         /**
+        * Custom properties added to all telemetry items (implementation of the TelemetryInitializer concept).
+        */
+        public properties;
+
+        /**
          * The session manager that manages session on the base of cookies.
          */
         public _sessionManager: Microsoft.ApplicationInsights.Context._SessionManager;
-        
+
         constructor(config: ITelemetryConfig) {
             this._config = config;
             this._sender = new Sender(config);
@@ -99,7 +104,7 @@ module Microsoft.ApplicationInsights {
                 if (envelope.name === Telemetry.PageView.envelopeType) {
                     _InternalLogging.resetInternalMessageCount();
                 }
-                
+
                 if (this.session) {
                     // If customer did not provide custom session id update sessionmanager
                     if (typeof this.session.id !== "string") {
@@ -131,6 +136,7 @@ module Microsoft.ApplicationInsights {
             this._applyOperationContext(envelope, this.operation);
             this._applySampleContext(envelope, this.sample);
             this._applyUserContext(envelope, this.user);
+            this._applyCustomProperties(envelope, this.properties);
 
             envelope.iKey = this._config.instrumentationKey();
 
@@ -145,12 +151,22 @@ module Microsoft.ApplicationInsights {
 
             sessionStateEnvelope.time = Util.toISOStringForIE8(new Date(timestamp));
 
-            tc._track(sessionStateEnvelope); 
+            tc._track(sessionStateEnvelope);
         }
 
+        private static _applyCustomProperties(envelope: Microsoft.Telemetry.Envelope, properties) {
+            if (properties) {
+                Object.getOwnPropertyNames(properties).forEach((val, index, array) => {
+                    if (envelope.data.baseData.properties[val] === undefined) {
+
+                    }
+                });
+            }
+        }
+
+
         private _applyApplicationContext(envelope: Microsoft.Telemetry.Envelope, appContext: Microsoft.ApplicationInsights.Context.Application) {
-            if (appContext)
-            {
+            if (appContext) {
                 var tagKeys: AI.ContextTagKeys = new AI.ContextTagKeys();
 
                 if (typeof appContext.ver === "string") {

--- a/JavaScript/JavaScriptSDK/TelemetryContext.ts
+++ b/JavaScript/JavaScriptSDK/TelemetryContext.ts
@@ -136,7 +136,7 @@ module Microsoft.ApplicationInsights {
             this._applyOperationContext(envelope, this.operation);
             this._applySampleContext(envelope, this.sample);
             this._applyUserContext(envelope, this.user);
-            this._applyCustomProperties(envelope, this.properties);
+            this._applyCustomProperties(envelope);
 
             envelope.iKey = this._config.instrumentationKey();
 
@@ -154,11 +154,13 @@ module Microsoft.ApplicationInsights {
             tc._track(sessionStateEnvelope);
         }
 
-        private static _applyCustomProperties(envelope: Microsoft.Telemetry.Envelope, properties) {
-            if (properties) {
-                Object.getOwnPropertyNames(properties).forEach((val, index, array) => {
-                    if (envelope.data.baseData.properties[val] === undefined) {
-
+        private _applyCustomProperties(envelope: Microsoft.Telemetry.Envelope) {
+            if (this.properties) {
+                var telemetryItem = (<any>envelope.data).baseData;
+                telemetryItem.properties = telemetryItem.properties || {};
+                Object.getOwnPropertyNames(this.properties).forEach((val, index, array) => {
+                    if (telemetryItem.properties[val] === undefined) {
+                        telemetryItem.properties[val] = this.properties[val];
                     }
                 });
             }

--- a/JavaScript/JavaScriptSDK/TelemetryContext.ts
+++ b/JavaScript/JavaScriptSDK/TelemetryContext.ts
@@ -151,9 +151,9 @@ module Microsoft.ApplicationInsights {
             this._applyCustomMeasurements(envelope);
 
             envelope.iKey = this._config.instrumentationKey();
-
+            
+            var sendItem = true;
             if (this.onInitializeTelemetry) {
-                var sendItem = true;
                 try {
                     sendItem = this.onInitializeTelemetry(envelope) === true;
                 } catch (e) {
@@ -161,7 +161,9 @@ module Microsoft.ApplicationInsights {
                         LoggingSeverity.CRITICAL,
                         "onInitializeTelemetry() failed with error, an attempt will be made to send the telemetry item but the data may be corrupted: " + Util.dump(e));
                 }
+            }
 
+            if (sendItem) {
                 this._sender.send(envelope);
             }
         }

--- a/JavaScript/JavaScriptSDK/appInsights.ts
+++ b/JavaScript/JavaScriptSDK/appInsights.ts
@@ -23,6 +23,7 @@ module Microsoft.ApplicationInsights {
         disableTelemetry: boolean;
         verboseLogging: boolean;
         diagnosticLogInterval: number;
+        properties: Object;
     }
 
     /**
@@ -65,7 +66,8 @@ module Microsoft.ApplicationInsights {
                 emitLineDelimitedJson: () => this.config.emitLineDelimitedJson,
                 maxBatchSizeInBytes: () => this.config.maxBatchSizeInBytes,
                 maxBatchInterval: () => this.config.maxBatchInterval,
-                disableTelemetry: () => this.config.disableTelemetry
+                disableTelemetry: () => this.config.disableTelemetry,
+                properties: () => this.config.properties,
             }
 
             this.context = new ApplicationInsights.TelemetryContext(configGetters);

--- a/JavaScript/JavaScriptSDK/appInsights.ts
+++ b/JavaScript/JavaScriptSDK/appInsights.ts
@@ -24,6 +24,7 @@ module Microsoft.ApplicationInsights {
         verboseLogging: boolean;
         diagnosticLogInterval: number;
         properties: Object;
+        measurements: Object;
     }
 
     /**
@@ -68,6 +69,7 @@ module Microsoft.ApplicationInsights {
                 maxBatchInterval: () => this.config.maxBatchInterval,
                 disableTelemetry: () => this.config.disableTelemetry,
                 properties: () => this.config.properties,
+                measurements: () => this.config.measurements
             }
 
             this.context = new ApplicationInsights.TelemetryContext(configGetters);

--- a/JavaScript/JavaScriptSDK/appInsights.ts
+++ b/JavaScript/JavaScriptSDK/appInsights.ts
@@ -27,8 +27,6 @@ module Microsoft.ApplicationInsights {
         verboseLogging: boolean;
         diagnosticLogInterval: number;
         autoTrackPageVisitTime: boolean;
-        properties: Object;
-        measurements: Object;
     }
 
     /**
@@ -72,9 +70,7 @@ module Microsoft.ApplicationInsights {
                 emitLineDelimitedJson: () => this.config.emitLineDelimitedJson,
                 maxBatchSizeInBytes: () => this.config.maxBatchSizeInBytes,
                 maxBatchInterval: () => this.config.maxBatchInterval,
-                disableTelemetry: () => this.config.disableTelemetry,
-                properties: () => this.config.properties,
-                measurements: () => this.config.measurements
+                disableTelemetry: () => this.config.disableTelemetry
             }
 
             this.context = new ApplicationInsights.TelemetryContext(configGetters);


### PR DESCRIPTION
Implementation of Telemtry initializer concept - allows to attach properties and measurements to all telemetry items.

Suggested use:
1) with snippet config

       <SNIPPET>
        }({
            instrumentationKey: "b9d56dad-4148-458d-8dd1-147c61a17b07",
            properties: { prop1: "val1", prop2: "val2" },
            measurements: { m1: 100, m2: 200 }
        });

        window.appInsights = appInsights;        
        appInsights.trackPageView();
2) with queue push (if can't use option 1)

       appInsights.queue.push(function() { 
         appInsights.context.properties = {prop1: "val1", prop2: "val2"}
         appInsights.context.measurements = {m1: 100, m2: 200}
       });

Next steps - stop needing queue.push (though reading appInsights.properties in initialization)