### PR TITLE
Fix "Cannot set property 'assembly' of undefined" error in CreateSimpleException 

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/Exception.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/Exception.tests.ts
@@ -156,6 +156,34 @@ Error: testmessage2\n\
                 test(ie, firefox);
             }
         });
+
+        this.testCase({
+            name: "CreateSimpleException returns Exception instance with specified properties",
+            test: () => {
+                var expectedMessage = "Test Message";
+                var expectedTypeName = "Test Type Name";
+                var expectedDetails = "Test Details";
+                var expectedAssembly = "Test Assembly";
+                var expectedFileName = "Test File Name";
+                var expectedLineNumber = 42;
+                var expectedHandledAt = "Test Handled At";
+
+                var actual = Microsoft.ApplicationInsights.Telemetry.Exception.CreateSimpleException(expectedMessage, expectedTypeName, expectedAssembly, expectedFileName, expectedDetails, expectedLineNumber, expectedHandledAt);
+
+                Assert.equal(expectedMessage, actual.exceptions[0].message);
+                Assert.equal(expectedTypeName, actual.exceptions[0].typeName);
+                Assert.equal(expectedDetails, actual.exceptions[0].stack);
+                Assert.equal(true, actual.exceptions[0].hasFullStack);
+                
+                Assert.equal(0, actual.exceptions[0].parsedStack[0].level);
+                Assert.equal(expectedAssembly, actual.exceptions[0].parsedStack[0].assembly);
+                Assert.equal(expectedFileName, actual.exceptions[0].parsedStack[0].fileName);
+                Assert.equal(expectedLineNumber, actual.exceptions[0].parsedStack[0].line);
+                Assert.equal("unknown", actual.exceptions[0].parsedStack[0].method);
+
+                Assert.equal(expectedHandledAt, actual.handledAt);
+            }
+        });
     }
 }
 new ExceptionTelemetryTests().registerTests();

--- a/JavaScript/JavaScriptSDK/Telemetry/Exception.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/Exception.ts
@@ -40,30 +40,26 @@ module Microsoft.ApplicationInsights.Telemetry {
         public static CreateSimpleException(message: string, typeName: string, assembly: string, fileName: string,
             details: string, line: number, handledAt?: string): Telemetry.Exception {
 
-            // We can't override constructors, so throwing a fake error to use existing constructor and override all fields after that.
-            var exceptionTelemetry;
-            try {
-                throw new Error();
-            } catch (e) {
-                exceptionTelemetry = new Telemetry.Exception(e);
-            }
-
-            var stack = exceptionTelemetry.exceptions[0].parsedStack[0];
-            stack.assembly = assembly;
-            stack.fileName = fileName;
-            stack.level = 0;
-            stack.line = line;
-            stack.method = "unknown";
-
-            var exception = exceptionTelemetry.exceptions[0];
-            exception.hasFullStack = true;
-            exception.message = message;
-            exception.parsedStack = null;
-            exception.stack = details;
-            exception.typeName = typeName;
-            exceptionTelemetry.handledAt = handledAt || "unhandled";
-
-            return exceptionTelemetry;
+            return <Telemetry.Exception> {
+                handledAt: handledAt || "unhandled",
+                exceptions: [
+                    <AI.ExceptionDetails> {
+                        hasFullStack: true,
+                        message: message,
+                        stack: details,
+                        typeName: typeName,
+                        parsedStack: [
+                            <AI.StackFrame> {
+                                level: 0,
+                                assembly: assembly,
+                                fileName: fileName,
+                                line: line,
+                                method: "unknown"
+                            }
+                        ]
+                    }
+                ]
+            };
         }
     }
 


### PR DESCRIPTION
The following unhandled exception was reported 671 times by internal AI JS SDK telemetry during the week of 8/16, affecting 24 applications:

```
AI (Internal): _onerror threw [object Error]{ 
stack: 'TypeError: Cannot set property 'assembly' of undefined    
    at <error: TypeError: undefined is not a function>     
    at <error: TypeError: undefined is not a function>     
    at <error: TypeError: undefined is not a function>     
    at <error: TypeError: undefined is not a function>', 
message: 'Cannot set property 'assembly' of undefined', 
name: 'TypeError' while logging error, error will not be collected: null
```

I believe it is caused by a problem in the `Exception.CreateSimpleException` method, which is called by `SendCORSException` called from `_onerror`. The current code in `CreateSimpleException` assumes that a `Telemetry.Exception` instance always has at least one stack frame object in the `parsedStack`. However, when the array is empty, `parsedStack[0]` returns an undefined object, triggering the `TypeError` in the code trying to set the `assembly` property.

This pull request fixes the problem by creating a `Telemetry.Exception`-compatible object without relying on browser-specific exception throwing and handling functionality. 