### PR TITLE
switching to performance.now() for ajax timing

### DIFF
--- a/JavaScript/JavaScriptSDK/ajax/ajaxUtils.ts
+++ b/JavaScript/JavaScriptSDK/ajax/ajaxUtils.ts
@@ -31,9 +31,14 @@ module Microsoft.ApplicationInsights {
 
     export class dateTime {
         ///<summary>Return the number of milliseconds since 1970/01/01 in local timezon</summary>
-        public static Now = function () {
-            return new Date().getTime();
-        }
+        public static Now = (window.performance && window.performance.now) ?
+            function () {
+                return performance.now();
+            }
+            :
+            function () {
+                return new Date().getTime();
+            }
 
         ///<summary>Gets duration between two timestamps</summary>
         public static GetDuration = function (start, end) {


### PR DESCRIPTION
Per http://stackoverflow.com/questions/313893/how-to-measure-time-taken-by-a-function-to-execute 

Our telemetry indicates that ajax start time sometimes is bigger than finish time.