### PR TITLE
Refactor tests

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Context/Sample.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Context/Sample.tests.ts
@@ -111,14 +111,14 @@ class SampleContextTests extends TestClass {
                 envelope1.tags[contextKeys.userId] = null;
                 envelope1.tags[contextKeys.operationId] = null;
 
-                var mathRandomSpy = sinon.spy(Math, "random");
+                var mathRandomSpy = this.sandbox.spy(Math, "random");
 
                 // act
                 sample.isSampledIn(envelope1);
 
                 // assert
                 Assert.ok(mathRandomSpy.calledOnce);
-                mathRandomSpy.restore();
+                
             }
         });
     }

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Context/Session.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Context/Session.tests.ts
@@ -93,9 +93,9 @@ class SessionContextTests extends TestClass {
                 // setup
                 var actualCookieName: string;
                 var actualCookieValue: string;
-                var newIdStub = sinon.stub(Microsoft.ApplicationInsights.Util, "newId", () => "newId");
-                var getCookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "getCookie", () => "");
-                var setCookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "setCookie", (cookieName, cookieValue) => {
+                var newIdStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "newId", () => "newId");
+                var getCookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "getCookie", () => "");
+                var setCookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "setCookie", (cookieName, cookieValue) => {
                     actualCookieName = cookieName;
                     actualCookieValue = cookieValue;
                 });
@@ -119,9 +119,9 @@ class SessionContextTests extends TestClass {
                 Assert.equal(30, expirationDate.getTime() / 1000 / 60, "cookie expiration should be in 30 minutes");
 
                 // cleanup
-                getCookieStub.restore();
-                setCookieStub.restore();
-                newIdStub.restore();
+                
+                
+                
             }
         });
 
@@ -132,9 +132,9 @@ class SessionContextTests extends TestClass {
                     // setup
                     var actualCookieName: string;
                     var actualCookieValue: string;
-                    var newIdStub = sinon.stub(Microsoft.ApplicationInsights.Util, "newId", () => "newId");
-                    var getCookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "getCookie",() => "");
-                    var setCookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "setCookie",(cookieName, cookieValue) => { });
+                    var newIdStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "newId", () => "newId");
+                    var getCookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "getCookie",() => "");
+                    var setCookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "setCookie",(cookieName, cookieValue) => { });
 
                     // act
                     var sessionManager = new Microsoft.ApplicationInsights.Context._SessionManager(null,() => { });
@@ -148,9 +148,9 @@ class SessionContextTests extends TestClass {
                     Assert.equal("newId", localStorage["ai_session"].split('|')[0], "First part of cookie value should be new user id guid");
 
                     // cleanup
-                    getCookieStub.restore();
-                    setCookieStub.restore();
-                    newIdStub.restore();
+                    
+                    
+                    
                 } else {
                     // this might happen on IE when using a file:// url
                     Assert.ok(true, "browser does not support local storage in current environment");
@@ -163,12 +163,12 @@ class SessionContextTests extends TestClass {
             test: () => {
                 var cookies = {};
                 var storage = {};
-                var getCookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "getCookie",(name) => cookies[name]);
-                var setCookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "setCookie",(name, value) => {
+                var getCookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "getCookie",(name) => cookies[name]);
+                var setCookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "setCookie",(name, value) => {
                     cookies[name] = value;
                 });
-                var getStorageStub = sinon.stub(Microsoft.ApplicationInsights.Util, "getStorage",(name) => storage[name]);
-                var setStorageStub = sinon.stub(Microsoft.ApplicationInsights.Util, "setStorage",(name, value) => {
+                var getStorageStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "getStorage",(name) => storage[name]);
+                var setStorageStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "setStorage",(name, value) => {
                     storage[name] = value;
                 });
 
@@ -187,10 +187,10 @@ class SessionContextTests extends TestClass {
                 Assert.ok(storage['ai_session'], "session cookie should be backed up in local storage");
 
                 // cleanup
-                getCookieStub.restore();
-                setCookieStub.restore();
-                getStorageStub.restore();
-                setStorageStub.restore();
+                
+                
+                
+                
             }
         });
 
@@ -199,12 +199,12 @@ class SessionContextTests extends TestClass {
             test: () => {
                 var cookies = {};
                 var storage = {};
-                var getCookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "getCookie",(name) => cookies[name]);
-                var setCookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "setCookie",(name, value) => {
+                var getCookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "getCookie",(name) => cookies[name]);
+                var setCookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "setCookie",(name, value) => {
                     cookies[name] = value;
                 });
-                var getStorageStub = sinon.stub(Microsoft.ApplicationInsights.Util, "getStorage",(name) => storage[name]);
-                var setStorageStub = sinon.stub(Microsoft.ApplicationInsights.Util, "setStorage",(name, value) => {
+                var getStorageStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "getStorage",(name) => storage[name]);
+                var setStorageStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "setStorage",(name, value) => {
                     storage[name] = value;
                 });
 
@@ -227,10 +227,10 @@ class SessionContextTests extends TestClass {
                 Assert.ok(!sessionManager.automaticSession.isFirst, "the isFirst state should be conserved after losing the session cookie");
 
                 // cleanup
-                getCookieStub.restore();
-                setCookieStub.restore();
-                getStorageStub.restore();
-                setStorageStub.restore();
+                
+                
+                
+                
             }
         });
 
@@ -239,15 +239,15 @@ class SessionContextTests extends TestClass {
             test: () => {
                 var cookies = {};
                 var storage = {};
-                var getCookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "getCookie",(name) => cookies[name]);
-                var setCookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "setCookie",(name, value) => {
+                var getCookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "getCookie",(name) => cookies[name]);
+                var setCookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "setCookie",(name, value) => {
                     cookies[name] = value;
                 });
-                var getStorageStub = sinon.stub(Microsoft.ApplicationInsights.Util, "getStorage",(name) => storage[name]);
-                var setStorageStub = sinon.stub(Microsoft.ApplicationInsights.Util, "setStorage",(name, value) => {
+                var getStorageStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "getStorage",(name) => storage[name]);
+                var setStorageStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "setStorage",(name, value) => {
                     storage[name] = value;
                 });
-                var removeStorageStub = sinon.stub(Microsoft.ApplicationInsights.Util, "removeStorage",(name, value) => {
+                var removeStorageStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "removeStorage",(name, value) => {
                     storage[name] = undefined;
                 });
 
@@ -270,11 +270,11 @@ class SessionContextTests extends TestClass {
                 Assert.ok(sessionManager.automaticSession.isFirst, "the isFirst state should be reset after losing all ai cookies");
 
                 // cleanup
-                getCookieStub.restore();
-                setCookieStub.restore();
-                getStorageStub.restore();
-                setStorageStub.restore();
-                removeStorageStub.restore();
+                
+                
+                
+                
+                
             }
         });
 
@@ -283,12 +283,12 @@ class SessionContextTests extends TestClass {
             test: () => {
                 var cookies = {};
                 var storage = {};
-                var getCookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "getCookie",(name) => cookies[name]);
-                var setCookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "setCookie",(name, value) => {
+                var getCookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "getCookie",(name) => cookies[name]);
+                var setCookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "setCookie",(name, value) => {
                     cookies[name] = value;
                 });
-                var getStorageStub = sinon.stub(Microsoft.ApplicationInsights.Util, "getStorage",(name) => null);
-                var setStorageStub = sinon.stub(Microsoft.ApplicationInsights.Util, "setStorage",(name, value) => false);
+                var getStorageStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "getStorage",(name) => null);
+                var setStorageStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "setStorage",(name, value) => false);
 
                 // Initialize our user and session cookies
                 var sessionId = "SESSID";
@@ -314,10 +314,10 @@ class SessionContextTests extends TestClass {
                 Assert.ok(sessionManager.automaticSession.isFirst, "the isFirst state should be reset after losing the session cookie");
 
                 // cleanup
-                getCookieStub.restore();
-                setCookieStub.restore();
-                getStorageStub.restore();
-                setStorageStub.restore();
+                
+                
+                
+                
             }
         });
 

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Context/User.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Context/User.tests.ts
@@ -23,14 +23,14 @@ class UserContextTests extends TestClass {
             test: () => {
                 // setup
                 var id = "userId";
-                var cookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "getCookie", () => id + "||||");
+                var cookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "getCookie", () => id + "||||");
 
                 // act
                 var user = new Microsoft.ApplicationInsights.Context.User(undefined);
 
                 // verify
                 Assert.equal(id, user.id, "user id was set from cookie");
-                cookieStub.restore();
+                
             }
         });
 
@@ -41,9 +41,9 @@ class UserContextTests extends TestClass {
                 var id = "userId";
                 var actualCookieName: string;
                 var actualCookieValue: string;
-                var newIdStub = sinon.stub(Microsoft.ApplicationInsights.Util, "newId", () => "newId");
-                var getCookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "getCookie",() => "");
-                var setCookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "setCookie",(cookieName, cookieValue) => {
+                var newIdStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "newId", () => "newId");
+                var getCookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "getCookie",() => "");
+                var setCookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "setCookie",(cookieName, cookieValue) => {
                     actualCookieName = cookieName;
                     actualCookieValue = cookieValue;
                 });
@@ -66,9 +66,9 @@ class UserContextTests extends TestClass {
                 Assert.equal(true, expirationDate > (new Date), "ai_user cookie expiration should be in the future");
 
                 // cleanup
-                getCookieStub.restore();
-                setCookieStub.restore();
-                newIdStub.restore();
+                
+                
+                
             }
         });
 
@@ -79,9 +79,9 @@ class UserContextTests extends TestClass {
                 var id = "userId"
                 var actualCookieName: string;
                 var actualCookieValue: string;
-                var newIdStub = sinon.stub(Microsoft.ApplicationInsights.Util, "newId", () => "newId");
-                var getCookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "getCookie",() => "");
-                var setCookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "setCookie",(cookieName, cookieValue) => {
+                var newIdStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "newId", () => "newId");
+                var getCookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "getCookie",() => "");
+                var setCookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "setCookie",(cookieName, cookieValue) => {
                     actualCookieName = cookieName;
                     actualCookieValue = cookieValue;
                 });
@@ -104,9 +104,9 @@ class UserContextTests extends TestClass {
                 Assert.equal(true, expirationDate > (new Date), "ai_user cookie expiration should be in the future");
 
                 // cleanup
-                getCookieStub.restore();
-                setCookieStub.restore();
-                newIdStub.restore();
+                
+                
+                
             }
         });
 
@@ -117,7 +117,7 @@ class UserContextTests extends TestClass {
                 var authId = "bla@bla.com";
                 var accountId = "Contoso";
 
-                var cookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "getCookie",() => authId + "|" + accountId);
+                var cookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "getCookie",() => authId + "|" + accountId);
 
                 // act
                 var user = new Microsoft.ApplicationInsights.Context.User(undefined);
@@ -125,7 +125,7 @@ class UserContextTests extends TestClass {
                 // verify
                 Assert.equal(authId, user.authenticatedId, "user auth id was set from cookie");
                 Assert.equal(accountId, user.accountId, "user account id was not set from cookie");
-                cookieStub.restore();
+                
             }
         });
 
@@ -134,14 +134,14 @@ class UserContextTests extends TestClass {
             test: () => {
                 // setup
                 var authId = "bla@bla.com";
-                var cookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "getCookie",() => authId);
+                var cookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "getCookie",() => authId);
 
                 // act
                 var user = new Microsoft.ApplicationInsights.Context.User(undefined);
 
                 // verify
                 Assert.equal(authId, user.authenticatedId, "user auth id was set from cookie");
-                cookieStub.restore();
+                
             }
         });
 
@@ -149,7 +149,7 @@ class UserContextTests extends TestClass {
             name: "Ctor: auth user context handles empty cookie",
             test: () => {
                 // setup
-                var cookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "getCookie",() => "");
+                var cookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "getCookie",() => "");
 
                 // act
                 var user = new Microsoft.ApplicationInsights.Context.User(undefined);
