### PR TITLE
Fix allows user to submit 0 custom duration

### DIFF
--- a/JavaScript/JavaScriptSDK/Telemetry/PageViewManager.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/PageViewManager.ts
@@ -63,7 +63,7 @@ module Microsoft.ApplicationInsights.Telemetry {
                 this.appInsights.sendPageViewInternal(
                     name,
                     url,
-                    duration ? duration : customDuration,
+                    !isNaN(duration) ? duration : customDuration,
                     properties,
                     measurements);
                 this.appInsights.flush();


### PR DESCRIPTION
Overriding duration with a duration of 0 will send page view with duration 0 now instead of the value of customDuration.