### PR TITLE
Ajax - client side throttling per view

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Initialization.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Initialization.tests.ts
@@ -28,7 +28,8 @@ class InitializationTests extends TestClass {
             autoTrackPageVisitTime: false,
             samplingPercentage: 33,
             disableAjaxTracking: true,
-            overridePageViewDuration: false
+            overridePageViewDuration: false,
+            maxAjaxCallsPerView: 44
         };
 
         // set default values
@@ -69,7 +70,8 @@ class InitializationTests extends TestClass {
                     disableTelemetry: undefined,
                     verboseLogging: undefined,
                     diagnosticLogInterval: undefined,
-                    samplingPercentage: undefined
+                    samplingPercentage: undefined,
+                    maxAjaxCallsPerView: undefined
                 };
 
                 var snippet = <Microsoft.ApplicationInsights.Snippet> {
@@ -90,6 +92,7 @@ class InitializationTests extends TestClass {
                 Assert.ok(!init.config.verboseLogging);
                 Assert.equal(10000, init.config.diagnosticLogInterval);
                 Assert.equal(100, init.config.samplingPercentage);
+                Assert.equal(20, init.config.maxAjaxCallsPerView);
             }
         });
 
@@ -116,6 +119,7 @@ class InitializationTests extends TestClass {
                 Assert.ok(init.config.verboseLogging);
                 Assert.equal(1, init.config.diagnosticLogInterval);
                 Assert.equal(33, init.config.samplingPercentage);
+                Assert.equal(44, init.config.maxAjaxCallsPerView);
             }
         });
 

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Initialization.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Initialization.tests.ts
@@ -92,7 +92,7 @@ class InitializationTests extends TestClass {
                 Assert.ok(!init.config.verboseLogging);
                 Assert.equal(10000, init.config.diagnosticLogInterval);
                 Assert.equal(100, init.config.samplingPercentage);
-                Assert.equal(20, init.config.maxAjaxCallsPerView);
+                Assert.equal(500, init.config.maxAjaxCallsPerView);
             }
         });
 

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -1687,6 +1687,30 @@ class AppInsightsTests extends TestClass {
             }
         });
 
+        this.testCase({
+            name: "trackAjax - only 1 user actionable trace about ajaxes limit per view",
+            test: () => {
+                var snippet = this.getAppInsightsSnippet();
+                var appInsights = new Microsoft.ApplicationInsights.AppInsights(snippet);
+                var trackStub = this.sandbox.stub(appInsights.context, "track");
+                var loggingSpy = this.sandbox.spy(Microsoft.ApplicationInsights._InternalLogging, "throwInternalUserActionable");                
+
+                // Act
+                for (var i = 0; i < 20; ++i) {
+                    appInsights.trackAjax("test", "http://asdf", 123, true, 200);
+                }
+                
+                loggingSpy.reset();
+
+                for (var i = 0; i < 100; ++i) {
+                    appInsights.trackAjax("test", "http://asdf", 123, true, 200);
+                }
+
+                // Assert
+                Assert.equal(1, loggingSpy.callCount, "Expected 1 invokation of internal logging");
+            }
+        });
+
 
         this.testCase({
             name: "trackAjax - '-1' means no ajax per view limit",

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -22,7 +22,8 @@ class AppInsightsTests extends TestClass {
             autoTrackPageVisitTime: false,
             samplingPercentage: 100,
             disableAjaxTracking: true,
-            overridePageViewDuration: false
+            overridePageViewDuration: false,
+            maxAjaxCallsPerView: 20
         };
 
         // set default values
@@ -96,7 +97,7 @@ class AppInsightsTests extends TestClass {
                     action();
                     this.clock.tick(1);
                     Assert.ok(senderStub.notCalled, "sender was not called called for: " + action);
-                    
+
                 };
 
                 // act
@@ -661,7 +662,7 @@ class AppInsightsTests extends TestClass {
             name: "AppInsightsTests: trackPageView sends custom duration when configured by user",
             test: () => {
                 var snippet = this.getAppInsightsSnippet();
-                snippet.overridePageViewDuration = true;                
+                snippet.overridePageViewDuration = true;
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(snippet);
                 var spy = this.sandbox.spy(appInsights, "sendPageViewInternal");
                 var stub = this.sandbox.stub(Microsoft.ApplicationInsights.Telemetry.PageViewPerformance, "getPerformanceTiming",
@@ -790,7 +791,7 @@ class AppInsightsTests extends TestClass {
                     () => { return false; });
                 
                 // act
-                appInsights.trackPageView();                
+                appInsights.trackPageView();
                 this.clock.tick(100);
 
                 // assert
@@ -812,7 +813,7 @@ class AppInsightsTests extends TestClass {
                 appInsights.trackException(<any>[new Error()]);
                 Assert.ok(trackStub.calledTwice, "array of exceptions is tracked");
 
-                
+
             }
         });
 
@@ -884,8 +885,8 @@ class AppInsightsTests extends TestClass {
                 sut._onerror("any message", "any://url", 420, 42, new Error());
 
                 Assert.ok(dumpSpy.calledWith(unexpectedError));
-                
-                
+
+
             }
         });
 
@@ -903,8 +904,8 @@ class AppInsightsTests extends TestClass {
                 Assert.ok(dumpSpy.returnValues[0].indexOf("message: 'my cool message'") != -1);
                 Assert.ok(dumpSpy.returnValues[0].indexOf("name: 'Error'") != -1);
 
-                
-                
+
+
             }
         });
 