@@ -157,7 +157,7 @@ class UserContextTests extends TestClass {
                 // verify
                 Assert.equal(undefined, user.authenticatedId, "user auth id was not set");
                 Assert.equal(undefined, user.accountId, "user account id was not set");
-                cookieStub.restore();
+                
             }
         });
 
@@ -166,14 +166,14 @@ class UserContextTests extends TestClass {
             test: () => {
                 // setup
                 var accountIdBackCompat = "account17";
-                var cookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "getCookie",() => null);
+                var cookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "getCookie",() => null);
 
                 // act
                 var user = new Microsoft.ApplicationInsights.Context.User(accountIdBackCompat);
 
                 // verify
                 Assert.equal(accountIdBackCompat, user.accountId, "user account id was set from back compat");
-                cookieStub.restore();
+                
             }
         });
 
@@ -182,7 +182,7 @@ class UserContextTests extends TestClass {
             test: () => {
                 // setup
                 var authAndAccountId = ["bla@bla.com"];
-                var cookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "setCookie");
+                var cookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "setCookie");
                 var user = new Microsoft.ApplicationInsights.Context.User(undefined);
 
                 // act
@@ -191,7 +191,7 @@ class UserContextTests extends TestClass {
                 // verify
                 Assert.equal(authAndAccountId[0], user.authenticatedId, "user auth id was set");
                 Assert.equal(cookieStub.calledWithExactly('ai_authUser', encodeURI(authAndAccountId.join('|'))), true, "user auth id nad account id cookie was set");
-                cookieStub.restore();
+                
             }
         });
 
@@ -200,7 +200,7 @@ class UserContextTests extends TestClass {
             test: () => {
                 // setup
                 var authAndAccountId = ['bla@bla.com', 'contoso'];
-                var cookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "setCookie");
+                var cookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "setCookie");
                 var user = new Microsoft.ApplicationInsights.Context.User(undefined);
 
                 // act
@@ -209,7 +209,7 @@ class UserContextTests extends TestClass {
                 // verify
                 Assert.equal(authAndAccountId[0], user.authenticatedId, "user auth id was set");
                 Assert.equal(cookieStub.calledWithExactly('ai_authUser', encodeURI(authAndAccountId.join('|'))), true, "user auth id cookie was set");
-                cookieStub.restore();
+                
             }
         });
 
@@ -218,7 +218,7 @@ class UserContextTests extends TestClass {
             test: () => {
                 // setup
                 var authAndAccountId = ['bla@bla.com'];
-                var cookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "setCookie");
+                var cookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "setCookie");
                 var user = new Microsoft.ApplicationInsights.Context.User(undefined);
 
                 // act
@@ -228,7 +228,7 @@ class UserContextTests extends TestClass {
                 Assert.equal(authAndAccountId[0], user.authenticatedId, "user auth id was set");
                 Assert.equal(null, user.accountId, "user account id was not set");
                 Assert.equal(cookieStub.calledWithExactly('ai_authUser', encodeURI(authAndAccountId[0])), true, "user auth id cookie was set");
-                cookieStub.restore();
+                
             }
         });
 
@@ -236,9 +236,9 @@ class UserContextTests extends TestClass {
             name: "setAuthenticatedUserContext: handles null correctly",
             test: () => {
                 // setup
-                var cookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "setCookie");
+                var cookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "setCookie");
                 var user = new Microsoft.ApplicationInsights.Context.User(undefined);
-                var loggingStub = sinon.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
+                var loggingStub = this.sandbox.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
                 cookieStub.reset();
 
                 // act
@@ -249,8 +249,8 @@ class UserContextTests extends TestClass {
                 Assert.equal(undefined, user.accountId, "user account id was not set");
                 Assert.equal(cookieStub.notCalled, true, "cookie was not set");
                 Assert.equal(loggingStub.calledOnce, true, "Warning was logged");
-                cookieStub.restore();
-                loggingStub.restore();
+                
+                
             }
         });
 
@@ -258,9 +258,9 @@ class UserContextTests extends TestClass {
             name: "setAuthenticatedUserContext: handles undefined correctly",
             test: () => {
                 // setup
-                var cookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "setCookie");
+                var cookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "setCookie");
                 var user = new Microsoft.ApplicationInsights.Context.User(undefined);
-                var loggingStub = sinon.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
+                var loggingStub = this.sandbox.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
 
                 // act
                 user.setAuthenticatedUserContext(undefined, undefined);
@@ -270,8 +270,8 @@ class UserContextTests extends TestClass {
                 Assert.equal(undefined, user.accountId, "user account id was not set");
                 Assert.equal(cookieStub.notCalled, true, "cookie was not set");
                 Assert.equal(loggingStub.calledOnce, true, "Warning was logged");
-                cookieStub.restore();
-                loggingStub.restore();
+                
+                
             }
         });
 
@@ -279,9 +279,9 @@ class UserContextTests extends TestClass {
             name: "setAuthenticatedUserContext: handles only accountID correctly",
             test: () => {
                 // setup
-                var cookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "setCookie");
+                var cookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "setCookie");
                 var user = new Microsoft.ApplicationInsights.Context.User(undefined);
-                var loggingStub = sinon.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
+                var loggingStub = this.sandbox.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
 
                 // act
                 user.setAuthenticatedUserContext(undefined, '1234');
@@ -291,8 +291,8 @@ class UserContextTests extends TestClass {
                 Assert.equal(undefined, user.accountId, "user account id was not set");
                 Assert.equal(cookieStub.notCalled, true, "cookie was not set");
                 Assert.equal(loggingStub.calledOnce, true, "Warning was logged");
-                cookieStub.restore();
-                loggingStub.restore();
+                
+                
             }
         });
 
@@ -302,8 +302,8 @@ class UserContextTests extends TestClass {
                 // setup
                 var authAndAccountId = ['my|||special;id', '1234'];
                 var user = new Microsoft.ApplicationInsights.Context.User(undefined);
-                var cookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "setCookie");
-                var loggingStub = sinon.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
+                var cookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "setCookie");
+                var loggingStub = this.sandbox.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
 
                 // act
                 user.setAuthenticatedUserContext(authAndAccountId[0], authAndAccountId[1]);
@@ -313,8 +313,8 @@ class UserContextTests extends TestClass {
                 Assert.equal(undefined, user.accountId, "user account id was not set");
                 Assert.equal(cookieStub.notCalled, true, "cookie was not set");
                 Assert.equal(loggingStub.calledOnce, true, "Warning was logged");
-                cookieStub.restore();
-                loggingStub.restore();
+                
+                
             }
         });
 
@@ -325,8 +325,8 @@ class UserContextTests extends TestClass {
                 var authAndAccountId = ['myid', '1234 5678'];
                 var user = new Microsoft.ApplicationInsights.Context.User(undefined);
                 user.clearAuthenticatedUserContext();
-                var cookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "setCookie");
-                var loggingStub = sinon.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
+                var cookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "setCookie");
+                var loggingStub = this.sandbox.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
 
                 // act
                 user.setAuthenticatedUserContext(authAndAccountId[0], authAndAccountId[1]);
@@ -336,8 +336,8 @@ class UserContextTests extends TestClass {
                 Assert.equal(undefined, user.accountId, "user account id was not set");
                 Assert.equal(cookieStub.notCalled, true, "cookie was not set");
                 Assert.equal(loggingStub.calledOnce, true, "Warning was logged");
-                cookieStub.restore();
-                loggingStub.restore();
+                
+                
             }
         });
 
@@ -347,8 +347,8 @@ class UserContextTests extends TestClass {
                 // setup
                 var authAndAccountId = ["\u05D0", "\u05D1"]; // Hebrew characters
                 var user = new Microsoft.ApplicationInsights.Context.User(undefined);
-                var cookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "setCookie");
-                var loggingStub = sinon.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
+                var cookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "setCookie");
+                var loggingStub = this.sandbox.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
 
                 // act
                 user.setAuthenticatedUserContext(authAndAccountId[0], authAndAccountId[1]);
@@ -358,8 +358,8 @@ class UserContextTests extends TestClass {
                 Assert.equal(authAndAccountId[1], user.accountId, "user account id was set");
                 Assert.equal(cookieStub.calledWithExactly('ai_authUser', encodeURI(authAndAccountId.join('|'))), true, "user auth id cookie was set");
                 Assert.equal(loggingStub.notCalled, true, "No warnings");
-                cookieStub.restore();
-                loggingStub.restore();
+                
+                
             }
         });
 
@@ -369,7 +369,7 @@ class UserContextTests extends TestClass {
                 // setup
                 var user = new Microsoft.ApplicationInsights.Context.User(undefined);
                 user.setAuthenticatedUserContext("bla", "123");
-                var cookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "deleteCookie");
+                var cookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "deleteCookie");
 
                 // act
                 user.clearAuthenticatedUserContext();
@@ -378,7 +378,7 @@ class UserContextTests extends TestClass {
                 Assert.equal(undefined, user.authenticatedId, "user auth id was cleared");
                 Assert.equal(undefined, user.accountId, "user account id was cleared");
                 Assert.equal(cookieStub.calledWithExactly('ai_authUser'), true, "cookie was deleted");
-                cookieStub.restore();
+                
             }
         });
 
@@ -387,7 +387,7 @@ class UserContextTests extends TestClass {
             test: () => {
                 // setup
                 var user = new Microsoft.ApplicationInsights.Context.User(undefined);
-                var cookieStub = sinon.stub(Microsoft.ApplicationInsights.Util, "deleteCookie");
+                var cookieStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "deleteCookie");
 
                 // act
                 user.clearAuthenticatedUserContext();
@@ -396,7 +396,7 @@ class UserContextTests extends TestClass {
                 Assert.equal(undefined, user.authenticatedId, "user auth id was cleared");
                 Assert.equal(undefined, user.accountId, "user account id was cleared");
                 Assert.equal(cookieStub.calledWithExactly('ai_authUser'), true, "cookie was deleted");
-                cookieStub.restore();
+                
             }
         });
     }

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Initialization.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Initialization.tests.ts
@@ -160,7 +160,7 @@ class InitializationTests extends TestClass {
 
                 var init = new Microsoft.ApplicationInsights.Initialization(snippet);
                 var appInsightsLocal = init.loadAppInsights();
-                var trackTraceSpy = sinon.stub(appInsightsLocal, "trackTrace");
+                var trackTraceSpy = this.sandbox.stub(appInsightsLocal, "trackTrace");
 
                 var queue: Array<string> = Microsoft.ApplicationInsights._InternalLogging["queue"];
                 var length = queue.length;
@@ -182,7 +182,7 @@ class InitializationTests extends TestClass {
 
                 clearInterval(poller);
 
-                trackTraceSpy.restore();
+                
                 
             }
         });
@@ -241,7 +241,7 @@ class InitializationTests extends TestClass {
                     config: userConfig,
                     queue: []
                 };
-                var addEventHandlerStub = sinon.stub(Microsoft.ApplicationInsights.Util, 'addEventHandler').returns(true);
+                var addEventHandlerStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, 'addEventHandler').returns(true);
                 var init = new Microsoft.ApplicationInsights.Initialization(snippet);
                 var appInsightsLocal = init.loadAppInsights();
                 

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Logging.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Logging.tests.ts
@@ -36,7 +36,7 @@ class LoggingTests extends TestClass {
                 // setup
                 var throwSpy = null;
                 try {
-                    throwSpy = sinon.spy(console, "warn");
+                    throwSpy = this.sandbox.spy(console, "warn");
                 } catch (e) {
                     Assert.ok(true, "IE8 breaks sinon spies \n" + e.toString());
                 }
@@ -60,8 +60,7 @@ class LoggingTests extends TestClass {
                 Assert.ok(!throwSpy || throwSpy.calledOnce, "console.warn was not called when the error was thrown");
 
                 // cleanup
-                InternalLogging.enableDebugExceptions = () => false;
-                !throwSpy || throwSpy.restore(); // IE8
+                InternalLogging.enableDebugExceptions = () => false;                
             }
         });
 
