### PR TITLE
By default page view duration equals Page load time 

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Initialization.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Initialization.tests.ts
@@ -28,7 +28,7 @@ class InitializationTests extends TestClass {
             autoTrackPageVisitTime: false,
             samplingPercentage: 33,
             autoTrackAjax: false,
-            relativePageViewDuration: false
+            overridePageViewDuration: false
         };
 
         // set default values

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Initialization.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Initialization.tests.ts
@@ -27,7 +27,8 @@ class InitializationTests extends TestClass {
             diagnosticLogInterval: 1,
             autoTrackPageVisitTime: false,
             samplingPercentage: 33,
-            autoTrackAjax: false
+            autoTrackAjax: false,
+            relativePageViewDuration: false
         };
 
         // set default values

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/PageViewPerformance.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/PageViewPerformance.tests.ts
@@ -11,7 +11,7 @@ class PageViewPerformanceTelemetryTests extends ContractTestHelper {
     public registerTests() {
         super.registerTests();
         var name = this.name + ": ";
-        
+
         this.testCase({
             name: name + "PageViewPerformanceTelemetry correct timing data",
             test: () => {
@@ -28,7 +28,7 @@ class PageViewPerformanceTelemetryTests extends ContractTestHelper {
                 } else {
                     var check = Microsoft.ApplicationInsights.Telemetry.PageViewPerformance.isPerformanceTimingSupported();
                     Assert.equal(false, check, "isPerformanceTimingSupported returns false when not performance timing is not supported");
-            }
+                }
             }
         });
 
@@ -58,13 +58,13 @@ class PageViewPerformanceTelemetryTests extends ContractTestHelper {
                 timing.responseEnd = 42;
                 timing.loadEventEnd = 60;
 
-                var timingSpy = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "getPerformanceTiming",() => {
-                    return timing;                  
+                var timingSpy = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "getPerformanceTiming", () => {
+                    return timing;
                 });
 
 
                 var telemetry = new Microsoft.ApplicationInsights.Telemetry.PageViewPerformance("name", "url", 0);
-                Assert.equal(true, telemetry.isValid);
+                Assert.equal(true, telemetry.getIsValid());
 
                 var data = telemetry;
 
@@ -90,16 +90,16 @@ class PageViewPerformanceTelemetryTests extends ContractTestHelper {
                 timing.responseEnd = 42;
                 timing.loadEventEnd = 60;
 
-                var timingSpy = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "getPerformanceTiming",() => {
+                var timingSpy = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "getPerformanceTiming", () => {
                     return timing;
                 });
 
                 var actualLoggedMessage = null;
-                var loggingSpy = sinon.stub(Microsoft.ApplicationInsights._InternalLogging, "warnToConsole",(m) => actualLoggedMessage = m);
+                var loggingSpy = sinon.stub(Microsoft.ApplicationInsights._InternalLogging, "warnToConsole", (m) => actualLoggedMessage = m);
 
 
                 var telemetry = new Microsoft.ApplicationInsights.Telemetry.PageViewPerformance("name", "url", 0);
-                Assert.equal(false, telemetry.isValid);
+                Assert.equal(false, telemetry.getIsValid());
 
                 var data = telemetry;
 
@@ -113,7 +113,7 @@ class PageViewPerformanceTelemetryTests extends ContractTestHelper {
 
                 timingSpy.restore();
                 loggingSpy.restore();
-               
+
             }
         });
 

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -21,7 +21,8 @@ class AppInsightsTests extends TestClass {
             diagnosticLogInterval: 1000,
             autoTrackPageVisitTime: false,
             samplingPercentage: 100,
-            autoTrackAjax: false
+            autoTrackAjax: false,
+            relativePageViewDuration: false
         };
 
         // set default values

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -671,11 +671,6 @@ class AppInsightsTests extends TestClass {
                 this.clock.tick(100);
                 Assert.ok(spy.calledOnce, "Data is available so page view should be sent");
                 Assert.equal(expectedDuration, spy.args[0][2], "Page view duration taken from page view performance object doesn't match expected value");
-
-                // teardown
-                spy.restore();
-                checkPageLoadStub.restore();
-                getDurationStub.restore();
             }
         });
 
