### PR TITLE
adding main to bower.json to help bower tools

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "applicationinsights-js",
-  "main": "dist/ai.js",
+  "main": "dist/ai.0.js",
   "version": "0.21.5",
   "homepage": "https://github.com/Microsoft/ApplicationInsights-JS",
   "authors": [

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
   "name": "applicationinsights-js",
+  "main": "dist/ai.js",
   "version": "0.21.5",
   "homepage": "https://github.com/Microsoft/ApplicationInsights-JS",
   "authors": [


### PR DESCRIPTION
It's common practice for third party tools to use the main object in bower.json to detect which are the distribution files. 

I encountered an issue where WireDep was not recognizing AppInsights #127, this fixes the problem.
