### PR TITLE
Changing console references to use Util console warn function

### DIFF
--- a/JavaScript/JavaScriptSDK/Init.ts
+++ b/JavaScript/JavaScriptSDK/Init.ts
@@ -31,7 +31,7 @@ function initializeAppInsights() {
             }
         }
     } catch (e) {
-        console.error('Failed to initialize AppInsights JS SDK: ' + e.message);
+        Microsoft.ApplicationInsights._InternalLogging.warnToConsole('Failed to initialize AppInsights JS SDK: ' + e.message);
     }
 }
 

--- a/JavaScript/JavaScriptSDK/Logging.ts
+++ b/JavaScript/JavaScriptSDK/Logging.ts
@@ -77,7 +77,7 @@
         public static warnToConsole(message: string) {
             if (typeof console !== "undefined" && !!console) {
                 if (typeof console.warn === "function") {
-                console.warn(message);
+                    console.warn(message);
                 } else if (typeof console.log === "function") {
                     console.log(message);
                 }

--- a/JavaScript/JavaScriptSDK/Util.ts
+++ b/JavaScript/JavaScriptSDK/Util.ts
@@ -17,7 +17,7 @@ module Microsoft.ApplicationInsights {
                     return null;
                 }   
             } catch (e) {
-                console.warn('Failed to get client localStorage: ' + e.message);
+                _InternalLogging.warnToConsole('Failed to get client localStorage: ' + e.message);
                 return null;
             }
         }
@@ -100,7 +100,7 @@ module Microsoft.ApplicationInsights {
                     return null;
                 }
             } catch (e) {
-                console.warn('Failed to get client session storage: ' + e.message);
+                _InternalLogging.warnToConsole('Failed to get client session storage: ' + e.message);
                 return null;
             }
         }


### PR DESCRIPTION
With reference to error - AI (Internal): trackPageView failed on page load calculation: [object Error]{ stack: 'undefined', message: ''console' is undefined'.

We are using console.warn directly in two places and console.error in one which will throw errors in case that the "console" object is undefined (as the error above suggests.) In this pull request, we are switching to use the Util console warn func which checks for the presence of the console object and its funcs before using them.