@@ -120,7 +119,7 @@ class LoggingTests extends TestClass {
                 // setup
                 var throwSpy = null;
                 try {
-                    throwSpy = sinon.spy(console, "warn");
+                    throwSpy = this.sandbox.spy(console, "warn");
 
                     // act
                     var message = "error!";
@@ -133,7 +132,7 @@ class LoggingTests extends TestClass {
                     Assert.equal("AI: " + message, InternalLogging.queue[0]);
 
                     // cleanup
-                    throwSpy.restore();
+                    
                 } catch (e) {
                     Assert.ok(true, "IE8 breaks sinon spies on window objects\n" + e.toString());
                 }
@@ -146,7 +145,7 @@ class LoggingTests extends TestClass {
                 // setup
                 var throwSpy = null;
                 try {
-                    throwSpy = sinon.spy(console, "warn");
+                    throwSpy = this.sandbox.spy(console, "warn");
 
                     // act
                     var message = "error!";
@@ -160,7 +159,7 @@ class LoggingTests extends TestClass {
                     Assert.equal("AI (Internal): " + message, InternalLogging.queue[0]);
 
                     // cleanup
-                    throwSpy.restore();
+                    
                 } catch (e) {
                     Assert.ok(true, "IE8 breaks sinon spies on window objects\n" + e.toString());
                 }
@@ -173,7 +172,7 @@ class LoggingTests extends TestClass {
                 // setup
                 var throwSpy = null;
                 try {
-                    throwSpy = sinon.spy(console, "warn");
+                    throwSpy = this.sandbox.spy(console, "warn");
 
                     // act
                     var message = "error!";
@@ -184,7 +183,7 @@ class LoggingTests extends TestClass {
                     Assert.equal(0, InternalLogging.queue.length);
 
                     // cleanup
-                    throwSpy.restore();
+                    
                 } catch (e) {
                     Assert.ok(true, "IE8 breaks sinon spies on window objects\n" + e.toString());
                 }
@@ -199,7 +198,7 @@ class LoggingTests extends TestClass {
                 var warn = console.warn;
                 try {
                     console.warn = undefined;
-                    throwSpy = sinon.spy(console, "log");
+                    throwSpy = this.sandbox.spy(console, "log");
 
                     // act
                     InternalLogging.enableDebugExceptions = () => false;
@@ -209,7 +208,7 @@ class LoggingTests extends TestClass {
                     Assert.ok(throwSpy.calledOnce, "console.log was called when console.warn was not present");
 
                     // cleanup
-                    throwSpy.restore();
+                    
                 } catch (e) {
                     Assert.ok(true, "IE8 breaks sinon spies on window objects\n" + e.toString());
                 } finally {
@@ -248,7 +247,7 @@ class LoggingTests extends TestClass {
             test: () => {
                 var maxAllowedInternalMessages = 2;
                 var message = "Internal Test Event";
-                var logInternalMessageStub = sinon.stub(InternalLogging, 'logInternalMessage');
+                var logInternalMessageStub = this.sandbox.stub(InternalLogging, 'logInternalMessage');
 
                 // setup
                 InternalLogging.enableDebugExceptions = () => false;
@@ -261,7 +260,7 @@ class LoggingTests extends TestClass {
                 Assert.ok(logInternalMessageStub.calledOnce, 'logInternalMessage was not called by throwInternalNonUserActionable');
 
                 // clean
-                logInternalMessageStub.restore();
+                
             }
         });
         
@@ -270,7 +269,7 @@ class LoggingTests extends TestClass {
             test: () => {
                 var maxAllowedInternalMessages = 2;
                 var message = "Internal Test Event";
-                var logInternalMessageStub = sinon.stub(InternalLogging, 'logInternalMessage');
+                var logInternalMessageStub = this.sandbox.stub(InternalLogging, 'logInternalMessage');
 
                 // setup
                 InternalLogging.enableDebugExceptions = () => false;
@@ -283,7 +282,7 @@ class LoggingTests extends TestClass {
                 Assert.ok(logInternalMessageStub.calledOnce, 'logInternalMessage was not called by throwInternalUserActionable');
 
                 // clean
-                logInternalMessageStub.restore();
+                
             }
         });
 

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/PageVisitTimeManager.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/PageVisitTimeManager.tests.ts
@@ -9,18 +9,12 @@ class PageVisitTimeManagerTests extends TestClass {
     /** Method called before the start of each test method */
     public testInitialize() {
         var storage = this.getMockStorage();
-        this.getStorageObjectStub = sinon.stub(Microsoft.ApplicationInsights.Util, "_getSessionStorageObject",() => storage);
+        this.getStorageObjectStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "_getSessionStorageObject",() => storage);
 
-        this.throwInternalNonUserActionableSpy = sinon.spy(Microsoft.ApplicationInsights._InternalLogging, "throwInternalNonUserActionable");
-        this.throwInternalUserActionableSpy = sinon.spy(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
+        this.throwInternalNonUserActionableSpy = this.sandbox.spy(Microsoft.ApplicationInsights._InternalLogging, "throwInternalNonUserActionable");
+        this.throwInternalUserActionableSpy = this.sandbox.spy(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
     }
 
-    /** Method called after each test method has completed */
-    public testCleanup() {
-        this.getStorageObjectStub.restore();
-        this.throwInternalNonUserActionableSpy.restore();
-        this.throwInternalUserActionableSpy.restore();
-    }
 
     public registerTests() {
 
@@ -44,7 +38,7 @@ class PageVisitTimeManagerTests extends TestClass {
 
                 //setup
                 var object = { method: function () { } };
-                var spy = sinon.spy(object, "method");
+                var spy = this.sandbox.spy(object, "method");
                 var pageVisitTimeManager = new Microsoft.ApplicationInsights.Telemetry.PageVisitTimeManager(spy);
 
 
@@ -64,7 +58,7 @@ class PageVisitTimeManagerTests extends TestClass {
 
                 //setup
                 var object = { method: function () { } };
-                var spy = sinon.spy(object, "method");
+                var spy = this.sandbox.spy(object, "method");
                 var pageVisitTimeManager = new Microsoft.ApplicationInsights.Telemetry.PageVisitTimeManager(spy);
 
 

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Sender.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Sender.tests.ts
@@ -36,16 +36,10 @@ class SenderTests extends TestClass {
         };
           
         this.getSender = () => new Microsoft.ApplicationInsights.Sender(config);
-        this.errorSpy = sinon.spy(Microsoft.ApplicationInsights.Sender, "_onError");
-        this.successSpy = sinon.stub(Microsoft.ApplicationInsights.Sender, "_onSuccess");
-        this.loggingSpy = sinon.stub(Microsoft.ApplicationInsights._InternalLogging, "warnToConsole");
+        this.errorSpy = this.sandbox.spy(Microsoft.ApplicationInsights.Sender, "_onError");
+        this.successSpy = this.sandbox.stub(Microsoft.ApplicationInsights.Sender, "_onSuccess");
+        this.loggingSpy = this.sandbox.stub(Microsoft.ApplicationInsights._InternalLogging, "warnToConsole");
         this.testTelemetry = { aiDataContract: true };
-    }
-
-    public testCleanup() {
-        this.errorSpy.restore();
-        this.successSpy.restore();
-        this.loggingSpy.restore();
     }
 
     public registerTests() {
@@ -258,7 +252,7 @@ class SenderTests extends TestClass {
                 // setup
                 var sender: Microsoft.ApplicationInsights.Sender = this.getSender();
                 sender._sender = () => null;
-                var senderSpy = sinon.spy(sender, "_sender");
+                var senderSpy = this.sandbox.spy(sender, "_sender");
                 this.maxBatchSizeInBytes = Microsoft.ApplicationInsights.Serializer.serialize(this.testTelemetry).length
                 this.maxBatchInterval = 1;
                 this.clock.now = 1;
@@ -286,7 +280,7 @@ class SenderTests extends TestClass {
                 Assert.ok(senderSpy.notCalled, "sender was not invoked a third time after maxInterval elapsed");
                 logAsserts(0);
 
-                senderSpy.restore();
+                
             }
         });
 
@@ -296,7 +290,7 @@ class SenderTests extends TestClass {
                 // setup
                 var sender: Microsoft.ApplicationInsights.Sender = this.getSender();
                 sender._sender = () => null;
-                var senderSpy = sinon.spy(sender, "_sender");
+                var senderSpy = this.sandbox.spy(sender, "_sender");
                 this.maxBatchSizeInBytes = Microsoft.ApplicationInsights.Serializer.serialize(this.testTelemetry).length;
                 this.maxBatchInterval = 1;
                 this.clock.now = 1;
@@ -311,7 +305,7 @@ class SenderTests extends TestClass {
                 Assert.ok(senderSpy.calledOnce, "sender was invoked");
                 logAsserts(0);
 
-                senderSpy.restore();
+                
                 Microsoft.ApplicationInsights._InternalLogging.enableDebugExceptions = () => false;
             }
         });
@@ -322,7 +316,7 @@ class SenderTests extends TestClass {
                 // setup
                 var sender: Microsoft.ApplicationInsights.Sender = this.getSender();
                 sender._sender = () => null;
-                var senderSpy = sinon.spy(sender, "_sender");
+                var senderSpy = this.sandbox.spy(sender, "_sender");
                 this.maxBatchSizeInBytes = Microsoft.ApplicationInsights.Serializer.serialize(this.testTelemetry).length * 2;
                 this.maxBatchInterval = 2;
 
@@ -349,7 +343,7 @@ class SenderTests extends TestClass {
                 Assert.ok(senderSpy.calledTwice, "sender was invoked twice");
                 logAsserts(0);
 
-                senderSpy.restore();
+                
             }
         });
 
@@ -372,7 +366,7 @@ class SenderTests extends TestClass {
                 this.disableTelemetry = true;
                 var sender: Microsoft.ApplicationInsights.Sender = this.getSender();
                 sender._sender = () => null;
-                var senderSpy = sinon.spy(sender, "_sender");
+                var senderSpy = this.sandbox.spy(sender, "_sender");
                 
                 // act
                 sender.send(this.testTelemetry);
@@ -382,7 +376,7 @@ class SenderTests extends TestClass {
                 Assert.ok(senderSpy.notCalled, "sender was not called");
                 logAsserts(0);
 
-                senderSpy.restore();
+                
             }
         });
 
@@ -393,7 +387,7 @@ class SenderTests extends TestClass {
                 this.disableTelemetry = true;
                 var sender: Microsoft.ApplicationInsights.Sender = this.getSender();
                 sender._sender = () => null;
-                var senderSpy = sinon.spy(sender, "_sender");
+                var senderSpy = this.sandbox.spy(sender, "_sender");
                 this.maxBatchInterval = 100;
 
                 // act
@@ -404,7 +398,7 @@ class SenderTests extends TestClass {
                 Assert.ok(senderSpy.notCalled, "sender was not called");
                 logAsserts(0);
 
-                senderSpy.restore();
+                
             }
         });
 
@@ -414,7 +408,7 @@ class SenderTests extends TestClass {
                 // setup
                 var sender: Microsoft.ApplicationInsights.Sender = this.getSender();
                 sender._sender = () => null;
-                var senderSpy = sinon.spy(sender, "_sender");
+                var senderSpy = this.sandbox.spy(sender, "_sender");
                 this.maxBatchInterval = 100;
 
                 // act
@@ -424,7 +418,7 @@ class SenderTests extends TestClass {
                 // verify
                 Assert.equal(true, senderSpy.getCall(0).args[1], "triggerSend should have called _send with async = true");
 
-                senderSpy.restore();
+                
             }
         });
 
@@ -434,7 +428,7 @@ class SenderTests extends TestClass {
                 // setup
                 var sender: Microsoft.ApplicationInsights.Sender = this.getSender();
                 sender._sender = () => null;
-                var senderSpy = sinon.spy(sender, "_sender");
+                var senderSpy = this.sandbox.spy(sender, "_sender");
                 this.maxBatchInterval = 100;
 
                 // act
@@ -444,7 +438,7 @@ class SenderTests extends TestClass {
                 // verify
                 Assert.equal(false, senderSpy.getCall(0).args[1], "triggerSend should have called _send with async = false");
 
-                senderSpy.restore();
+                
             }
         });
 
@@ -454,7 +448,7 @@ class SenderTests extends TestClass {
                 // setup
                 var sender: Microsoft.ApplicationInsights.Sender = this.getSender();
                 sender._sender = () => null;
-                var senderSpy = sinon.spy(sender, "_sender");
+                var senderSpy = this.sandbox.spy(sender, "_sender");
                 this.maxBatchInterval = 100;
 
                 // act
@@ -464,7 +458,7 @@ class SenderTests extends TestClass {
                 // verify
                 Assert.equal(true, senderSpy.getCall(0).args[1], "triggerSend should have called _send with async = true");
 
-                senderSpy.restore();
+                
             }
         });
     }

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Serializer.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Serializer.tests.ts
@@ -8,14 +8,8 @@ class SerializerTests extends TestClass {
 
     /** Method called before the start of each test method */
     public testInitialize() {
-        this.throwInternalNonUserActionableSpy = sinon.spy(Microsoft.ApplicationInsights._InternalLogging, "throwInternalNonUserActionable");
-        this.throwInternalUserActionableSpy = sinon.spy(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
-    }
-
-    /** Method called after each test method has completed */
-    public testCleanup() {
-        this.throwInternalNonUserActionableSpy.restore();
-        this.throwInternalUserActionableSpy.restore();
+        this.throwInternalNonUserActionableSpy = this.sandbox.spy(Microsoft.ApplicationInsights._InternalLogging, "throwInternalNonUserActionable");
+        this.throwInternalUserActionableSpy = this.sandbox.spy(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
     }
 
     public registerTests() {

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/PageViewPerformance.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/PageViewPerformance.tests.ts
@@ -65,7 +65,7 @@ class PageViewPerformanceTelemetryTests extends ContractTestHelper {
                 timing.responseEnd = 42;
                 timing.loadEventEnd = 60;
 
-                var timingSpy = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "getPerformanceTiming", () => {
+                var timingSpy = this.sandbox.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "getPerformanceTiming", () => {
                     return timing;
                 });
 
@@ -81,7 +81,7 @@ class PageViewPerformanceTelemetryTests extends ContractTestHelper {
                 Assert.equal(Microsoft.ApplicationInsights.Util.msToTimeSpan(12), data.receivedResponse);
                 Assert.equal(Microsoft.ApplicationInsights.Util.msToTimeSpan(18), data.domProcessing);
 
-                timingSpy.restore();
+                
             }
         });
 
@@ -97,12 +97,12 @@ class PageViewPerformanceTelemetryTests extends ContractTestHelper {
                 timing.responseEnd = 42;
                 timing.loadEventEnd = 60;
 
-                var timingSpy = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "getPerformanceTiming", () => {
+                var timingSpy = this.sandbox.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "getPerformanceTiming", () => {
                     return timing;
                 });
 
                 var actualLoggedMessage = null;
-                var loggingSpy = sinon.stub(Microsoft.ApplicationInsights._InternalLogging, "warnToConsole", (m) => actualLoggedMessage = m);
+                var loggingSpy = this.sandbox.stub(Microsoft.ApplicationInsights._InternalLogging, "warnToConsole", (m) => actualLoggedMessage = m);
 
 
                 var telemetry = new Microsoft.ApplicationInsights.Telemetry.PageViewPerformance("name", "url", 0);
@@ -118,8 +118,8 @@ class PageViewPerformanceTelemetryTests extends ContractTestHelper {
 
                 Assert.equal("client performance math error:59 < 39 + 19 + 12 + 18", actualLoggedMessage);
 
-                timingSpy.restore();
-                loggingSpy.restore();
+                
+                
 
             }
         });

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/TelemetryContext.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/TelemetryContext.tests.ts
@@ -46,12 +46,12 @@ class TelemetryContextTests extends TestClass {
             name: "TelemtetryContext: calling track with null or undefined fails",
             test: () => {
                 var tc = new Microsoft.ApplicationInsights.TelemetryContext(this._config);
-                var logSpy = sinon.spy(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
+                var logSpy = this.sandbox.spy(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
                 tc.track(undefined);
                 Assert.ok(logSpy.calledOnce, "sender throws with undefined");
                 tc.track(null);
                 Assert.ok(logSpy.calledTwice, "sender throws with null");
-                logSpy.restore();
+
             }
         });
 
@@ -59,47 +59,26 @@ class TelemetryContextTests extends TestClass {
             name: "TelemtetryContext: does not overwrite user sessioncontext with defaults",
             test: () => {
                 this._telemetryContext.session.id = "101";
-                this._telemetryContext.session.isFirst = true; 
-                                
+                this._telemetryContext.session.isFirst = true;
+
                 var env = new Microsoft.ApplicationInsights.Telemetry.Common.Envelope(null, "");
                 this._telemetryContext.track(env);
 
                 var contextKeys = new AI.ContextTagKeys();
                 Assert.equal("101", env.tags[contextKeys.sessionId], "session.id");
-                Assert.equal(true, env.tags[contextKeys.sessionIsFirst], "session.isFirst");            }
+                Assert.equal(true, env.tags[contextKeys.sessionIsFirst], "session.isFirst");
+            }
         });
 
         function getEnvelope<T>(item, dataType: string, envelopeType: string) {
             var data = new Microsoft.ApplicationInsights.Telemetry.Common.Data<T>(dataType, item);
             return new Microsoft.ApplicationInsights.Telemetry.Common.Envelope(data, envelopeType);
         }
-        
-        /**
-        * Gets the sinon stub for telemetryContext.sample.isSampledIn function. Result is wrapped to an object
-        * which has a counter of how many times the stub was accessed with expected envelope type.
-        */
-        function getStub(envelopeType: string, telemetryContext: Microsoft.ApplicationInsights.TelemetryContext) {            
-            var stub = {
-                sinonStub: null,
-                isSampledInCallsCount: 0
-            };
-
-            var isSampledInStub = sinon.stub(telemetryContext.sample, "isSampledIn",
-                (envelope: Microsoft.ApplicationInsights.Telemetry.Common.Envelope) => {
-                    if (envelope.name === envelopeType) {
-                        ++stub.isSampledInCallsCount;
-                    }
-                });
-
-            stub.sinonStub = isSampledInStub;
-
-            return stub;
-        }
 
         this.testCase({
             name: "TelemetryContext: page views get sampled",
             test: () => {
-                var stub = getStub(Microsoft.ApplicationInsights.Telemetry.PageView.envelopeType, this._telemetryContext);
+                var stub = this.getStub(Microsoft.ApplicationInsights.Telemetry.PageView.envelopeType, this._telemetryContext);
 
                 var envelope = getEnvelope<Microsoft.ApplicationInsights.Telemetry.PageView>(
                     new Microsoft.ApplicationInsights.Telemetry.PageView("asdf", "asdf", 10),
@@ -113,15 +92,13 @@ class TelemetryContextTests extends TestClass {
                 Assert.equal(1, stub.isSampledInCallsCount);
 
                 // tear down
-                stub.sinonStub.restore();
             }
         });
-
 
         this.testCase({
             name: "TelemetryContext: events get sampled",
             test: () => {
-                var stub = getStub(Microsoft.ApplicationInsights.Telemetry.Event.envelopeType, this._telemetryContext);
+                var stub = this.getStub(Microsoft.ApplicationInsights.Telemetry.Event.envelopeType, this._telemetryContext);
 
                 var envelope = getEnvelope<Microsoft.ApplicationInsights.Telemetry.Event>(
                     new Microsoft.ApplicationInsights.Telemetry.Event("asdf"),
@@ -135,14 +112,13 @@ class TelemetryContextTests extends TestClass {
                 Assert.equal(1, stub.isSampledInCallsCount);
 
                 // tear down
-                stub.sinonStub.restore();
             }
         });
 
         this.testCase({
             name: "TelemetryContext: exceptions get sampled",
             test: () => {
-                var stub = getStub(Microsoft.ApplicationInsights.Telemetry.Exception.envelopeType, this._telemetryContext);
+                var stub = this.getStub(Microsoft.ApplicationInsights.Telemetry.Exception.envelopeType, this._telemetryContext);
 
                 var exception;
                 try {
@@ -163,14 +139,13 @@ class TelemetryContextTests extends TestClass {
                 Assert.equal(1, stub.isSampledInCallsCount);
 
                 // tear down
-                stub.sinonStub.restore();
             }
         });
 
         this.testCase({
             name: "TelemetryContext: metrics do NOT get sampled",
             test: () => {
-                var stub = getStub(Microsoft.ApplicationInsights.Telemetry.Metric.envelopeType, this._telemetryContext);
+                var stub = this.getStub(Microsoft.ApplicationInsights.Telemetry.Metric.envelopeType, this._telemetryContext);
 
                 var envelope = getEnvelope<Microsoft.ApplicationInsights.Telemetry.Metric>(
                     new Microsoft.ApplicationInsights.Telemetry.Metric("asdf", 1234),
@@ -184,14 +159,13 @@ class TelemetryContextTests extends TestClass {
                 Assert.equal(0, stub.isSampledInCallsCount);
 
                 // tear down
-                stub.sinonStub.restore();
             }
         });
 
         this.testCase({
             name: "TelemetryContext: pageViewPerformance gets sampled",
             test: () => {
-                var stub = getStub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance.envelopeType, this._telemetryContext);
+                var stub = this.getStub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance.envelopeType, this._telemetryContext);
 
                 var envelope = getEnvelope<Microsoft.ApplicationInsights.Telemetry.PageViewPerformance>(
                     new Microsoft.ApplicationInsights.Telemetry.PageViewPerformance("adsf", "asdf", 10),
@@ -205,14 +179,13 @@ class TelemetryContextTests extends TestClass {
                 Assert.equal(1, stub.isSampledInCallsCount);
 
                 // tear down
-                stub.sinonStub.restore();
             }
         });
 
         this.testCase({
             name: "TelemetryContext: sessions do NOT get sampled",
             test: () => {
-                var stub = getStub(Microsoft.ApplicationInsights.Telemetry.SessionTelemetry.envelopeType, this._telemetryContext);
+                var stub = this.getStub(Microsoft.ApplicationInsights.Telemetry.SessionTelemetry.envelopeType, this._telemetryContext);
 
                 var envelope = getEnvelope<Microsoft.ApplicationInsights.Telemetry.SessionTelemetry>(
                     new Microsoft.ApplicationInsights.Telemetry.SessionTelemetry(AI.SessionState.Start),
@@ -226,14 +199,13 @@ class TelemetryContextTests extends TestClass {
                 Assert.equal(0, stub.isSampledInCallsCount);
 
                 // tear down
-                stub.sinonStub.restore();
             }
         });
 
         this.testCase({
             name: "TelemetryContext: traces get sampled",
             test: () => {
-                var stub = getStub(Microsoft.ApplicationInsights.Telemetry.Trace.envelopeType, this._telemetryContext);
+                var stub = this.getStub(Microsoft.ApplicationInsights.Telemetry.Trace.envelopeType, this._telemetryContext);
 
                 var envelope = getEnvelope<Microsoft.ApplicationInsights.Telemetry.Trace>(
                     new Microsoft.ApplicationInsights.Telemetry.Trace("afd"),
@@ -247,9 +219,8 @@ class TelemetryContextTests extends TestClass {
                 Assert.equal(1, stub.isSampledInCallsCount);
 
                 // tear down
-                stub.sinonStub.restore();
             }
-        });     
+        });
 
         this.testCase({
             name: "TelemetryContext: onBeforeSendTelemetry is called within track() and gets the envelope as an argument",
@@ -259,7 +230,7 @@ class TelemetryContextTests extends TestClass {
                 var telemetryInitializer = {
                     initializer: (envelope) => { }
                 }
-                var spy = sinon.spy(telemetryInitializer, "initializer");
+                var spy = this.sandbox.spy(telemetryInitializer, "initializer");
                 this._telemetryContext.addTelemetryInitializer(<any>telemetryInitializer.initializer);
                     
                 // act
@@ -270,7 +241,7 @@ class TelemetryContextTests extends TestClass {
                 Assert.ok(eventEnvelope === spy.args[0][0]);
 
                 // teardown
-                spy.restore();
+                
                 (<any>this._telemetryContext).telemetryInitializers = undefined;
             }
         });
@@ -289,7 +260,7 @@ class TelemetryContextTests extends TestClass {
                 }
 
                 this._telemetryContext.addTelemetryInitializer(<any>telemetryInitializer.initializer);
-                var stub = sinon.stub(this._telemetryContext._sender, "send");
+                var stub = this.sandbox.stub(this._telemetryContext._sender, "send");
                     
                 // act
                 (<any>this._telemetryContext)._track(eventEnvelope);
@@ -301,7 +272,7 @@ class TelemetryContextTests extends TestClass {
                     (<Microsoft.ApplicationInsights.Telemetry.Common.Envelope>stub.args[0][0]).name);
 
                 // teardown
-                stub.restore();
+                
                 (<any>this._telemetryContext).telemetryInitializers = undefined;
             }
         });
@@ -310,7 +281,7 @@ class TelemetryContextTests extends TestClass {
             name: "TelemetryContext: telemetryInitializers array is null (not initialized) means envelope goes straight to the sender",
             test: () => {
                 var eventEnvelope = this.getTestEventEnvelope();
-                var stub = sinon.stub(this._telemetryContext._sender, "send");
+                var stub = this.sandbox.stub(this._telemetryContext._sender, "send");
                     
                 // act
                 (<any>this._telemetryContext)._track(eventEnvelope);
@@ -320,10 +291,10 @@ class TelemetryContextTests extends TestClass {
                 Assert.ok(eventEnvelope === stub.args[0][0]);
 
                 // teardown
-                stub.restore();
+                
             }
         });
-        
+
         this.testCase({
             name: "TelemetryContext: telemetry initializer can modify the contents of an envelope",
             test: () => {
@@ -344,7 +315,7 @@ class TelemetryContextTests extends TestClass {
                 }
 
                 this._telemetryContext.addTelemetryInitializer(<any>telemetryInitializer.init);
-                var stub = sinon.stub(this._telemetryContext._sender, "send");
+                var stub = this.sandbox.stub(this._telemetryContext._sender, "send");
                     
                 // act
                 (<any>this._telemetryContext)._track(eventEnvelope);
@@ -356,7 +327,7 @@ class TelemetryContextTests extends TestClass {
                 Assert.equal("val1", (<any>stub.args[0][0]).data.baseData.properties["prop1"]);
                 
                 // teardown
-                stub.restore();
+                
                 (<any>this._telemetryContext).telemetryInitializers = undefined;
             }
         });
@@ -365,16 +336,16 @@ class TelemetryContextTests extends TestClass {
             name: "TelemetryContext: all added telemetry initializers get invoked",
             test: () => {
                 // prepare
-                var eventEnvelope = this.getTestEventEnvelope();                
-                var initializer1 = { init: () => { } };                
+                var eventEnvelope = this.getTestEventEnvelope();
+                var initializer1 = { init: () => { } };
                 var initializer2 = { init: () => { } };
-                var spy1 = sinon.spy(initializer1, "init");
-                var spy2 = sinon.spy(initializer2, "init");
+                var spy1 = this.sandbox.spy(initializer1, "init");
+                var spy2 = this.sandbox.spy(initializer2, "init");
 
                 // act
                 this._telemetryContext.addTelemetryInitializer(<any>initializer1.init);
                 this._telemetryContext.addTelemetryInitializer(<any>initializer2.init);
-                
+
                 (<any>this._telemetryContext)._track(eventEnvelope);
 
                 // verify
@@ -385,6 +356,28 @@ class TelemetryContextTests extends TestClass {
                 (<any>this._telemetryContext).telemetryInitializers = undefined;
             }
         });
+    }
+
+    /**
+    * Gets the sinon stub for telemetryContext.sample.isSampledIn function. Result is wrapped to an object
+    * which has a counter of how many times the stub was accessed with expected envelope type.
+    */
+    private getStub(envelopeType: string, telemetryContext: Microsoft.ApplicationInsights.TelemetryContext) {
+        var stub = {
+            sinonStub: null,
+            isSampledInCallsCount: 0
+        };
+
+        var isSampledInStub = this.sandbox.stub(telemetryContext.sample, "isSampledIn",
+            (envelope: Microsoft.ApplicationInsights.Telemetry.Common.Envelope) => {
+                if (envelope.name === envelopeType) {
+                    ++stub.isSampledInCallsCount;
+                }
+            });
+
+        stub.sinonStub = isSampledInStub;
+
+        return stub;
     }
 
     private getTestEventEnvelope(properties?: Object, measurements?: Object) {

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Util.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Util.tests.ts
@@ -10,14 +10,14 @@ class UtilTests extends TestClass {
             name: "UtilTests: getStorage with available storage",
             test: () => {
                 var storage = this.getMockStorage();
-                var getStorageObjectStub = sinon.stub(Microsoft.ApplicationInsights.Util, "_getStorageObject",() => storage);
+                var getStorageObjectStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "_getStorageObject",() => storage);
 
                 storage["test"] = "A";
 
                 Assert.equal("A", Util.getStorage("test"), "getStorage should return value of getItem for known keys");
                 Assert.equal(undefined, Util.getStorage("another"), "getStorage should return value of getItem for unknown keys");
 
-                getStorageObjectStub.restore();
+                
             }
         });
 
@@ -25,11 +25,11 @@ class UtilTests extends TestClass {
             name: "UtilTests: getStorage with no storage support",
             test: () => {
                 var storage = undefined;
-                var getStorageObjectStub = sinon.stub(Microsoft.ApplicationInsights.Util, "_getStorageObject",() => storage);
+                var getStorageObjectStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "_getStorageObject",() => storage);
 
                 Assert.equal(null, Util.getStorage("test"), "getStorage should return null when storage is unavailable");
 
-                getStorageObjectStub.restore();
+                
             }
         });
 
@@ -37,11 +37,11 @@ class UtilTests extends TestClass {
             name: "UtilTests: setStorage with available storage",
             test: () => {
                 var storage = this.getMockStorage();
-                var getStorageObjectStub = sinon.stub(Microsoft.ApplicationInsights.Util, "_getStorageObject",() => storage);
+                var getStorageObjectStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "_getStorageObject",() => storage);
 
                 Assert.ok(Util.setStorage("test","A"), "setStorage should return true if storage is available for writes");
 
-                getStorageObjectStub.restore();
+                
             }
         });
 
@@ -49,11 +49,11 @@ class UtilTests extends TestClass {
             name: "UtilTests: setStorage with no storage support",
             test: () => {
                 var storage = undefined;
-                var getStorageObjectStub = sinon.stub(Microsoft.ApplicationInsights.Util, "_getStorageObject",() => storage);
+                var getStorageObjectStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "_getStorageObject",() => storage);
 
                 Assert.ok(!Util.setStorage("test", "A"), "setStorage should return false if storage is unavailable for writes");
 
-                getStorageObjectStub.restore();
+                
             }
         });
 
@@ -61,14 +61,14 @@ class UtilTests extends TestClass {
             name: "UtilTests: removeStorage with available storage",
             test: () => {
                 var storage = this.getMockStorage();
-                var getStorageObjectStub = sinon.stub(Microsoft.ApplicationInsights.Util, "_getStorageObject",() => storage);
+                var getStorageObjectStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "_getStorageObject",() => storage);
 
                 storage["test"] = "A";
 
                 Assert.ok(Util.removeStorage("test"), "removeStorage should return true if storage is available for writes");
                 Assert.deepEqual(undefined, storage["test"], "removeStorage should remove items from storage");
 
-                getStorageObjectStub.restore();
+                
             }
         });
 
@@ -76,11 +76,11 @@ class UtilTests extends TestClass {
             name: "UtilTests: removeStorage with no storage support",
             test: () => {
                 var storage = undefined;
-                var getStorageObjectStub = sinon.stub(Microsoft.ApplicationInsights.Util, "_getStorageObject",() => storage);
+                var getStorageObjectStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "_getStorageObject",() => storage);
 
                 Assert.ok(!Util.removeStorage("test"), "removeStorage should return false if storage is unavailable for writes");
 
-                getStorageObjectStub.restore();
+                
             }
         });
         

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/ajax.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/ajax.tests.ts
@@ -5,11 +5,13 @@
 class AjaxTests extends TestClass {
 
     private appInsightsMock = { trackAjax: (absoluteUrl: string, isAsync: boolean, totalTime: number, success: boolean) => { } }
-    private trackAjaxSpy = sinon.spy(this.appInsightsMock, "trackAjax");
-    private callbackSpy = sinon.spy();
+    private trackAjaxSpy;
+    private callbackSpy;
     private requests;
 
     public testInitialize() {
+        this.trackAjaxSpy = this.sandbox.spy(this.appInsightsMock, "trackAjax");
+        this.callbackSpy = this.sandbox.spy();
         this.trackAjaxSpy.reset();
         var xhr = sinon.useFakeXMLHttpRequest();
     }
@@ -55,7 +57,7 @@ class AjaxTests extends TestClass {
         this.testCase({
             name: "Ajax: successful request, ajax monitor doesn't change payload",
             test: () => {
-                var callback = sinon.spy();
+                var callback = this.sandbox.spy();
                 var ajax = new Microsoft.ApplicationInsights.AjaxMonitor(<any>this.appInsightsMock);                
 
                 // Act
@@ -83,7 +85,7 @@ class AjaxTests extends TestClass {
         this.testCase({
             name: "Ajax: custom onreadystatechange gets called",
             test: () => {
-                var onreadystatechangeSpy = sinon.spy();
+                var onreadystatechangeSpy = this.sandbox.spy();
                 var ajax = new Microsoft.ApplicationInsights.AjaxMonitor(<any>this.appInsightsMock);
 
                 // Act
@@ -163,13 +165,13 @@ class AjaxTests extends TestClass {
             name: "Ajax: overriding ready state change handlers in all possible ways",
             test: () => {
                 var ajax = new Microsoft.ApplicationInsights.AjaxMonitor(<any>this.appInsightsMock);
-                var cb1 = sinon.spy();
-                var cb2 = sinon.spy();
-                var cb3 = sinon.spy();
-                var cb4 = sinon.spy();
-                var cb5 = sinon.spy();
-                var cb6 = sinon.spy();
-                var cb7 = sinon.spy();
+                var cb1 = this.sandbox.spy();
+                var cb2 = this.sandbox.spy();
+                var cb3 = this.sandbox.spy();
+                var cb4 = this.sandbox.spy();
+                var cb5 = this.sandbox.spy();
+                var cb6 = this.sandbox.spy();
+                var cb7 = this.sandbox.spy();
 
                 // Act
                 var xhr = new XMLHttpRequest();
@@ -233,7 +235,7 @@ class AjaxTests extends TestClass {
             name: "Ajax: 2nd invokation of xhr.send doesn't cause send wrapper to execute 2nd time",
             test: () => {
                 var ajax = new Microsoft.ApplicationInsights.AjaxMonitor(<any>this.appInsightsMock);
-                var spy = sinon.spy(ajax, "sendHandler");
+                var spy = this.sandbox.spy(ajax, "sendHandler");
                 
                 // Act
                 var xhr = new XMLHttpRequest();
@@ -254,7 +256,7 @@ class AjaxTests extends TestClass {
             name: "Ajax: 2 invokation of xhr.open() doesn't cause send wrapper to execute 2nd time",
             test: () => {
                 var ajax = new Microsoft.ApplicationInsights.AjaxMonitor(<any>this.appInsightsMock);
-                var spy = sinon.spy(ajax, "openHandler");
+                var spy = this.sandbox.spy(ajax, "openHandler");
                 
                 // Act
                 var xhr = new XMLHttpRequest();

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -87,7 +87,7 @@ class AppInsightsTests extends TestClass {
                 config.disableTelemetry = true;
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(config);
                 appInsights.context._sender._sender = () => null;
-                var senderStub = sinon.stub(appInsights.context._sender, "_sender", () => {
+                var senderStub = this.sandbox.stub(appInsights.context._sender, "_sender", () => {
                     console.log("GOT HERE");
                 });
                 
@@ -96,14 +96,14 @@ class AppInsightsTests extends TestClass {
                     action();
                     this.clock.tick(1);
                     Assert.ok(senderStub.notCalled, "sender was not called called for: " + action);
-                    senderStub.restore();
+                    
                 };
 
                 // act
                 test(() => appInsights.trackEvent("testEvent"));
 
                 // teardown
-                senderStub.restore();
+                
             }
         });
 
@@ -113,7 +113,7 @@ class AppInsightsTests extends TestClass {
                 // setup
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
                 appInsights.context._sessionManager._sessionHandler = null;
-                var trackStub = sinon.stub(appInsights.context._sender, "send");
+                var trackStub = this.sandbox.stub(appInsights.context._sender, "send");
 
                 // act
                 appInsights.trackPageView();
@@ -125,7 +125,7 @@ class AppInsightsTests extends TestClass {
                 Assert.ok(trackStub.calledTwice, "track was called");
 
                 // teardown
-                trackStub.restore();
+                
             }
         });
 
@@ -134,7 +134,7 @@ class AppInsightsTests extends TestClass {
             test: () => {
                 // setup
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
-                var trackStub = sinon.stub(appInsights.context._sender, "send");
+                var trackStub = this.sandbox.stub(appInsights.context._sender, "send");
                 
                 // act
                 this.clock.tick(1);
@@ -160,7 +160,7 @@ class AppInsightsTests extends TestClass {
                 
 
                 // teardown
-                trackStub.restore();
+                
             }
         });
 
@@ -172,7 +172,7 @@ class AppInsightsTests extends TestClass {
                 config.instrumentationKey = "12345";
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(config);
                 appInsights.context._sessionManager._sessionHandler = null;
-                var trackStub = sinon.stub(appInsights.context._sender, "send");
+                var trackStub = this.sandbox.stub(appInsights.context._sender, "send");
 
                 // verify
                 var test = (action, expectedEnvelopeType, expectedDataType) => {
@@ -188,7 +188,7 @@ class AppInsightsTests extends TestClass {
                 test(() => appInsights.trackEvent("testEvent"), Microsoft.ApplicationInsights.Telemetry.Event.envelopeType, Microsoft.ApplicationInsights.Telemetry.Event.dataType);
 
                 // teardown
-                trackStub.restore();
+                
             }
         });
 
@@ -199,7 +199,7 @@ class AppInsightsTests extends TestClass {
                 var config = this.getAppInsightsSnippet();
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(config);
                 appInsights.context._sessionManager._sessionHandler = null;
-                var trackStub = sinon.stub(appInsights.context._sender, "send");
+                var trackStub = this.sandbox.stub(appInsights.context._sender, "send");
                 this.clock.tick(60000);
 
                 // act 
@@ -210,7 +210,7 @@ class AppInsightsTests extends TestClass {
                 Assert.equal(60000, new Date(envelope.time).getTime(), "envelope time");
                 
                 // teardown
-                trackStub.restore();
+                
             }
         });
 
@@ -222,7 +222,7 @@ class AppInsightsTests extends TestClass {
                 appInsights.context._sessionManager._sessionHandler = null;
                 appInsights.context.application.ver = "101";
                 appInsights.context.application.build = "101";
-                var trackStub = sinon.stub(appInsights.context._sender, "send");
+                var trackStub = this.sandbox.stub(appInsights.context._sender, "send");
 
                 // verify
                 var test = (action) => {
@@ -239,7 +239,7 @@ class AppInsightsTests extends TestClass {
                 test(() => appInsights.trackEvent("testEvent"));
 
                 // teardown
-                trackStub.restore();
+                
             }
         });
 
@@ -261,7 +261,7 @@ class AppInsightsTests extends TestClass {
                 appInsights.context.device.resolution = "101";
                 appInsights.context.device.type = "101";
 
-                var trackStub = sinon.stub(appInsights.context._sender, "send");
+                var trackStub = this.sandbox.stub(appInsights.context._sender, "send");
 
                 // verify
                 var test = (action) => {
@@ -288,7 +288,7 @@ class AppInsightsTests extends TestClass {
                 test(() => appInsights.trackEvent("testEvent"));
 
                 // teardown
-                trackStub.restore();
+                
             }
         });
 
@@ -300,7 +300,7 @@ class AppInsightsTests extends TestClass {
                 appInsights.context._sessionManager._sessionHandler = null;
                 appInsights.context.internal.agentVersion = "101";
                 appInsights.context.internal.sdkVersion = "101";
-                var trackStub = sinon.stub(appInsights.context._sender, "send");
+                var trackStub = this.sandbox.stub(appInsights.context._sender, "send");
 
                 // verify
                 var test = (action) => {
@@ -317,7 +317,7 @@ class AppInsightsTests extends TestClass {
                 test(() => appInsights.trackEvent("testEvent"));
 
                 // teardown
-                trackStub.restore();
+                
             }
         });
 
@@ -328,7 +328,7 @@ class AppInsightsTests extends TestClass {
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
                 appInsights.context._sessionManager._sessionHandler = null;
                 appInsights.context.location.ip = "101";
-                var trackStub = sinon.stub(appInsights.context._sender, "send");
+                var trackStub = this.sandbox.stub(appInsights.context._sender, "send");
 
                 // verify
                 var test = (action) => {
@@ -344,7 +344,7 @@ class AppInsightsTests extends TestClass {
                 test(() => appInsights.trackEvent("testEvent"));
 
                 // teardown
-                trackStub.restore();
+                
             }
         });
 
@@ -359,7 +359,7 @@ class AppInsightsTests extends TestClass {
                 appInsights.context.operation.parentId = "101";
                 appInsights.context.operation.rootId = "101";
                 appInsights.context.operation.syntheticSource = "101";
-                var trackStub = sinon.stub(appInsights.context._sender, "send");
+                var trackStub = this.sandbox.stub(appInsights.context._sender, "send");
 
                 // verify
                 var test = (action) => {
@@ -379,7 +379,7 @@ class AppInsightsTests extends TestClass {
                 test(() => appInsights.trackEvent("testEvent"));
 
                 // teardown
-                trackStub.restore();
+                
             }
         });
 
@@ -389,7 +389,7 @@ class AppInsightsTests extends TestClass {
                 // setup
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
                 appInsights.context.sample.sampleRate = 33;
-                var trackSpy = sinon.spy(appInsights.context, "_track");
+                var trackSpy = this.sandbox.spy(appInsights.context, "_track");
 
                 // verify
                 var test = (action) => {
@@ -405,7 +405,7 @@ class AppInsightsTests extends TestClass {
                 test(() => appInsights.trackEvent("testEvent"));
 
                 // teardown
-                trackSpy.restore();
+                
             }
         });
 
@@ -416,7 +416,7 @@ class AppInsightsTests extends TestClass {
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
                 appInsights.context.sample.sampleRate = 33;
                 appInsights.context.user.id = "asdf";
-                var trackSpy = sinon.spy(appInsights.context.sample, "isSampledIn");
+                var trackSpy = this.sandbox.spy(appInsights.context.sample, "isSampledIn");
 
                 // verify
                 var test = (action) => {
@@ -438,7 +438,7 @@ class AppInsightsTests extends TestClass {
                 test(() => appInsights.trackTrace("testTrace"));
 
                 // teardown
-                trackSpy.restore();
+                
             }
         });
 
@@ -450,7 +450,7 @@ class AppInsightsTests extends TestClass {
                 appInsights.context._sessionManager._sessionHandler = null;
                 appInsights.context.session.id = "101";
                 appInsights.context.session.isFirst = true;
-                var trackStub = sinon.stub(appInsights.context._sender, "send");
+                var trackStub = this.sandbox.stub(appInsights.context._sender, "send");
 
                 // verify
                 var test = (action) => {
@@ -467,7 +467,7 @@ class AppInsightsTests extends TestClass {
                 test(() => appInsights.trackEvent("testEvent"));
 
                 // teardown
-                trackStub.restore();
+                
             }
         });
 
@@ -481,7 +481,7 @@ class AppInsightsTests extends TestClass {
                 appInsights.context.user.agent = "101";
                 appInsights.context.user.id = "101";
                 appInsights.context.user.storeRegion = "101";
-                var trackStub = sinon.stub(appInsights.context._sender, "send");
+                var trackStub = this.sandbox.stub(appInsights.context._sender, "send");
 
                 // verify
                 var test = (action) => {
@@ -500,7 +500,7 @@ class AppInsightsTests extends TestClass {
                 test(() => appInsights.trackEvent("testEvent"));
 
                 // teardown
-                trackStub.restore();
+                
             }
         });
 
@@ -512,7 +512,7 @@ class AppInsightsTests extends TestClass {
 
                 appInsights.setAuthenticatedUserContext("10001");
 
-                var trackStub = sinon.stub(appInsights.context._sender, "send");
+                var trackStub = this.sandbox.stub(appInsights.context._sender, "send");
 
                 // verify
                 var test = (action) => {
@@ -529,7 +529,7 @@ class AppInsightsTests extends TestClass {
                 test(() => appInsights.trackEvent("testEvent"));
                 
                 // teardown
-                trackStub.restore();
+                
             }
         });
 
@@ -541,7 +541,7 @@ class AppInsightsTests extends TestClass {
 
                 appInsights.setAuthenticatedUserContext("10001", "account33");
 
-                var trackStub = sinon.stub(appInsights.context._sender, "send");
+                var trackStub = this.sandbox.stub(appInsights.context._sender, "send");
 
                 // verify
                 var test = (action) => {
@@ -559,7 +559,7 @@ class AppInsightsTests extends TestClass {
                 test(() => appInsights.trackEvent("testEvent"));
 
                 // teardown
-                trackStub.restore();
+                
             }
         });
 
@@ -570,7 +570,7 @@ class AppInsightsTests extends TestClass {
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
 
                 appInsights.setAuthenticatedUserContext("\u0428", "\u0429"); // Cyrillic characters
-                var trackStub = sinon.stub(appInsights.context._sender, "send");
+                var trackStub = this.sandbox.stub(appInsights.context._sender, "send");
 
                 // verify
                 var test = (action) => {
@@ -588,7 +588,7 @@ class AppInsightsTests extends TestClass {
                 test(() => appInsights.trackEvent("testEvent"));
                 
                 // teardown
-                trackStub.restore();
+                
             }
         });
 
@@ -597,7 +597,7 @@ class AppInsightsTests extends TestClass {
             test: () => {
                 // setup
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
-                var trackStub = sinon.stub(appInsights.context._sender, "send");
+                var trackStub = this.sandbox.stub(appInsights.context._sender, "send");
                 appInsights.setAuthenticatedUserContext("1234", "abcd");
 
                 // Clear authenticatedId
@@ -619,7 +619,7 @@ class AppInsightsTests extends TestClass {
                 test(() => appInsights.trackEvent("testEvent"));
 
                 // teardown
-                trackStub.restore();
+                
             }
         });
 
@@ -805,14 +805,14 @@ class AppInsightsTests extends TestClass {
                 // setup
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
                 appInsights.context._sessionManager._sessionHandler = null;
-                var trackStub = sinon.stub(appInsights.context._sender, "send");
+                var trackStub = this.sandbox.stub(appInsights.context._sender, "send");
 
                 appInsights.trackException(new Error());
                 Assert.ok(trackStub.calledOnce, "single exception is tracked");
                 appInsights.trackException(<any>[new Error()]);
                 Assert.ok(trackStub.calledTwice, "array of exceptions is tracked");
 
-                trackStub.restore();
+                
             }
         });
 
@@ -822,7 +822,7 @@ class AppInsightsTests extends TestClass {
                 // setup
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
                 appInsights.context._sessionManager._sessionHandler = null;
-                var trackStub = sinon.stub(appInsights.context._sender, "send");
+                var trackStub = this.sandbox.stub(appInsights.context._sender, "send");
 
                 // act 
                 appInsights.trackMetric("testMetric", 0);
@@ -843,7 +843,7 @@ class AppInsightsTests extends TestClass {
                 Assert.equal(100, trackStub.callCount, "track was called 100 times");
 
                 // teardown
-                trackStub.restore();
+                
             }
         });
 
@@ -877,15 +877,15 @@ class AppInsightsTests extends TestClass {
             name: "AppInsights._onerror creates a dump of unexpected error thrown by trackException for logging",
             test: () => {
                 var sut = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
-                var dumpSpy = sinon.spy(Microsoft.ApplicationInsights.Util, "dump")
+                var dumpSpy = this.sandbox.spy(Microsoft.ApplicationInsights.Util, "dump")
                 var unexpectedError = new Error();
-                var stub = sinon.stub(sut, "trackException").throws(unexpectedError);
+                var stub = this.sandbox.stub(sut, "trackException").throws(unexpectedError);
 
                 sut._onerror("any message", "any://url", 420, 42, new Error());
 
                 Assert.ok(dumpSpy.calledWith(unexpectedError));
-                stub.restore();
-                dumpSpy.restore();
+                
+                
             }
         });
 
@@ -893,9 +893,9 @@ class AppInsightsTests extends TestClass {
             name: "AppInsights._onerror stringifies error object",
             test: () => {
                 var sut = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
-                var dumpSpy = sinon.spy(Microsoft.ApplicationInsights.Util, "dump")
+                var dumpSpy = this.sandbox.spy(Microsoft.ApplicationInsights.Util, "dump")
                 var unexpectedError = new Error("my cool message");
-                var stub = sinon.stub(sut, "trackException").throws(unexpectedError);
+                var stub = this.sandbox.stub(sut, "trackException").throws(unexpectedError);
 
                 sut._onerror("any message", "any://url", 420, 42, new Error());
 
@@ -903,8 +903,8 @@ class AppInsightsTests extends TestClass {
                 Assert.ok(dumpSpy.returnValues[0].indexOf("message: 'my cool message'") != -1);
                 Assert.ok(dumpSpy.returnValues[0].indexOf("name: 'Error'") != -1);
 
-                stub.restore();
-                dumpSpy.restore();
+                
+                
             }
         });
 
@@ -912,9 +912,9 @@ class AppInsightsTests extends TestClass {
             name: "AppInsights._onerror logs dump of unexpected error thrown by trackException for diagnostics",
             test: () => {
                 var sut = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
-                var throwInternalNonUserActionableSpy = sinon.spy(Microsoft.ApplicationInsights._InternalLogging, "throwInternalNonUserActionable");
-                var dumpStub = sinon.stub(Microsoft.ApplicationInsights.Util, "dump");
-                var stub = sinon.stub(sut, "trackException").throws(new Error());
+                var throwInternalNonUserActionableSpy = this.sandbox.spy(Microsoft.ApplicationInsights._InternalLogging, "throwInternalNonUserActionable");
+                var dumpStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, "dump");
+                var stub = this.sandbox.stub(sut, "trackException").throws(new Error());
                 var expectedErrorDump: string = "test error";
                 dumpStub.returns(expectedErrorDump);
 
@@ -922,9 +922,9 @@ class AppInsightsTests extends TestClass {
 
                 var logMessage: string = throwInternalNonUserActionableSpy.getCall(0).args[1];
                 Assert.notEqual(-1, logMessage.indexOf(expectedErrorDump));
-                stub.restore();
-                dumpStub.restore();
-                throwInternalNonUserActionableSpy.restore();
+                
+                
+                
             }
         });
 
@@ -933,7 +933,7 @@ class AppInsightsTests extends TestClass {
             test: () => {
                 // prepare
                 var sut = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
-                var trackSpy = sinon.spy(sut.context, "track");                
+                var trackSpy = this.sandbox.spy(sut.context, "track");                
 
                 // act
                 sut._onerror("Script error.", "", 0, 0, null);
@@ -941,7 +941,7 @@ class AppInsightsTests extends TestClass {
                 // assert
                 Assert.equal(document.URL, (<any>trackSpy.args[0][0]).data.baseData.properties.url);
 
-                trackSpy.restore();
+                
             }
         });
 
@@ -950,7 +950,7 @@ class AppInsightsTests extends TestClass {
             test: () => {
                 // prepare
                 var sut = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
-                var trackExceptionSpy = sinon.spy(sut, "trackException");                
+                var trackExceptionSpy = this.sandbox.spy(sut, "trackException");                
 
                 // act
                 // Last arg is not an error\null which will be treated as not CORS issue
@@ -960,7 +960,7 @@ class AppInsightsTests extends TestClass {
                 // properties are passed as a 3rd parameter
                 Assert.equal(document.URL, (<any>trackExceptionSpy.args[0][2]).url);
 
-                trackExceptionSpy.restore();
+                
             }
         });
 
@@ -986,7 +986,7 @@ class AppInsightsTests extends TestClass {
             // setup
             var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
             appInsights.context._sessionManager._sessionHandler = null;
-            var stub = sinon.stub(Microsoft.ApplicationInsights.Telemetry.PageViewManager.prototype, "trackPageView");
+            var stub = this.sandbox.stub(Microsoft.ApplicationInsights.Telemetry.PageViewManager.prototype, "trackPageView");
 
             // act
             trackAction(appInsights);
@@ -997,7 +997,7 @@ class AppInsightsTests extends TestClass {
             validateAction(data);
 
             // teardown
-            stub.restore();
+            
         }
 
 
@@ -1133,7 +1133,7 @@ class AppInsightsTests extends TestClass {
             test: () => {
                 // setup
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
-                var spy = sinon.spy(appInsights, "sendPageViewInternal");
+                var spy = this.sandbox.spy(appInsights, "sendPageViewInternal");
 
                 // act
                 appInsights.startTrackPage();
@@ -1146,7 +1146,7 @@ class AppInsightsTests extends TestClass {
                 Assert.equal(testValues.duration, actualDuration, "duration is calculated and sent correctly");
 
                 // teardown                
-                spy.restore();
+                
             }
         });
 
@@ -1156,7 +1156,7 @@ class AppInsightsTests extends TestClass {
                 // setup
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
                 appInsights.context._sessionManager._sessionHandler = null;
-                var trackStub = sinon.stub(appInsights.context._sender, "send");
+                var trackStub = this.sandbox.stub(appInsights.context._sender, "send");
                 this.clock.tick(10);        // Needed to ensure the duration calculation works
 
                 // act
@@ -1173,7 +1173,7 @@ class AppInsightsTests extends TestClass {
                 Assert.notEqual(testValues.measurements, telemetry.measurements);
 
                 // teardown
-                trackStub.restore();
+                
             }
         });
 
@@ -1183,7 +1183,7 @@ class AppInsightsTests extends TestClass {
                 // setup
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
                 appInsights.context._sessionManager._sessionHandler = null;
-                var trackStub = sinon.stub(appInsights.context._sender, "send");
+                var trackStub = this.sandbox.stub(appInsights.context._sender, "send");
                 this.clock.tick(10);        // Needed to ensure the duration calculation works
 
                 // act
@@ -1214,7 +1214,7 @@ class AppInsightsTests extends TestClass {
                 Assert.deepEqual(testValues.measurements, telemetry.measurements);
 
                 // teardown
-                trackStub.restore();
+                
             }
         });
 
@@ -1224,7 +1224,7 @@ class AppInsightsTests extends TestClass {
                 // setup
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
                 appInsights.context._sessionManager._sessionHandler = null;
-                var trackStub = sinon.stub(appInsights.context._sender, "send");
+                var trackStub = this.sandbox.stub(appInsights.context._sender, "send");
                 this.clock.tick(10);        // Needed to ensure the duration calculation works
 
                 // act
@@ -1256,7 +1256,7 @@ class AppInsightsTests extends TestClass {
                 Assert.deepEqual(testValues.measurements, telemetry.measurements);
 
                 // teardown
-                trackStub.restore();
+                
             }
         });
 
@@ -1267,7 +1267,7 @@ class AppInsightsTests extends TestClass {
                 // setup
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
                 appInsights.context._sessionManager._sessionHandler = null;
-                var logStub = sinon.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
+                var logStub = this.sandbox.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
                 Microsoft.ApplicationInsights._InternalLogging.verboseLogging = () => true;
                 
                 // act
@@ -1278,7 +1278,7 @@ class AppInsightsTests extends TestClass {
                 Assert.ok(logStub.calledOnce, "calling start twice triggers warning to user");
 
                 // teardown
-                logStub.restore();
+                
             }
         });
 
@@ -1289,7 +1289,7 @@ class AppInsightsTests extends TestClass {
                 // setup
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
                 appInsights.context._sessionManager._sessionHandler = null;
-                var logStub = sinon.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
+                var logStub = this.sandbox.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
                 Microsoft.ApplicationInsights._InternalLogging.verboseLogging = () => true;
 
                 // act
@@ -1299,7 +1299,7 @@ class AppInsightsTests extends TestClass {
                 Assert.ok(logStub.calledOnce, "calling stop without a corresponding start triggers warning to user");
 
                 // teardown
-                logStub.restore();
+                
             }
         });
 
@@ -1309,7 +1309,7 @@ class AppInsightsTests extends TestClass {
                 // setup
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
                 appInsights.context._sessionManager._sessionHandler = null;
-                var trackStub = sinon.stub(appInsights.context._sender, "send");
+                var trackStub = this.sandbox.stub(appInsights.context._sender, "send");
                 this.clock.tick(10);        // Needed to ensure the duration calculation works
 
                 // act
@@ -1338,7 +1338,7 @@ class AppInsightsTests extends TestClass {
                 Assert.deepEqual(testValues.measurements, telemetry.measurements);
 
                 // teardown
-                trackStub.restore();
+                
             }
         });
 
@@ -1354,7 +1354,7 @@ class AppInsightsTests extends TestClass {
 
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
                 appInsights.context._sessionManager._sessionHandler = null;
-                var trackStub = sinon.stub(appInsights.context._sender, "send");
+                var trackStub = this.sandbox.stub(appInsights.context._sender, "send");
                 this.clock.tick(10);        // Needed to ensure the duration calculation works
 
                 // act
@@ -1381,7 +1381,7 @@ class AppInsightsTests extends TestClass {
                 Assert.deepEqual(testValues.measurements, telemetry.measurements);
 
                 // teardown
-                trackStub.restore();
+                
             }
         });
 
@@ -1392,7 +1392,7 @@ class AppInsightsTests extends TestClass {
                 // setup
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
                 appInsights.context._sessionManager._sessionHandler = null;
-                var logStub = sinon.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
+                var logStub = this.sandbox.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
                 Microsoft.ApplicationInsights._InternalLogging.verboseLogging = () => true;
 
                 // act
@@ -1403,7 +1403,7 @@ class AppInsightsTests extends TestClass {
                 Assert.ok(logStub.calledOnce, "calling startTrackEvent twice triggers warning to user");
 
                 // teardown
-                logStub.restore();
+                
             }
         });
 
@@ -1414,7 +1414,7 @@ class AppInsightsTests extends TestClass {
                 // setup
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
                 appInsights.context._sessionManager._sessionHandler = null;
-                var logStub = sinon.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
+                var logStub = this.sandbox.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
                 Microsoft.ApplicationInsights._InternalLogging.verboseLogging = () => true;
 
                 // act
@@ -1424,7 +1424,7 @@ class AppInsightsTests extends TestClass {
                 Assert.ok(logStub.calledOnce, "calling stopTrackEvent without a corresponding start triggers warning to user");
 
                 // teardown
-                logStub.restore();
+                
             }
         });
 
@@ -1445,7 +1445,7 @@ class AppInsightsTests extends TestClass {
 
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
                 appInsights.context._sessionManager._sessionHandler = null;
-                var trackStub = sinon.stub(appInsights.context._sender, "send");
+                var trackStub = this.sandbox.stub(appInsights.context._sender, "send");
                 this.clock.tick(55);        // Needed to ensure the duration calculation works
 
                 // act
@@ -1469,7 +1469,7 @@ class AppInsightsTests extends TestClass {
                 Assert.equal(testValues2.duration, telemetry.measurements["duration"]);
 
                 // teardown
-                trackStub.restore();
+                
             }
         });
 
@@ -1491,7 +1491,7 @@ class AppInsightsTests extends TestClass {
 
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
                 appInsights.context._sessionManager._sessionHandler = null;
-                var trackStub = sinon.stub(appInsights.context._sender, "send");
+                var trackStub = this.sandbox.stub(appInsights.context._sender, "send");
                 this.clock.tick(10);       
 
                 // act
@@ -1507,7 +1507,7 @@ class AppInsightsTests extends TestClass {
                 Assert.deepEqual(testValues2.measurements, telemetry.measurements);
 
                 // teardown
-                trackStub.restore();
+                
             }
         });
 
@@ -1521,7 +1521,7 @@ class AppInsightsTests extends TestClass {
                 appInsights.config.maxBatchInterval = 100;
                 Microsoft.ApplicationInsights._InternalLogging.verboseLogging = () => true;
                 appInsights.context._sender._sender = () => null;
-                var senderSpy = sinon.spy(appInsights.context._sender, "_sender");
+                var senderSpy = this.sandbox.spy(appInsights.context._sender, "_sender");
 
                 // act
                 appInsights.trackEvent("Event1");
@@ -1540,7 +1540,7 @@ class AppInsightsTests extends TestClass {
                 Assert.ok(senderSpy.calledOnce, "data is sent after calling flush");
 
                 // teardown
-                senderSpy.restore();
+                
             }
         });
 
