### PR TITLE
Making messages reporting incorrect page performance warning-only

### DIFF
--- a/JavaScript/JavaScriptSDK/Logging.ts
+++ b/JavaScript/JavaScriptSDK/Logging.ts
@@ -1,7 +1,14 @@
 ﻿module Microsoft.ApplicationInsights {
     
     export enum LoggingSeverity {
+        /**
+         * Error will be sent as internal telemetry
+         */
         CRITICAL = 0,
+
+        /**
+         * Error will NOT be sent as internal telemetry, and will only be shown in browser console
+         */
         WARNING = 1
     }
 

--- a/JavaScript/JavaScriptSDK/Telemetry/PageViewManager.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/PageViewManager.ts
@@ -74,7 +74,7 @@ module Microsoft.ApplicationInsights.Telemetry {
 
             if (!Telemetry.PageViewPerformance.isPerformanceTimingSupported()) {
                 // no navigation timing (IE 8, iOS Safari 8.4, Opera Mini 8 - see http://caniuse.com/#feat=nav-timing)
-                _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.CRITICAL,
+                _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.WARNING,
                     "trackPageView: navigation timing API used for calculation of page duration is not supported in this browser. This page view will be collected without duration and timing info.");
                 return;
             }

--- a/JavaScript/JavaScriptSDK/Telemetry/PageViewPerformance.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/PageViewPerformance.ts
@@ -75,15 +75,15 @@ module Microsoft.ApplicationInsights.Telemetry {
 
                 if (total == 0) {
                     _InternalLogging.throwInternalNonUserActionable(
-                        LoggingSeverity.CRITICAL,
+                        LoggingSeverity.WARNING,
                         "error calculating page view performance: total='" +
                         total + "', network='" + network + "', request='" + request + "', response='" +
                         response + "', dom='" + dom + "'");
                 } else if (total < Math.floor(network) + Math.floor(request) + Math.floor(response) + Math.floor(dom)) {
                     // some browsers may report individual components incorrectly so that the sum of the parts will be bigger than total PLT
-                    // in this case, don't report client performance from this page                    
+                    // in this case, don't report client performance from this page
                     _InternalLogging.throwInternalNonUserActionable(
-                        LoggingSeverity.CRITICAL,
+                        LoggingSeverity.WARNING,
                         "client performance math error:" + total + " < " + network + " + " + request + " + " + response + " + " + dom);
                 } else {
                     this.durationMs = total;


### PR DESCRIPTION
This means they won't be sent to customer ikey as trace messages and instead will just appear in browser console. These are non-actionable errors for the ikey owner as we know that certain browser either don't support or incorrectly implement page performance API. This is to address #99 