@@ -922,9 +923,9 @@ class AppInsightsTests extends TestClass {
 
                 var logMessage: string = throwInternalNonUserActionableSpy.getCall(0).args[1];
                 Assert.notEqual(-1, logMessage.indexOf(expectedErrorDump));
-                
-                
-                
+
+
+
             }
         });
 
@@ -941,7 +942,7 @@ class AppInsightsTests extends TestClass {
                 // assert
                 Assert.equal(document.URL, (<any>trackSpy.args[0][0]).data.baseData.properties.url);
 
-                
+
             }
         });
 
@@ -960,7 +961,7 @@ class AppInsightsTests extends TestClass {
                 // properties are passed as a 3rd parameter
                 Assert.equal(document.URL, (<any>trackExceptionSpy.args[0][2]).url);
 
-                
+
             }
         });
 
@@ -1642,6 +1643,67 @@ class AppInsightsTests extends TestClass {
                 Assert.ok(trackStub.called, "Track should be called");
                 var envelope = trackStub.args[0][0];
                 Assert.equal(expectedEnvelopeName, envelope.name, "Envelope name should include instrumentation key without dashes");
+            }
+        });
+
+        this.testCase({
+            name: "trackAjax - by default no more than 20 ajaxes per view",
+            test: () => {
+                var snippet = this.getAppInsightsSnippet();
+                var appInsights = new Microsoft.ApplicationInsights.AppInsights(snippet);
+                var trackStub = this.sandbox.stub(appInsights.context, "track");
+
+                // Act
+                for (var i = 0; i < 100; ++i) {
+                    appInsights.trackAjax("test", "http://asdf", 123, true, 200);
+                }
+
+                // Assert
+                Assert.equal(20, trackStub.callCount, "Expected 20 invokations of trackAjax");
+            }
+        });
+
+        this.testCase({
+            name: "trackAjax - trackPageView resets counter of sent ajaxes",
+            test: () => {
+                var snippet = this.getAppInsightsSnippet();
+                var appInsights = new Microsoft.ApplicationInsights.AppInsights(snippet);
+                var trackStub = this.sandbox.stub(appInsights.context, "track");
+
+                // Act
+                for (var i = 0; i < 100; ++i) {
+                    appInsights.trackAjax("test", "http://asdf", 123, true, 200);
+                }
+
+                appInsights.sendPageViewInternal("asdf", "http://microsoft.com", 123);
+                trackStub.reset();
+
+                for (var i = 0; i < 100; ++i) {
+                    appInsights.trackAjax("test", "http://asdf", 123, true, 200);
+                }
+
+                // Assert
+                Assert.equal(20, trackStub.callCount, "Expected 20 invokations of trackAjax");
+            }
+        });
+
+
+        this.testCase({
+            name: "trackAjax - '-1' means no ajax per view limit",
+            test: () => {
+                var snippet = this.getAppInsightsSnippet();
+                snippet.maxAjaxCallsPerView = -1;
+                var appInsights = new Microsoft.ApplicationInsights.AppInsights(snippet);
+                var trackStub = this.sandbox.stub(appInsights.context, "track");
+                var ajaxCallsCount = 1000;
+
+                // Act
+                for (var i = 0; i < ajaxCallsCount; ++i) {
+                    appInsights.trackAjax("test", "http://asdf", 123, true, 200);
+                }
+
+                // Assert
+                Assert.equal(ajaxCallsCount, trackStub.callCount, "Expected " + ajaxCallsCount + " invokations of trackAjax (no limit)");
             }
         });
     }

--- a/JavaScript/JavaScriptSDK/AppInsights.ts
+++ b/JavaScript/JavaScriptSDK/AppInsights.ts
@@ -12,7 +12,7 @@ module Microsoft.ApplicationInsights {
 
     "use strict";
 
-    export var Version = "0.21.2";
+    export var Version = "0.21.3";
 
     export interface IConfig {
         instrumentationKey: string;

--- a/JavaScript/JavaScriptSDK/AppInsights.ts
+++ b/JavaScript/JavaScriptSDK/AppInsights.ts
@@ -12,7 +12,7 @@ module Microsoft.ApplicationInsights {
 
     "use strict";
 
-    export var Version = "0.21.3";
+    export var Version = "0.21.4";
 
     export interface IConfig {
         instrumentationKey: string;

--- a/JavaScript/JavaScriptSDK/Initialization.ts
+++ b/JavaScript/JavaScriptSDK/Initialization.ts
@@ -164,6 +164,8 @@ module Microsoft.ApplicationInsights {
                 Util.stringToBoolOrDefault(config.disableAjaxTracking) :
                 false;
 
+            config.maxAjaxCallsPerView = !isNaN(config.maxAjaxCallsPerView) ? config.maxAjaxCallsPerView : 20;
+
             return config;
         }
     }

--- a/JavaScript/JavaScriptSDK/Initialization.ts
+++ b/JavaScript/JavaScriptSDK/Initialization.ts
@@ -164,7 +164,7 @@ module Microsoft.ApplicationInsights {
                 Util.stringToBoolOrDefault(config.disableAjaxTracking) :
                 false;
 
-            config.maxAjaxCallsPerView = !isNaN(config.maxAjaxCallsPerView) ? config.maxAjaxCallsPerView : 20;
+            config.maxAjaxCallsPerView = !isNaN(config.maxAjaxCallsPerView) ? config.maxAjaxCallsPerView : 500;
 
             return config;
         }


### PR DESCRIPTION
75th percentile of our users have 15 ajaxes per page view. To prevent quota cap setting limit of ajaxes per view to 20.