### PR TITLE
Setting operation name to window.location.pathname

### DIFF
--- a/JavaScript/JavaScriptSDK/Context/Operation.ts
+++ b/JavaScript/JavaScriptSDK/Context/Operation.ts
@@ -12,7 +12,10 @@ module Microsoft.ApplicationInsights.Context {
         public syntheticSource: string;
 
         constructor() {
-            this.id = Util.newGuid();
+            this.id = Util.newGuid();            
+            if (window && window.location && window.location.pathname) {
+                this.name = window.location.pathname;
+            }
         }
     }
 } 


### PR DESCRIPTION
This change will allow to glue page view and page view performance documents in the UI. So that we can show a blade filtered by operation name and showing data of both doc types (raw grid with page views and performance stacked area chart based on page view performance)