### PR TITLE
Bug in handling response when using XDomainRequest

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Sender.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Sender.tests.ts
@@ -213,6 +213,39 @@ class SenderTests extends TestClass {
         });
 
         this.testCase({
+            name: "SenderTests: XDomain sender correctly handles json response",
+            test: () => {
+                // setup
+                XDomainRequest = <any>(() => {
+                    var xdr = new this.xhr;
+                    xdr.onload = xdr.onreadystatechange;
+                    xdr.responseText = 200;
+                    return xdr;
+                });
+
+                // act
+                var sender: Microsoft.ApplicationInsights.Sender = this.getSender();
+
+                // verify
+                Assert.ok(sender, "sender was constructed");
+
+                // act
+                this.fakeServer.requests.pop();
+                sender.send(this.testTelemetry);
+                this.clock.tick(sender._config.maxBatchInterval());
+
+                // verify
+                requestAsserts();
+                this.fakeServer.requests[0].respond(200, { "Content-Type": "application/json" }, '{"itemsRecieved":2,"itemsAccepted":2,"errors":[]}');
+                successAsserts();
+                logAsserts(0);
+                this.successSpy.reset();
+                this.errorSpy.reset();
+
+            }
+        });
+
+        this.testCase({
             name: "SenderTests: XMLHttpRequest and XDomainRequest native error handlers are logged",
             test: () => {
                 // setup

--- a/JavaScript/JavaScriptSDK/Sender.ts
+++ b/JavaScript/JavaScriptSDK/Sender.ts
@@ -221,11 +221,21 @@ module Microsoft.ApplicationInsights {
          * xdr state changes
          */
         public static _xdrOnLoad(xdr: XDomainRequest, payload: string) {
-            if (xdr && (xdr.responseText + "" === "200" || xdr.responseText === "")) {
+            
+            var validResponse: boolean = false;
+            
+            try {
+                // try and parse the response and check for errors
+                validResponse = (JSON.parse(xdr.responseText).errors.length === 0);
+            }
+            catch(e){ }
+            
+            if (validResponse) {
                 Sender._onSuccess(payload);
             } else {
                 Sender._onError(payload, xdr && xdr.responseText || "");
             }
+            
         }
 
         /**


### PR DESCRIPTION
The current version requires the response text to be "" or "200" for it
to be a successful call.
But, the web service actually returns a json string like this:
{"itemsRecieved":2,"itemsAccepted":2,"errors":[]}
This change attempts to parse the response text and check for a zero
length array of errors.