### PR TITLE
adding WebApplication.targets as nuget package, and changing references

### DIFF
--- a/JavaScript/JavaScriptSDK/JavaScriptSDK.csproj
+++ b/JavaScript/JavaScriptSDK/JavaScriptSDK.csproj
@@ -28,9 +28,14 @@
     <TypeScriptGeneratesDeclarations>True</TypeScriptGeneratesDeclarations>
     <!-- Suppress the "CS2008: No source files specified" warning -->
     <NoWarn>2008</NoWarn>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>12.0</OldToolsVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="..\..\..\packages\MSBuild.Microsoft.VisualStudio.Web.targets.14.0.0\tools\VSToolsPath\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <Import Project="..\..\..\packages\AjaxMin.5.5.5091.22839\tools\net40\AjaxMin.targets" Condition="Exists('..\..\..\packages\AjaxMin.5.5.5091.22839\tools\net40\AjaxMin.targets')" />
   <ProjectExtensions>
     <VisualStudio>

--- a/JavaScript/JavaScriptSDK/packages.config
+++ b/JavaScript/JavaScriptSDK/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AjaxMin" version="5.5.5091.22839" targetFramework="net45" />
+  <package id="MSBuild.Microsoft.VisualStudio.Web.targets" version="14.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
choosing to reference WebApplication from nuget package, as this is more likely to be stable across different vs versions, and different vs installations (apparently not everyone has WebApplication.targets by default, my vs2015 ultimate installation did not).