@@ -697,11 +692,6 @@ class AppInsightsTests extends TestClass {
                 // Data not available yet - should not send events
                 this.clock.tick(100);
                 Assert.ok(!spy.called, "Page view should not be sent since the timing data is invalid");
-
-                // teardown
-                spy.restore();
-                checkPageLoadStub.restore();
-                getIsValidStub.restore();
             }
         });
 
@@ -726,9 +716,6 @@ class AppInsightsTests extends TestClass {
                 perfDataAvailable = true;
                 this.clock.tick(100);
                 Assert.ok(triggerStub.calledTwice, "Data is available hence both page view and client perf should be sent");
-
-                triggerStub.restore();
-                checkPageLoadStub.restore();
             }
         });
 
@@ -752,10 +739,6 @@ class AppInsightsTests extends TestClass {
                 this.clock.tick(65432);
                 Assert.ok(spy.calledOnce, "60 seconds passed, page view is supposed to be sent");
                 Assert.equal(60000, spy.args[0][2], "Page view duration doesn't match expected maximum duration (60000 ms)");
-
-                spy.restore();
-                checkPageLoadStub.restore();
-                stub.restore();
             }
         });
 

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -630,12 +630,16 @@ class AppInsightsTests extends TestClass {
             name: "AppInsightsTests: trackPageView sends custom duration when configured by user",
             test: () => {
                 var snippet = this.getAppInsightsSnippet();
-                snippet.relativePageViewDuration = true;
+                snippet.relativePageViewDuration = true;                
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(snippet);
-                var spy = sinon.spy(appInsights, "sendPageViewInternal");
-                var stub = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "getPerformanceTiming",
+                var spy = this.sandbox.spy(appInsights, "sendPageViewInternal");
+                var stub = this.sandbox.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "getPerformanceTiming",
                     () => {
                         return { navigationStart: 0 };
+                    });
+                var getDurationMsStub = this.sandbox.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance.prototype, "getDurationMs",
+                    () => {
+                        return 54321;
                     });
 
                 // act
@@ -645,23 +649,19 @@ class AppInsightsTests extends TestClass {
                 // verify
                 Assert.ok(spy.calledOnce, "sendPageViewInternal is called");
                 Assert.equal(123, spy.args[0][2], "PageView duration doesn't match expected value");
-                
-                // teardowon
-                spy.restore();
-                stub.restore();
             }
         });
 
         this.testCase({
-            name: "AppInsightsTests: trackPageView gets the data from page view performance when it's available",
+            name: "AppInsightsTests: by default trackPageView gets the data from page view performance when it's available",
             test: () => {
                 // setup
                 var expectedDuration = 123;
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
-                var spy = sinon.stub(appInsights, "sendPageViewInternal");
-                var checkPageLoadStub = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "isPerformanceTimingDataReady",
+                var spy = this.sandbox.stub(appInsights, "sendPageViewInternal");
+                var checkPageLoadStub = this.sandbox.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "isPerformanceTimingDataReady",
                     () => { return true; });
-                var getDurationStub = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance.prototype, "getDurationMs",
+                var getDurationStub = this.sandbox.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance.prototype, "getDurationMs",
                     () => { return expectedDuration; });
 
                 // act
@@ -685,10 +685,10 @@ class AppInsightsTests extends TestClass {
             test: () => {
                 // setup
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
-                var spy = sinon.stub(appInsights, "sendPageViewInternal");
-                var checkPageLoadStub = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "isPerformanceTimingDataReady",
+                var spy = this.sandbox.stub(appInsights, "sendPageViewInternal");
+                var checkPageLoadStub = this.sandbox.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "isPerformanceTimingDataReady",
                     () => { return true; });
-                var getIsValidStub = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance.prototype, "getIsValid",
+                var getIsValidStub = this.sandbox.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance.prototype, "getIsValid",
                     () => { return false; });
 
                 // act
@@ -712,8 +712,8 @@ class AppInsightsTests extends TestClass {
                 var perfDataAvailable = false;
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
                 appInsights.context._sessionManager._sessionHandler = null; /* otherwise we'll get session event too */
-                var triggerStub = sinon.stub(appInsights.context, "track");
-                var checkPageLoadStub = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "isPerformanceTimingDataReady", () => { return perfDataAvailable; });
+                var triggerStub = this.sandbox.stub(appInsights.context, "track");
+                var checkPageLoadStub = this.sandbox.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "isPerformanceTimingDataReady", () => { return perfDataAvailable; });
 
                 // act
                 appInsights.trackPageView();
