### PR TITLE
PageView: sending 0 duration when duration is unknown

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -690,7 +690,8 @@ class AppInsightsTests extends TestClass {
 
                 // Data not available yet - should not send events
                 this.clock.tick(100);
-                Assert.ok(!spy.called, "Page view should not be sent since the timing data is invalid");
+                Assert.ok(spy.called, "Page view should not be sent since the timing data is invalid");
+                Assert.equal(undefined, spy.args[0][2], "Page view duration should be undefined if performance data is not valid.");
             }
         });
 

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -675,7 +675,7 @@ class AppInsightsTests extends TestClass {
 
 
         this.testCase({
-            name: "AppInsightsTests: trackPageView does not send data if page view performance is not valid",
+            name: "AppInsightsTests: if performance data is no valid then trackPageView sends page view with duration equal time to spent from navigation start time till calling into trackPageView",
             test: () => {
                 // setup
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
@@ -684,6 +684,12 @@ class AppInsightsTests extends TestClass {
                     () => { return true; });
                 var getIsValidStub = this.sandbox.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance.prototype, "getIsValid",
                     () => { return false; });
+                var stub = this.sandbox.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "getPerformanceTiming",
+                    () => {
+                        return { navigationStart: 0 };
+                    });
+
+                this.clock.tick(50);
 
                 // act
                 appInsights.trackPageView();
@@ -691,7 +697,7 @@ class AppInsightsTests extends TestClass {
                 // Data not available yet - should not send events
                 this.clock.tick(100);
                 Assert.ok(spy.called, "Page view should not be sent since the timing data is invalid");
-                Assert.equal(undefined, spy.args[0][2], "Page view duration should be undefined if performance data is not valid.");
+                Assert.equal(50, spy.args[0][2], "Page view duration should be equal to time from navigation start to when trackPageView is called (aka 'override page view duration' mode)");
             }
         });
 
@@ -739,6 +745,25 @@ class AppInsightsTests extends TestClass {
                 this.clock.tick(65432);
                 Assert.ok(spy.calledOnce, "60 seconds passed, page view is supposed to be sent");
                 Assert.equal(60000, spy.args[0][2], "Page view duration doesn't match expected maximum duration (60000 ms)");
+            }
+        });
+
+        this.testCase({
+            name: "AppInsightsTests: a page view is sent with 0 duration if navigation timing API is not supported",
+            test: () => {
+                // setup
+                var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
+                var spy = this.sandbox.stub(appInsights, "sendPageViewInternal");
+                var checkPageLoadStub = this.sandbox.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "isPerformanceTimingSupported",
+                    () => { return false; });
+                
+                // act
+                appInsights.trackPageView();                
+                this.clock.tick(100);
+
+                // assert
+                Assert.ok(spy.calledOnce, "sendPageViewInternal should be called even if navigation timing is not supported");
+                Assert.equal(0, spy.args[0][2], "Page view duration should be 0");
             }
         });
 

--- a/JavaScript/JavaScriptSDK/Telemetry/PageViewPerformance.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/PageViewPerformance.ts
@@ -75,7 +75,7 @@ module Microsoft.ApplicationInsights.Telemetry {
 
                 if (total == 0) {
                     _InternalLogging.throwInternalNonUserActionable(
-                        LoggingSeverity.WARNING,
+                        LoggingSeverity.CRITICAL,
                         "error calculating page view performance: total='" +
                         total + "', network='" + network + "', request='" + request + "', response='" +
                         response + "', dom='" + dom + "'");
@@ -83,7 +83,7 @@ module Microsoft.ApplicationInsights.Telemetry {
                     // some browsers may report individual components incorrectly so that the sum of the parts will be bigger than total PLT
                     // in this case, don't report client performance from this page                    
                     _InternalLogging.throwInternalNonUserActionable(
-                        LoggingSeverity.WARNING,
+                        LoggingSeverity.CRITICAL,
                         "client performance math error:" + total + " < " + network + " + " + request + " + " + response + " + " + dom);
                 } else {
                     this.durationMs = total;

--- a/JavaScript/JavaScriptSDK/snippet.js
+++ b/JavaScript/JavaScriptSDK/snippet.js
@@ -1,6 +1,4 @@
 ﻿var appInsights = window.appInsights || (function(aiConfig) {
-    var snippetLoadTime = new Date;
-    
     var appInsights = {
         config: aiConfig
     };

--- a/JavaScript/JavaScriptSDK/snippet.js
+++ b/JavaScript/JavaScriptSDK/snippet.js
@@ -1,5 +1,6 @@
 ﻿var appInsights = window.appInsights || (function(aiConfig) {
-
+    var snippetLoadTime = new Date;
+    
     var appInsights = {
         config: aiConfig
     };


### PR DESCRIPTION
We don't want to lose page views when navigation timing is not supported by browsers (3% of cases).
However since duration property is mandatory we have no choice but setting it to 0. 