@@ -1552,8 +1552,8 @@ class AppInsightsTests extends TestClass {
                 appInsights.context._sessionManager._sessionHandler = null;
                 Microsoft.ApplicationInsights._InternalLogging.verboseLogging = () => true;
                 appInsights.context._sender._sender = () => null;
-                var senderStub = sinon.stub(appInsights.context._sender, "_sender");
-                var resetInternalMessageCountStub = sinon.stub(Microsoft.ApplicationInsights._InternalLogging, "resetInternalMessageCount");
+                var senderStub = this.sandbox.stub(appInsights.context._sender, "_sender");
+                var resetInternalMessageCountStub = this.sandbox.stub(Microsoft.ApplicationInsights._InternalLogging, "resetInternalMessageCount");
 
                 // setup a page view envelope
                 var pageView = new Microsoft.ApplicationInsights.Telemetry.PageView();
@@ -1567,8 +1567,8 @@ class AppInsightsTests extends TestClass {
                 Assert.ok(resetInternalMessageCountStub.calledOnce, "Internal throttle was not reset even though Page View was tracked");
 
                 // restore
-                senderStub.restore();
-                resetInternalMessageCountStub.restore();
+                
+                
             }
         });
 
@@ -1580,8 +1580,8 @@ class AppInsightsTests extends TestClass {
                 appInsights.context._sessionManager._sessionHandler = null;
                 Microsoft.ApplicationInsights._InternalLogging.verboseLogging = () => true;
                 appInsights.context._sender._sender = () => null;
-                var senderStub = sinon.stub(appInsights.context._sender, "_sender");
-                var resetInternalMessageCountStub = sinon.stub(Microsoft.ApplicationInsights._InternalLogging, "resetInternalMessageCount");
+                var senderStub = this.sandbox.stub(appInsights.context._sender, "_sender");
+                var resetInternalMessageCountStub = this.sandbox.stub(Microsoft.ApplicationInsights._InternalLogging, "resetInternalMessageCount");
 
                 // setup a some other envelope
                 var event = new Microsoft.ApplicationInsights.Telemetry.Event('Test Event');
@@ -1595,8 +1595,8 @@ class AppInsightsTests extends TestClass {
                 Assert.ok(resetInternalMessageCountStub.notCalled, "Internal throttle was reset even though Page View was not tracked");
 
                 // restore
-                senderStub.restore();
-                resetInternalMessageCountStub.restore();
+                
+                
             }
         });
 