@@ -737,10 +737,10 @@ class AppInsightsTests extends TestClass {
             test: () => {
                 // setup
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
-                var spy = sinon.stub(appInsights, "sendPageViewInternal");
-                var checkPageLoadStub = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "isPerformanceTimingDataReady",
+                var spy = this.sandbox.stub(appInsights, "sendPageViewInternal");
+                var checkPageLoadStub = this.sandbox.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "isPerformanceTimingDataReady",
                     () => { return false; });
-                var stub = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "getPerformanceTiming",
+                var stub = this.sandbox.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "getPerformanceTiming",
                     () => {
                         return { navigationStart: 0 };
                     });

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -661,7 +661,7 @@ class AppInsightsTests extends TestClass {
                 var spy = sinon.stub(appInsights, "sendPageViewInternal");
                 var checkPageLoadStub = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "isPerformanceTimingDataReady",
                     () => { return true; });
-                var getDurationStub = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "getDurationMs",
+                var getDurationStub = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance.prototype, "getDurationMs",
                     () => { return expectedDuration; });
 
                 // act
@@ -688,7 +688,7 @@ class AppInsightsTests extends TestClass {
                 var spy = sinon.stub(appInsights, "sendPageViewInternal");
                 var checkPageLoadStub = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "isPerformanceTimingDataReady",
                     () => { return true; });
-                var getIsValidStub = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "getIsValid",
+                var getIsValidStub = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance.prototype, "getIsValid",
                     () => { return false; });
 
                 // act
