### PR TITLE
Do not send sampleRate when it is 100 #74

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Sender.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Sender.tests.ts
@@ -368,7 +368,7 @@ class SenderTests extends TestClass {
         });
 
         this.testCase({
-            name: "SenderTests: enableTracking swtich is set to false.  Sender should not send/save data",
+            name: "SenderTests: enableTracking switch is set to false.  Sender should not send/save data",
             test: () => {
                 // setup
                 this.disableTelemetry = true;
@@ -389,7 +389,7 @@ class SenderTests extends TestClass {
         });
 
         this.testCase({
-            name: "SenderTests: enableTracking swtich is set to false.  Trigger send should not send data",
+            name: "SenderTests: enableTracking switch is set to false.  Trigger send should not send data",
             test: () => {
                 // setup
                 this.disableTelemetry = true;

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Serializer.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Serializer.tests.ts
@@ -43,8 +43,8 @@ class SerializerTests extends TestClass {
                         stillSerializable: "yep"
                     },
                     aiDataContract: {
-                        str: true,
-                        noContract: true
+                        str: Microsoft.ApplicationInsights.FieldType.Required,
+                        noContract: Microsoft.ApplicationInsights.FieldType.Required
                     }
                 };
 
@@ -64,7 +64,7 @@ class SerializerTests extends TestClass {
                 // act
                 var obj = {
                     aiDataContract: {
-                        str: true
+                        str: Microsoft.ApplicationInsights.FieldType.Required
                     }
                 };
 
@@ -82,14 +82,14 @@ class SerializerTests extends TestClass {
             test: () => {
 
                 // act
-                var noCycle = { value: "value", aiDataContract: { value: true } };
+                var noCycle = { value: "value", aiDataContract: { value: Microsoft.ApplicationInsights.FieldType.Required } };
                 var obj = {
                     arr: [
                         noCycle,
                         noCycle,
                         noCycle
                     ],
-                    aiDataContract: { arr: [] }
+                    aiDataContract: { arr: Microsoft.ApplicationInsights.FieldType.Array }
                 };
                 var expected = '{"arr":[{"value":"value"},{"value":"value"},{"value":"value"}]}';
                 var actual = Microsoft.ApplicationInsights.Serializer.serialize(obj);
@@ -108,7 +108,7 @@ class SerializerTests extends TestClass {
                 // act
                 var obj = {
                     arr: {},
-                    aiDataContract: { arr: [] }
+                    aiDataContract: { arr: Microsoft.ApplicationInsights.FieldType.Array }
                 };
 
                 Microsoft.ApplicationInsights.Serializer.serialize(obj);
@@ -120,18 +120,65 @@ class SerializerTests extends TestClass {
         });
 
         this.testCase({
+            name: "SerializerTests: hidden fields are not serialized",
+            test: () => {
+
+                // act
+                var obj = {
+                    str: "yes!",
+                    hiddenStr: "im the invisible man",
+                    hiddenStrRequired: "required fields can also be marked as hidden",
+                    aiDataContract: {
+                        str: Microsoft.ApplicationInsights.FieldType.Required,
+                        hiddenStr: Microsoft.ApplicationInsights.FieldType.Hidden,
+                        hiddenStrRequired: Microsoft.ApplicationInsights.FieldType.Required | Microsoft.ApplicationInsights.FieldType.Hidden,
+                    }
+                };
+
+                var expected = '{"str":"yes!"}';
+                var actual = Microsoft.ApplicationInsights.Serializer.serialize(obj);
+
+                // verify
+                Assert.equal(expected, actual, "Object is serialized correctly");
+            }
+        });
+
+        this.testCase({
+            name: "SerializerTests: serialize a field which has a dynamic required state",
+            test: () => {
+
+                // act
+                var obj = {
+                    str: "required",
+                    strOptional: "optional",
+
+                    aiDataContract: {
+                        str: { isRequired: () => { return Microsoft.ApplicationInsights.FieldType.Required; } },
+                        strOptional: { isRequired: () => { return Microsoft.ApplicationInsights.FieldType.Default; } }
+                    }
+                };
+
+                var expected = '{"str":"required","strOptional":"optional"}';
+                var actual = Microsoft.ApplicationInsights.Serializer.serialize(obj);
+
+                // verify
+                Assert.equal(expected, actual, "Object is serialized correctly");
+            }
+        });
+
+        this.testCase({
             name: "SerializerTests: cycles without contracts are handled",
             test: () => {
                 // act
-                var cyclePt1 = { value: undefined, aiDataContract: { value: true } };
-                var cyclePt2 = { value: cyclePt1, aiDataContract: { value: true } };
+                var cyclePt1 = { value: undefined, aiDataContract: { value: Microsoft.ApplicationInsights.FieldType.Required } };
+                var cyclePt2 = { value: cyclePt1, aiDataContract: { value: Microsoft.ApplicationInsights.FieldType.Required } };
                 cyclePt1.value = cyclePt2;
                 var obj = {
                     noContractWithCycle: {
                         notSerializable: cyclePt1
                     },
                     aiDataContract: {
-                        noContractWithCycle: true,
+                        noContractWithCycle: Microsoft.ApplicationInsights.FieldType.Required,
                     }
                 };
 
@@ -148,13 +195,13 @@ class SerializerTests extends TestClass {
             name: "SerializerTests: cycles with contracts are handled",
             test: () => {
                 // act
-                var cyclePt1 = { value: undefined, aiDataContract: { value: true } };
-                var cyclePt2 = { value: cyclePt1, aiDataContract: { value: true } };
+                var cyclePt1 = { value: undefined, aiDataContract: { value: Microsoft.ApplicationInsights.FieldType.Required } };
+                var cyclePt2 = { value: cyclePt1, aiDataContract: { value: Microsoft.ApplicationInsights.FieldType.Required } };
                 cyclePt1.value = cyclePt2;
                 var obj = {
                     aCycleWithContract: cyclePt1,
                     aiDataContract: {
-                        aCycleWithContract: true,
+                        aCycleWithContract: Microsoft.ApplicationInsights.FieldType.Required,
                     }
                 };
 
@@ -176,7 +223,7 @@ class SerializerTests extends TestClass {
                     str: "str",
                     notInContract: "foo",
                     aiDataContract: {
-                        str: true,
+                        str: Microsoft.ApplicationInsights.FieldType.Required,
                     }
                 };
 
@@ -196,7 +243,7 @@ class SerializerTests extends TestClass {
                 var obj = {
                     str: "str",
                     aiDataContract: {
-                        str: true
+                        str: Microsoft.ApplicationInsights.FieldType.Required
                     }
                 };
 
@@ -233,8 +280,8 @@ class SerializerTests extends TestClass {
                         properties: props,
                         measurements: meas,
                         aiDataContract: {
-                            properties: false,
-                            measurements: false
+                            properties: Microsoft.ApplicationInsights.FieldType.Default,
+                            measurements: Microsoft.ApplicationInsights.FieldType.Default
                         }
                     };
 
@@ -267,8 +314,8 @@ class SerializerTests extends TestClass {
                         properties: props,
                         measurements: meas,
                         aiDataContract: {
-                            properties: false,
-                            measurements: false
+                            properties: Microsoft.ApplicationInsights.FieldType.Default,
+                            measurements: Microsoft.ApplicationInsights.FieldType.Default,
                         }
                     };
 
@@ -288,7 +335,6 @@ class SerializerTests extends TestClass {
 
             }
         });
-
     }
 }
 new SerializerTests().registerTests();  

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/PageViewPerformance.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/PageViewPerformance.tests.ts
@@ -37,11 +37,18 @@ class PageViewPerformanceTelemetryTests extends ContractTestHelper {
             test: () => {
                 var telemetry = new Microsoft.ApplicationInsights.Telemetry.PageViewPerformance("name", "url", 0);
 
-                Assert.equal("boolean", typeof telemetry.aiDataContract.perfTotal, "perfTotal is set in data contract");
-                Assert.equal("boolean", typeof telemetry.aiDataContract.networkConnect, "networkConnect is set in data contract");
-                Assert.equal("boolean", typeof telemetry.aiDataContract.receivedResponse, "receivedResponse is set in data contract");
-                Assert.equal("boolean", typeof telemetry.aiDataContract.sentRequest, "sentRequest is set in data contract");
-                Assert.equal("boolean", typeof telemetry.aiDataContract.domProcessing, "domProcessing is set in data contract");
+                Assert.equal(Microsoft.ApplicationInsights.FieldType.Required, telemetry.aiDataContract.ver, "version fields is required");
+
+                // all other fields are optional
+                for (var field in telemetry.aiDataContract) {
+
+                    if (field == "ver") {
+                        continue;
+                    }
+
+                    var contract = telemetry.aiDataContract[field];
+                    Assert.notEqual(true, contract.isRequired, field + " is not required");
+                }
             }
         });
 

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -34,7 +34,7 @@ class AppInsightsTests extends TestClass {
         Microsoft.ApplicationInsights.Util.setCookie('ai_user', "");
         if (window.localStorage) {
             window.localStorage.clear();
-    }
+        }
     }
 
     public testCleanup() {
@@ -43,7 +43,7 @@ class AppInsightsTests extends TestClass {
         Microsoft.ApplicationInsights.Util.setCookie('ai_user', "");
         if (window.localStorage) {
             window.localStorage.clear();
-    }
+        }
     }
 
     public registerTests() {
@@ -1328,14 +1328,14 @@ class AppInsightsTests extends TestClass {
                 appInsights.trackEvent("Event3");
 
                 // verify
-                sinon.clock.tick(1);
+                this.clock.tick(1);
                 Assert.ok(senderSpy.notCalled, "data is not sent without calling flush");
 
                 // act
                 appInsights.flush();
 
                 // verify
-                sinon.clock.tick(1);
+                this.clock.tick(1);
                 Assert.ok(senderSpy.calledOnce, "data is sent after calling flush");
 
                 // teardown

--- a/JavaScript/JavaScriptSDK.Tests/TestFramework/ContractTestHelper.ts
+++ b/JavaScript/JavaScriptSDK.Tests/TestFramework/ContractTestHelper.ts
@@ -76,7 +76,7 @@ class ContractTestHelper extends TestClass {
     private allRequiredFieldsAreConstructed(initializer: () => any, name: string) {
         var subject = this.getSubject(initializer, name);
         for (var field in subject.aiDataContract) {
-            if (subject.aiDataContract[field]) {
+            if (subject.aiDataContract[field] & Microsoft.ApplicationInsights.FieldType.Required) {
                 Assert.ok(subject[field] != null, "The required field '" + field + "' is constructed for: '" + name + "'");
             }
         }

--- a/JavaScript/JavaScriptSDK/Telemetry/Common/Data.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/Common/Data.ts
@@ -8,8 +8,8 @@ module Microsoft.ApplicationInsights.Telemetry.Common {
          * The data contract for serializing this object.
          */
         public aiDataContract = {
-            baseType: true,
-            baseData: true
+            baseType: FieldType.Required,
+            baseData: FieldType.Required
         }
 
         /**

--- a/JavaScript/JavaScriptSDK/Telemetry/Common/DataPoint.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/Common/DataPoint.ts
@@ -8,13 +8,13 @@ module Microsoft.ApplicationInsights.Telemetry.Common {
          * The data contract for serializing this object.
          */
         public aiDataContract = {
-            name: true,
-            kind: false,
-            value: true,
-            count: false,
-            min: false,
-            max: false,
-            stdDev: false
+            name: FieldType.Required,
+            kind: FieldType.Default,
+            value: FieldType.Required,
+            count: FieldType.Default,
+            min: FieldType.Default,
+            max: FieldType.Default,
+            stdDev: FieldType.Default
         }
     }
 }

--- a/JavaScript/JavaScriptSDK/Telemetry/Common/Envelope.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/Common/Envelope.ts
@@ -20,14 +20,16 @@ module Microsoft.ApplicationInsights.Telemetry.Common {
             this.name = name;
             this.data = data;
             this.time = Util.toISOStringForIE8(new Date());
-            
+
             this.aiDataContract = {
-                time: true,
-                iKey: true,
-                name: true,
-                sampleRate: true,
-                tags: true,
-                data: true
+                time: FieldType.Required,
+                iKey: FieldType.Required,
+                name: FieldType.Required,
+                sampleRate: () => {
+                    return (this.sampleRate == 100) ? FieldType.Hidden : FieldType.Required;
+                },
+                tags: FieldType.Required,
+                data: FieldType.Required,
             };
         }
     }

--- a/JavaScript/JavaScriptSDK/Telemetry/Event.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/Event.ts
@@ -10,10 +10,10 @@ module Microsoft.ApplicationInsights.Telemetry {
         public static dataType = "EventData";
 
         public aiDataContract = {
-            ver: true,
-            name: true,
-            properties: false,
-            measurements: false,
+            ver: FieldType.Required,
+            name: FieldType.Required,
+            properties: FieldType.Default,
+            measurements: FieldType.Default,
         }
 
         /**

--- a/JavaScript/JavaScriptSDK/Telemetry/Exception.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/Exception.ts
@@ -12,12 +12,12 @@ module Microsoft.ApplicationInsights.Telemetry {
 
 
         public aiDataContract = {
-            ver: true,
-            handledAt: true,
-            exceptions: true,
-            severityLevel: false,
-            properties: false,
-            measurements: false
+            ver: FieldType.Required,
+            handledAt: FieldType.Required,
+            exceptions: FieldType.Required,
+            severityLevel: FieldType.Default,
+            properties: FieldType.Default,
+            measurements: FieldType.Default,
         }
 
         /**
@@ -66,13 +66,13 @@ module Microsoft.ApplicationInsights.Telemetry {
     class _ExceptionDetails extends AI.ExceptionDetails implements ISerializable {
 
         public aiDataContract = {
-            id: false,
-            outerId: false,
-            typeName: true,
-            message: true,
-            hasFullStack: false,
-            stack: false,
-            parsedStack: []
+            id: FieldType.Default,
+            outerId: FieldType.Default,
+            typeName: FieldType.Required,
+            message: FieldType.Required,
+            hasFullStack: FieldType.Default,
+            stack: FieldType.Default,
+            parsedStack: FieldType.Array,
         };
 
         constructor(exception: Error) {
@@ -149,11 +149,11 @@ module Microsoft.ApplicationInsights.Telemetry {
         public sizeInBytes = 0;
 
         public aiDataContract = {
-            level: true,
-            method: true,
-            assembly: false,
-            fileName: false,
-            line: false
+            level: FieldType.Required,
+            method: FieldType.Required,
+            assembly: FieldType.Default,
+            fileName: FieldType.Default,
+            line: FieldType.Default,
         };
 
         constructor(frame: string, level: number) {

--- a/JavaScript/JavaScriptSDK/Telemetry/Metric.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/Metric.ts
@@ -11,9 +11,9 @@ module Microsoft.ApplicationInsights.Telemetry {
         public static dataType = "MetricData";
 
         public aiDataContract = {
-            ver: true,
-            metrics: true,
-            properties: false
+            ver: FieldType.Required,
+            metrics: FieldType.Required,
+            properties: FieldType.Default,
         }
 
         /**

--- a/JavaScript/JavaScriptSDK/Telemetry/PageView.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/PageView.ts
@@ -10,12 +10,12 @@ module Microsoft.ApplicationInsights.Telemetry {
         public static dataType = "PageviewData";
 
         public aiDataContract = {
-            ver: true,
-            name: false,
-            url: false,
-            duration: false,
-            properties: false,
-            measurements: false
+            ver: FieldType.Required,
+            name: FieldType.Default,
+            url: FieldType.Default,
+            duration: FieldType.Default,
+            properties: FieldType.Default,
+            measurements: FieldType.Default,
         }
 
         /**

--- a/JavaScript/JavaScriptSDK/Telemetry/PageViewPerformance.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/PageViewPerformance.ts
@@ -11,17 +11,17 @@ module Microsoft.ApplicationInsights.Telemetry {
         public static dataType = "PageviewPerformanceData";
 
         public aiDataContract = {
-            ver: true,
-            name: false,
-            url: false,
-            duration: false,
-            perfTotal: false,
-            networkConnect: false,
-            sentRequest: false,
-            receivedResponse: false,
-            domProcessing: false,
-            properties: false,
-            measurements: false
+            ver: FieldType.Required,
+            name: FieldType.Default,
+            url: FieldType.Default,
+            duration: FieldType.Default,
+            perfTotal: FieldType.Default,
+            networkConnect: FieldType.Default,
+            sentRequest: FieldType.Default,
+            receivedResponse: FieldType.Default,
+            domProcessing: FieldType.Default,
+            properties: FieldType.Default,
+            measurements: FieldType.Default
         };
 
         /**

--- a/JavaScript/JavaScriptSDK/Telemetry/RemoteDependencyData.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/RemoteDependencyData.ts
@@ -11,21 +11,21 @@ module Microsoft.ApplicationInsights.Telemetry {
         public static dataType = "RemoteDependencyData";
 
         public aiDataContract = {
-            ver: true,
-            name: false,
-            kind: true,
-            value: false,
-            count: false,
-            min: false,
-            max: false,
-            stdDev: false,
-            dependencyKind: false,
-            success: false,
-            async: false,
-            dependencySource: false,
-            commandName: false,
-            dependencyTypeName: false,
-            properties: false,
+            ver: FieldType.Required,
+            name: FieldType.Default,
+            kind: FieldType.Required,
+            value: FieldType.Default,
+            count: FieldType.Default,
+            min: FieldType.Default,
+            max: FieldType.Default,
+            stdDev: FieldType.Default,
+            dependencyKind: FieldType.Default,
+            success: FieldType.Default,
+            async: FieldType.Default,
+            dependencySource: FieldType.Default,
+            commandName: FieldType.Default,
+            dependencyTypeName: FieldType.Default,
+            properties: FieldType.Default,
         }
 
         /**

--- a/JavaScript/JavaScriptSDK/Telemetry/SessionTelemetry.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/SessionTelemetry.ts
@@ -11,8 +11,8 @@ module Microsoft.ApplicationInsights.Telemetry {
         public static dataType = "SessionStateData";
 
         public aiDataContract = {
-            ver: true,
-            state: true
+            ver: FieldType.Required,
+            state: FieldType.Required,
         }
 
         constructor(state: AI.SessionState) {

--- a/JavaScript/JavaScriptSDK/Telemetry/Trace.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/Trace.ts
@@ -10,11 +10,11 @@ module Microsoft.ApplicationInsights.Telemetry {
         public static dataType = "MessageData";
 
         public aiDataContract = {
-            ver: true,
-            message: true,
-            severityLevel: false,
-            measurements: false,
-            properties: false
+            ver: FieldType.Required,
+            message: FieldType.Required,
+            severityLevel: FieldType.Default,
+            measurements: FieldType.Default,
+            properties: FieldType.Default
         };
 
         /**

--- a/JavaScript/JavaScriptSDK/ajax/ajax.ts
+++ b/JavaScript/JavaScriptSDK/ajax/ajax.ts
@@ -521,6 +521,6 @@ module Microsoft.ApplicationInsights {
             var ajaxMonitoringObject = new ajaxMonitoring(this.appInsights);
             ajaxMonitoringObject.Init();
             this.ajaxMonitorInternal = ajaxMonitoringObject;            
-        };
+        }
     }
 }


### PR DESCRIPTION
* Refactor aiDataContract object to use enum instead of bool 
* User can use functions in aiDataContract (see Envelope.ts)
* User can mark a fields as hidden an it will not be serialized