@@ -1604,7 +1604,7 @@ class AppInsightsTests extends TestClass {
             name: "trackAjax passes ajax data correctly",
             test: () => {
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.getAppInsightsSnippet());
-                var trackStub = sinon.stub(appInsights.context, "track");
+                var trackStub = this.sandbox.stub(appInsights.context, "track");
                 var name = "test";
                 var url = "http://myurl.com";
                 var duration = 123;
@@ -1629,7 +1629,7 @@ class AppInsightsTests extends TestClass {
                 var snippet = this.getAppInsightsSnippet();
                 snippet.instrumentationKey = "BDC8736D-D8E8-4B69-B19B-B0CE6B66A456";
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(snippet);
-                var trackStub = sinon.stub(appInsights.context, "track");
+                var trackStub = this.sandbox.stub(appInsights.context, "track");
                 // dashes are removed
                 var expectedEnvelopeName = "Microsoft.ApplicationInsights.BDC8736DD8E84B69B19BB0CE6B66A456.RemoteDependency";
 

--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/DisableTelemetryTests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/DisableTelemetryTests.ts
@@ -15,9 +15,9 @@ class DisableTelemetryTests extends TestClass {
         sinon.fakeServer["restore"]();
         this.useFakeTimers = false;
         this.clock.restore();
-        this.errorSpy = sinon.spy(Microsoft.ApplicationInsights.Sender, "_onError");
-        this.successSpy = sinon.stub(Microsoft.ApplicationInsights.Sender, "_onSuccess");
-        this.loggingSpy = sinon.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
+        this.errorSpy = this.sandbox.spy(Microsoft.ApplicationInsights.Sender, "_onError");
+        this.successSpy = this.sandbox.stub(Microsoft.ApplicationInsights.Sender, "_onSuccess");
+        this.loggingSpy = this.sandbox.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
     }
 
     /** Method called after each test method has completed */
@@ -25,9 +25,6 @@ class DisableTelemetryTests extends TestClass {
         console.log("cleanup");
         this.useFakeServer = true;
         this.useFakeTimers = true;
-        this.errorSpy.restore();
-        this.successSpy.restore();
-        this.loggingSpy.restore();
     }
 
     public registerTests() {

--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/PublicApiTests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/PublicApiTests.ts
@@ -14,18 +14,15 @@ class PublicApiTests extends TestClass {
         sinon.fakeServer["restore"]();
         this.useFakeTimers = false;
         this.clock.restore();
-        this.errorSpy = sinon.spy(Microsoft.ApplicationInsights.Sender, "_onError");
-        this.successSpy = sinon.stub(Microsoft.ApplicationInsights.Sender, "_onSuccess");
-        this.loggingSpy = sinon.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
+        this.errorSpy = this.sandbox.spy(Microsoft.ApplicationInsights.Sender, "_onError");
+        this.successSpy = this.sandbox.stub(Microsoft.ApplicationInsights.Sender, "_onSuccess");
+        this.loggingSpy = this.sandbox.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
     }
 
     /** Method called after each test method has completed */
     public testCleanup() {
         this.useFakeServer = true;
         this.useFakeTimers = true;
-        this.errorSpy.restore();
-        this.successSpy.restore();
-        this.loggingSpy.restore();
     }
 
     public registerTests() {

--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/SanitizerE2E.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/SanitizerE2E.tests.ts
@@ -14,18 +14,15 @@ class Sanitizer2ETests extends TestClass {
         sinon.fakeServer["restore"]();
         this.useFakeTimers = false;
         this.clock.restore();
-        this.errorSpy = sinon.spy(Microsoft.ApplicationInsights.Sender, "_onError");
-        this.successSpy = sinon.stub(Microsoft.ApplicationInsights.Sender, "_onSuccess");
-        this.loggingSpy = sinon.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
+        this.errorSpy = this.sandbox.spy(Microsoft.ApplicationInsights.Sender, "_onError");
+        this.successSpy = this.sandbox.stub(Microsoft.ApplicationInsights.Sender, "_onSuccess");
+        this.loggingSpy = this.sandbox.stub(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
     }
 
     /** Method called after each test method has completed */
     public testCleanup() {
         this.useFakeServer = true;
         this.useFakeTimers = true;
-        this.errorSpy.restore();
-        this.successSpy.restore();
-        this.loggingSpy.restore();
     }
 
     public registerTests() {

--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/autoCollection.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/autoCollection.tests.ts
@@ -199,7 +199,7 @@ class AutoCollectionTests extends TestClass {
 
     private getListener(address): SinonSpy {
         var listener = { onMessage: () => null };
-        var spy = sinon.spy(listener, "onMessage");
+        var spy = this.sandbox.spy(listener, "onMessage");
 
         if (window.addEventListener) {
             addEventListener("message", listener.onMessage, false);

--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/snippet.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/snippet.tests.ts
@@ -34,7 +34,7 @@ class SnippetTests extends TestClass {
         }
 
         window['queueTest'] = () => null;
-        this.queueSpy = sinon.spy(window, "queueTest");
+        this.queueSpy = this.sandbox.spy(window, "queueTest");
         this.useFakeTimers = false;
         this.clock.restore();
         this.useFakeServer = false;
@@ -46,7 +46,6 @@ class SnippetTests extends TestClass {
         this.useFakeServer = true;
         this.useFakeTimers = true;
         window[this.name] = this.originalAppInsights;
-        this.queueSpy.restore();
     }
 
     public registerTests() {
@@ -81,7 +80,7 @@ class SnippetTests extends TestClass {
                     Assert.deepEqual("test", pv.url, "url was set correctly");
                     Assert.deepEqual({ property: "p1" }, pv.properties, "properties were set correctly");
                     Assert.deepEqual({ measurement: 5 }, pv.measurements, "measurements were set correctly");
-                    senderSpy71V2.restore();
+                    
                 }
             ]
         });
@@ -105,7 +104,7 @@ class SnippetTests extends TestClass {
                     var count = 2 + this.timingOffset;
                     Assert.equal(count, senderSpy66V2V1.sender.callCount, "v2 send called " + count + " times");
                     this.boilerPlateAsserts(senderSpy66V2V1);
-                    senderSpy66V2V1.restore();
+                    
                 }
             ]
         });
@@ -173,7 +172,7 @@ class SnippetTests extends TestClass {
                     var count = 5 + this.timingOffset;
                     Assert.equal(count, sender.sender.callCount, "send called " + count + " times");
                     this.boilerPlateAsserts(sender);
-                    sender.restore();
+                    
                 }
             ]
         });
@@ -217,10 +216,10 @@ class SnippetTests extends TestClass {
         window["appInsights"].endpointUrl = "https://dc.services.visualstudio.com/v2/track";
         window["appInsights"].maxBatchInterval = 1;
         var appIn = <Microsoft.ApplicationInsights.AppInsights>window[this.name];
-        var sender = sinon.spy(appIn.context._sender, "send");
-        var errorSpy = sinon.spy(Microsoft.ApplicationInsights.Sender, "_onError");
-        var successSpy = sinon.spy(Microsoft.ApplicationInsights.Sender, "_onSuccess");
-        var loggingSpy = sinon.spy(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
+        var sender = this.sandbox.spy(appIn.context._sender, "send");
+        var errorSpy = this.sandbox.spy(Microsoft.ApplicationInsights.Sender, "_onError");
+        var successSpy = this.sandbox.spy(Microsoft.ApplicationInsights.Sender, "_onSuccess");
+        var loggingSpy = this.sandbox.spy(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");
 
         return {
             sender: sender,
@@ -228,10 +227,10 @@ class SnippetTests extends TestClass {
             successSpy: successSpy,
             loggingSpy: loggingSpy,
             restore: () => {
-                sender.restore();
-                errorSpy.restore();
-                successSpy.restore();
-                loggingSpy.restore();
+                
+                
+                
+                
             }
         };
     }

--- a/JavaScript/JavaScriptSDK.Tests/Performance/pageLoad.perftests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/Performance/pageLoad.perftests.ts
@@ -143,7 +143,7 @@ class PageLoadPerfTests extends PerformanceTestHelper {
 
     private getListener(): SinonSpy {
         var listener = { onMessage: (data) => null };
-        var spy = sinon.spy(listener, "onMessage");
+        var spy = this.sandbox.spy(listener, "onMessage");
 
         if (window.addEventListener) {
             addEventListener("message", listener.onMessage, false);


### PR DESCRIPTION
In this change I made sure we create spies/stubs/mocks via 'this.sandbox'. This allows to skip manual .restore() and reduces bugs because of missed restore (and simplifies the code for future tests).