@@ -737,7 +737,7 @@ class AppInsightsTests extends TestClass {
             test: () => {
                 // setup
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
-                var spy = sinon.stub(appInsights.context, "sendPageViewInternal");
+                var spy = sinon.stub(appInsights, "sendPageViewInternal");
                 var checkPageLoadStub = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "isPerformanceTimingDataReady",
                     () => { return false; });
                 var stub = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "getPerformanceTiming",

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -22,7 +22,7 @@ class AppInsightsTests extends TestClass {
             autoTrackPageVisitTime: false,
             samplingPercentage: 100,
             autoTrackAjax: false,
-            relativePageViewDuration: false
+            overridePageViewDuration: false
         };
 
         // set default values
@@ -630,7 +630,7 @@ class AppInsightsTests extends TestClass {
             name: "AppInsightsTests: trackPageView sends custom duration when configured by user",
             test: () => {
                 var snippet = this.getAppInsightsSnippet();
-                snippet.relativePageViewDuration = true;                
+                snippet.overridePageViewDuration = true;                
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(snippet);
                 var spy = this.sandbox.spy(appInsights, "sendPageViewInternal");
                 var stub = this.sandbox.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "getPerformanceTiming",

--- a/JavaScript/JavaScriptSDK/Telemetry/PageViewPerformance.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/PageViewPerformance.ts
@@ -27,9 +27,17 @@ module Microsoft.ApplicationInsights.Telemetry {
         /**
          * Field indicating whether this instance of PageViewPerformance is valid and should be sent
          */
-        public isValid: boolean;
+        private isValid: boolean;
 
-        public durationMs: number;
+        public getIsValid() {
+            return this.isValid;
+        }
+
+        private durationMs: number;
+
+        public getDurationMs() {
+            return this.durationMs;
+        }
 
         /**
          * Constructs a new instance of the PageEventTelemetry object
@@ -111,7 +119,7 @@ module Microsoft.ApplicationInsights.Telemetry {
          * As page loads different parts of performance timing numbers get set. When all of them are set we can report it.
          * Returns true if ready, false otherwise.
          */
-        public static isPerformanceTimingDataReady() {
+            public static isPerformanceTimingDataReady() {
             var timing = window.performance.timing;
 
             return timing.domainLookupStart > 0

--- a/JavaScript/JavaScriptSDK/Telemetry/PageViewPerformance.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/PageViewPerformance.ts
@@ -29,10 +29,12 @@ module Microsoft.ApplicationInsights.Telemetry {
          */
         public isValid: boolean;
 
+        public durationMs: number;
+
         /**
          * Constructs a new instance of the PageEventTelemetry object
          */
-        constructor(name: string, url: string, durationMs: number, properties?: any, measurements?: any) {
+        constructor(name: string, url: string, unused: number, properties?: any, measurements?: any) {
             super();
 
             this.isValid = false;
@@ -57,7 +59,6 @@ module Microsoft.ApplicationInsights.Telemetry {
                 var response = PageViewPerformance.getDuration(timing.responseStart, timing.responseEnd);
                 var dom = PageViewPerformance.getDuration(timing.responseEnd, timing.loadEventEnd);
 
-
                 if (total == 0) {
                     _InternalLogging.throwInternalNonUserActionable(
                         LoggingSeverity.WARNING,
@@ -70,14 +71,11 @@ module Microsoft.ApplicationInsights.Telemetry {
                     _InternalLogging.throwInternalNonUserActionable(
                         LoggingSeverity.WARNING,
                         "client performance math error:" + total + " < " + network + " + " + request + " + " + response + " + " + dom);
-
                 } else {
-
-                    // use timing data for duration if possible
-                    durationMs = total;
+                    this.durationMs = total;
 
                     // convert to timespans
-                    this.perfTotal = Util.msToTimeSpan(total);
+                    this.perfTotal = this.duration = Util.msToTimeSpan(total);
                     this.networkConnect = Util.msToTimeSpan(network);
                     this.sentRequest = Util.msToTimeSpan(request);
                     this.receivedResponse = Util.msToTimeSpan(response);
@@ -86,16 +84,12 @@ module Microsoft.ApplicationInsights.Telemetry {
                     this.isValid = true;
                 }
             }
+
             this.url = Common.DataSanitizer.sanitizeUrl(url);
             this.name = Common.DataSanitizer.sanitizeString(name || Util.NotSpecified);
 
-            if (!isNaN(durationMs)) {
-                this.duration = Util.msToTimeSpan(durationMs);
-            }
-
             this.properties = ApplicationInsights.Telemetry.Common.DataSanitizer.sanitizeProperties(properties);
             this.measurements = ApplicationInsights.Telemetry.Common.DataSanitizer.sanitizeMeasurements(measurements);
-
         }
 
         public static getPerformanceTiming(): PerformanceTiming {

--- a/JavaScript/JavaScriptSDK/Telemetry/PageViewPerformance.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/PageViewPerformance.ts
@@ -28,13 +28,19 @@ module Microsoft.ApplicationInsights.Telemetry {
          * Field indicating whether this instance of PageViewPerformance is valid and should be sent
          */
         private isValid: boolean;
-
+                
+        /**
+         * Indicates whether this instance of PageViewPerformance is valid and should be sent
+         */
         public getIsValid() {
             return this.isValid;
         }
 
         private durationMs: number;
 
+        /**
+        * Gets the total duration (PLT) in milliseconds. Check getIsValid() before using this method.
+        */
         public getDurationMs() {
             return this.durationMs;
         }

--- a/JavaScript/JavaScriptSDK/appInsights.ts
+++ b/JavaScript/JavaScriptSDK/appInsights.ts
@@ -31,7 +31,7 @@ module Microsoft.ApplicationInsights {
         samplingPercentage: number;
         autoTrackPageVisitTime: boolean;
         autoTrackAjax: boolean;
-        relativePageViewDuration: boolean;
+        overridePageViewDuration: boolean;
     }
 
     /**
@@ -197,7 +197,7 @@ module Microsoft.ApplicationInsights {
 
             var start = Telemetry.PageViewPerformance.getPerformanceTiming().navigationStart;
 
-            if (this.config.relativePageViewDuration) {
+            if (this.config.overridePageViewDuration) {
                 var duration = Telemetry.PageViewPerformance.getDuration(start, +new Date);
                 this.sendPageViewInternal(name, url, duration, properties, measurements);
                 this.flush();
@@ -211,7 +211,7 @@ module Microsoft.ApplicationInsights {
                         var pageViewPerformance = new Telemetry.PageViewPerformance(name, url, null, properties, measurements);
                         
                         if (pageViewPerformance.getIsValid()) {
-                            if (!this.config.relativePageViewDuration) {
+                            if (!this.config.overridePageViewDuration) {
                                 this.sendPageViewInternal(name, url, pageViewPerformance.getDurationMs(), properties, measurements);
                             }
 
@@ -225,7 +225,7 @@ module Microsoft.ApplicationInsights {
                     }
                     else if (Telemetry.PageViewPerformance.getDuration(start, +new Date) > maxDurationLimit) {
                         clearInterval(handle);
-                        if (!this.config.relativePageViewDuration) {
+                        if (!this.config.overridePageViewDuration) {
                             this.sendPageViewInternal(name, url, maxDurationLimit, properties, measurements);
                             this.flush();
                         }

--- a/JavaScript/JavaScriptSDK/appInsights.ts
+++ b/JavaScript/JavaScriptSDK/appInsights.ts
@@ -188,7 +188,7 @@ module Microsoft.ApplicationInsights {
 
         public trackPageViewInternal(name?: string, url?: string, properties?: Object, measurements?: Object) {
             if (!Telemetry.PageViewPerformance.isPerformanceTimingSupported()) {
-                // TODO: no navigation timing (IE 8, iOS Safari 8.4, Opera Mini 8 - see http://caniuse.com/#feat=nav-timing)
+                // no navigation timing (IE 8, iOS Safari 8.4, Opera Mini 8 - see http://caniuse.com/#feat=nav-timing)
                 _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL,
                     "trackPageView failed: navigation timing API used for calculation of page duration is not supported in this browser.");
 

--- a/JavaScript/JavaScriptSDK/appInsights.ts
+++ b/JavaScript/JavaScriptSDK/appInsights.ts
@@ -31,6 +31,7 @@ module Microsoft.ApplicationInsights {
         samplingPercentage: number;
         autoTrackPageVisitTime: boolean;
         autoTrackAjax: boolean;
+        relativePageViewDuration: boolean;
     }
 
     /**
@@ -174,7 +175,7 @@ module Microsoft.ApplicationInsights {
                     url = window.location && window.location.href || "";
                 }
 
-                this.trackPageViewInternal(name, url, properties, measurements);
+                this.trackPageViewInternal(this.config.relativePageViewDuration, name, url, properties, measurements);
 
                 if (this.config.autoTrackPageVisitTime) {
                     this._pageVisitTimeManager.trackPreviousPageVisit(name, url);
@@ -185,54 +186,111 @@ module Microsoft.ApplicationInsights {
             }
         }
 
-        private trackPageViewInternal(name?: string, url?: string, properties?: Object, measurements?: Object) {
-            var durationMs = 0;
-            // check if timing data is available
-            if (Telemetry.PageViewPerformance.isPerformanceTimingSupported()) {
-                // compute current duration (navigation start to now) for the pageViewTelemetry
-                var startTime = window.performance.timing.navigationStart;
-                durationMs = Telemetry.PageViewPerformance.getDuration(startTime, +new Date);
+        public trackPageViewInternal(relativePageViewDuration: boolean, name?: string, url?: string, properties?: Object, measurements?: Object) {
+            if (!Telemetry.PageViewPerformance.isPerformanceTimingSupported()) {
+                // TODO: no navigation timing (IE 8, iOS Safari 8.4, Opera Mini 8 - see http://caniuse.com/#feat=nav-timing)
+                _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL,
+                    "trackPageView failed: navigation timing API used for calculation of page duration is not supported in this browser.");
 
-                // poll for page load completion and send page view performance data when ready
-                var handle = setInterval(() => {
-                    try {
-                        // abort this check if we have not finished loading after 1 minute
-                        durationMs = Telemetry.PageViewPerformance.getDuration(startTime, +new Date);
-                        var timingDataReady = Telemetry.PageViewPerformance.isPerformanceTimingDataReady();
-                        var timeoutReached = durationMs > 60000;
-                        if (timeoutReached || timingDataReady) {
-                            clearInterval(handle);
-                            durationMs = Telemetry.PageViewPerformance.getDuration(startTime, +new Date);
-                            var pageViewPerformance = new Telemetry.PageViewPerformance(name, url, durationMs, properties, measurements);
-
-                            // Sending page view when navigation timing (i.e. client perf data) is ready.
-                            // We used to report page view duration separtely and it caused confusion - 
-                            // how is that different from client perf duration?
-                            // So we made these 2 metrics to have the same value (by reporting it at the same time).
-                            this.sendPageViewInternal(
-                                name,
-                                url,
-                                pageViewPerformance.isValid && !isNaN(<any>pageViewPerformance.duration) ?
-                                    +pageViewPerformance.duration :
-                                    durationMs,
-                                properties,
-                                measurements);
-
-                            if (pageViewPerformance.isValid) {
-                                var pageViewPerformanceData = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.PageViewPerformance>(
-                                    Telemetry.PageViewPerformance.dataType, pageViewPerformance);
-                                var pageViewPerformanceEnvelope = new Telemetry.Common.Envelope(pageViewPerformanceData, Telemetry.PageViewPerformance.envelopeType);
-                                this.context.track(pageViewPerformanceEnvelope);
-                            }
-
-                            this.context._sender.triggerSend();
-                        }
-                    } catch (e) {
-                        _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "trackPageView failed on page load calculation: " + Util.dump(e));
-                    }
-                }, 100);
+                return;
             }
+
+            var start = window.performance.timing.navigationStart;
+
+            if (relativePageViewDuration) {
+                var duration = Telemetry.PageViewPerformance.getDuration(start, +new Date);
+                this.sendPageViewInternal(name, url, duration, properties, measurements);
+                this.flush();
+            }
+
+            var maxDurationLimit = 60000;
+            var handle = setInterval(() => {
+                try {
+                    if (Telemetry.PageViewPerformance.isPerformanceTimingDataReady()) {
+                        clearInterval(handle);
+                        var pageViewPerformance = new Telemetry.PageViewPerformance(name, url, null, properties, measurements);
+
+                        if (!relativePageViewDuration) {
+                            var duration = pageViewPerformance.isValid ?
+                                pageViewPerformance.durationMs :
+                                maxDurationLimit;
+
+                            this.sendPageViewInternal(name, url, duration, properties, measurements);
+                        }
+
+                        if (pageViewPerformance.isValid) {
+                            var pageViewPerformanceData = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.PageViewPerformance>(
+                                Telemetry.PageViewPerformance.dataType, pageViewPerformance);
+                            var pageViewPerformanceEnvelope = new Telemetry.Common.Envelope(pageViewPerformanceData, Telemetry.PageViewPerformance.envelopeType);
+                            this.context.track(pageViewPerformanceEnvelope);
+                        }
+
+                        this.flush();
+                    }
+                    else if (Telemetry.PageViewPerformance.getDuration(start, +new Date) > maxDurationLimit) {
+                        clearInterval(handle);
+                        if (!relativePageViewDuration) {
+                            this.sendPageViewInternal(name, url, maxDurationLimit, properties, measurements);
+                            this.flush();
+                        }
+                    }
+                } catch (e) {
+                    _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "trackPageView failed on page load calculation: " + Util.dump(e));
+                }
+            }, 100);
         }
+
+        //private trackPageViewInternal(name?: string, url?: string, properties?: Object, measurements?: Object) {
+        //    var durationMs = 0;
+        //    // check if timing data is available
+        //    if (Telemetry.PageViewPerformance.isPerformanceTimingSupported()) {
+        //        // compute current duration (navigation start to now) for the pageViewTelemetry
+        //        var startTime = window.performance.timing.navigationStart;
+        //        durationMs = Telemetry.PageViewPerformance.getDuration(startTime, +new Date);
+
+        //        // poll for page load completion and send page view performance data when ready
+        //        var handle = setInterval(() => {
+        //            try {
+        //                // abort this check if we have not finished loading after 1 minute
+        //                durationMs = Telemetry.PageViewPerformance.getDuration(startTime, +new Date);
+        //                var timingDataReady = Telemetry.PageViewPerformance.isPerformanceTimingDataReady();
+        //                var timeoutReached = durationMs > 60000;
+        //                if (timeoutReached || timingDataReady) {
+        //                    clearInterval(handle);
+        //                    durationMs = Telemetry.PageViewPerformance.getDuration(startTime, +new Date);
+        //                    var pageViewPerformance = new Telemetry.PageViewPerformance(name, url, durationMs, properties, measurements);
+
+        //                    // Sending page view when navigation timing (i.e. client perf data) is ready.
+        //                    // We used to report page view duration separtely and it caused confusion - 
+        //                    // how is that different from client perf duration?
+        //                    // So we made these 2 metrics to have the same value (by reporting it at the same time).
+        //                    this.sendPageViewInternal(
+        //                        name,
+        //                        url,
+        //                        pageViewPerformance.isValid && !isNaN(<any>pageViewPerformance.duration) ?
+        //                            +pageViewPerformance.duration :
+        //                            durationMs,
+        //                        properties,
+        //                        measurements);
+
+        //                    if (pageViewPerformance.isValid) {
+        //                        var pageViewPerformanceData = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.PageViewPerformance>(
+        //                            Telemetry.PageViewPerformance.dataType, pageViewPerformance);
+        //                        var pageViewPerformanceEnvelope = new Telemetry.Common.Envelope(pageViewPerformanceData, Telemetry.PageViewPerformance.envelopeType);
+        //                        this.context.track(pageViewPerformanceEnvelope);
+        //                    }
+
+        //                    this.context._sender.triggerSend();
+        //                }
+        //            } catch (e) {
+        //                _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL, "trackPageView failed on page load calculation: " + Util.dump(e));
+        //            }
+        //        }, 100);
+        //    } else {
+        //        // TODO: no navigation timing (IE 8, iOS Safari 8.4, Opera Mini 8 - see http://caniuse.com/#feat=nav-timing)
+        //    }
+
+        //}
 
 
         /**


### PR DESCRIPTION
1) Default scenario: forcing PageView duration being page load time (equal to PageViewPerformance.total).
This will be the default behavior. 

2) If new config parameter ('relativePageViewDuration') is set to true than page view duration will equal to the time from window.performance.timing.navigationStart to the moment of calling the trackPageView(). This is useful when page view duration has a special meaning and is not bound to "physical" page load time. For example, if a page has many ajax calls which execute after DOM and all resources are loaded, and we consider the last ajax call as the end of page load.