### PR TITLE
Client/server correlation

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Initialization.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Initialization.tests.ts
@@ -30,7 +30,8 @@ class InitializationTests extends TestClass {
             disableAjaxTracking: true,
             overridePageViewDuration: false,
             maxAjaxCallsPerView: 44,
-            disableDataLossAnalysis: true
+            disableDataLossAnalysis: true,
+            disableCorrelationHeaders: false
         };
 
         // set default values

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/RemoteDependency.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/RemoteDependency.tests.ts
@@ -5,6 +5,7 @@
 class RemoteDependencyTests extends ContractTestHelper {
 
     private exception;
+    private static id = "someid";
     private static name = "testName"
     private static url = "http://myurl.com"
     private static totalTime = 123;
@@ -14,7 +15,7 @@ class RemoteDependencyTests extends ContractTestHelper {
     constructor() {
         super(
             () => new Microsoft.ApplicationInsights.Telemetry.RemoteDependencyData(
-                RemoteDependencyTests.name, RemoteDependencyTests.url, RemoteDependencyTests.totalTime, RemoteDependencyTests.success, RemoteDependencyTests.resultCode),
+                RemoteDependencyTests.id, RemoteDependencyTests.name, RemoteDependencyTests.url, RemoteDependencyTests.totalTime, RemoteDependencyTests.success, RemoteDependencyTests.resultCode),
             "RemoteDependencyTelemetryTests");
     }
 
@@ -26,7 +27,7 @@ class RemoteDependencyTests extends ContractTestHelper {
             name: name + "Constructor parameters are set correctly",
             test: () => {
                 var telemetry = new Microsoft.ApplicationInsights.Telemetry.RemoteDependencyData(
-                    RemoteDependencyTests.name, RemoteDependencyTests.url, RemoteDependencyTests.totalTime, RemoteDependencyTests.success, RemoteDependencyTests.resultCode);
+                    RemoteDependencyTests.id, RemoteDependencyTests.name, RemoteDependencyTests.url, RemoteDependencyTests.totalTime, RemoteDependencyTests.success, RemoteDependencyTests.resultCode);
 
                 Assert.equal(RemoteDependencyTests.url, telemetry.commandName, "commandName should be set to url");
                 Assert.equal(RemoteDependencyTests.totalTime, telemetry.value, "value should be set correctly");
@@ -39,7 +40,7 @@ class RemoteDependencyTests extends ContractTestHelper {
         this.testCase({
             name: name + "default properties are set correctly",
             test: () => {
-                var telemetry = new Microsoft.ApplicationInsights.Telemetry.RemoteDependencyData("", "", 0, false, 0);
+                var telemetry = new Microsoft.ApplicationInsights.Telemetry.RemoteDependencyData("", "", "", 0, false, 0);
                 
                 Assert.equal(AI.DependencyKind.Http, telemetry.dependencyKind, "dependencyKind gets correct default value");
                 Assert.equal("Ajax", telemetry.dependencyTypeName, "dependencyTypeName gets correct default value");

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/ajax.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/ajax.tests.ts
@@ -4,7 +4,14 @@
 
 class AjaxTests extends TestClass {
 
-    private appInsightsMock = { trackAjax: (id: string, absoluteUrl: string, isAsync: boolean, totalTime: number, success: boolean) => { } }
+    private appInsightsMock = {
+        trackAjax: (id: string, absoluteUrl: string, isAsync: boolean, totalTime: number, success: boolean) => { },
+        context: {
+            operation: {
+                id: "asdf"                
+            }
+        }
+    }
     private trackAjaxSpy;
     private callbackSpy;
     private requests;

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/ajax.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/ajax.tests.ts
@@ -8,8 +8,11 @@ class AjaxTests extends TestClass {
         trackAjax: (id: string, absoluteUrl: string, isAsync: boolean, totalTime: number, success: boolean) => { },
         context: {
             operation: {
-                id: "asdf"                
+                id: "asdf"
             }
+        },
+        config: {
+            disableCorrelationHeaders: false
         }
     }
     private trackAjaxSpy;
@@ -237,7 +240,7 @@ class AjaxTests extends TestClass {
                 } finally {
                     window.performance = initialPerformance;
                 }
-             }
+            }
         });
 
         this.testCase({

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/ajax.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/ajax.tests.ts
@@ -4,7 +4,7 @@
 
 class AjaxTests extends TestClass {
 
-    private appInsightsMock = { trackAjax: (absoluteUrl: string, isAsync: boolean, totalTime: number, success: boolean) => { } }
+    private appInsightsMock = { trackAjax: (id: string, absoluteUrl: string, isAsync: boolean, totalTime: number, success: boolean) => { } }
     private trackAjaxSpy;
     private callbackSpy;
     private requests;
@@ -101,7 +101,7 @@ class AjaxTests extends TestClass {
                 (<any>xhr).respond(200, {}, "");
 
                 // Assert
-                Assert.equal(true, this.trackAjaxSpy.args[0][3], "TrackAjax should receive true as a 'success' argument");
+                Assert.equal(true, this.trackAjaxSpy.args[0][4], "TrackAjax should receive true as a 'success' argument");
 
             }
         });
@@ -120,7 +120,7 @@ class AjaxTests extends TestClass {
                 (<any>xhr).respond(404, {}, "");
 
                 // Assert
-                Assert.equal(false, this.trackAjaxSpy.args[0][3], "TrackAjax should receive false as a 'success' argument");
+                Assert.equal(false, this.trackAjaxSpy.args[0][4], "TrackAjax should receive false as a 'success' argument");
 
             }
         });
@@ -226,7 +226,7 @@ class AjaxTests extends TestClass {
 
                     // Assert
                     Assert.ok(this.trackAjaxSpy.calledOnce, "TrackAjax should be called");
-                    Assert.equal(expectedResponseDuration, this.trackAjaxSpy.args[0][2], "Ajax duration should match expected duration");
+                    Assert.equal(expectedResponseDuration, this.trackAjaxSpy.args[0][3], "Ajax duration should match expected duration");
                 } finally {
                     window.performance = initialPerformance;
                 }
@@ -287,7 +287,7 @@ class AjaxTests extends TestClass {
         (<any>xhr).respond(responseCode, {}, "");
 
         // Assert
-        Assert.equal(success, this.trackAjaxSpy.args[0][3], "TrackAjax should receive " + success + " as a 'success' argument");
+        Assert.equal(success, this.trackAjaxSpy.args[0][4], "TrackAjax should receive " + success + " as a 'success' argument");
     }
 }
 new AjaxTests().registerTests();

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -1738,6 +1738,7 @@ class AppInsightsTests extends TestClass {
             test: () => {
                 var snippet = this.getAppInsightsSnippet();
                 snippet.disableAjaxTracking = false;
+                snippet.disableCorrelationHeaders = false;
                 snippet.maxBatchInterval = 0;
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(snippet);
                 var trackStub = this.sandbox.spy(appInsights, "trackAjax");
@@ -1759,6 +1760,32 @@ class AppInsightsTests extends TestClass {
                 Assert.equal(expectedAjaxId, (<any>xhr).requestHeaders['x-ms-request-id'], "x-ms-request-id id set correctly");
                 Assert.equal(expectedRootId, (<any>xhr).requestHeaders['x-ms-request-root-id'], "x-ms-request-root-id set correctly");
                 Assert.equal(expectedAjaxId, trackStub.args[0][0], "ajax id passed to trackAjax correctly");
+            }
+        });
+
+        this.testCase({
+            name: "Ajax - disableCorrelationHeaders disables x-ms-request-id headers",
+            test: () => {
+                var snippet = this.getAppInsightsSnippet();
+                snippet.disableAjaxTracking = false;
+                snippet.disableCorrelationHeaders = true;
+                snippet.maxBatchInterval = 0;
+                var appInsights = new Microsoft.ApplicationInsights.AppInsights(snippet);
+                var trackStub = this.sandbox.spy(appInsights, "trackAjax");
+                var expectedRootId = appInsights.context.operation.id;
+                Assert.ok(expectedRootId.length > 0, "root id was initialized to non empty string");
+                
+                // Act
+                var xhr = new XMLHttpRequest();
+                xhr.open("GET", "/bla");
+                xhr.send();
+                                
+                // Emulate response                               
+                (<any>xhr).respond("200", {}, "");
+
+                // Assert
+                Assert.equal(null, (<any>xhr).requestHeaders['x-ms-request-id'], "x-ms-request-id should not be set");
+                Assert.equal(null, (<any>xhr).requestHeaders['x-ms-request-root-id'], "x-ms-request-root-id should not be set");
             }
         });
     }

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -1614,7 +1614,7 @@ class AppInsightsTests extends TestClass {
                 var resultCode = 404;
 
                 // Act
-                appInsights.trackAjax(name, url, duration, success, resultCode);
+                appInsights.trackAjax("0", name, url, duration, success, resultCode);
 
                 // Assert
                 Assert.ok(trackStub.called, "Track should be called");
@@ -1638,7 +1638,7 @@ class AppInsightsTests extends TestClass {
                 var expectedEnvelopeName = "Microsoft.ApplicationInsights.BDC8736DD8E84B69B19BB0CE6B66A456.RemoteDependency";
 
                 // Act
-                appInsights.trackAjax("test", "http://asdf", 123, true, 200);
+                appInsights.trackAjax("0", "test", "http://asdf", 123, true, 200);
 
                 // Assert
                 Assert.ok(trackStub.called, "Track should be called");
@@ -1656,7 +1656,7 @@ class AppInsightsTests extends TestClass {
 
                 // Act
                 for (var i = 0; i < 100; ++i) {
-                    appInsights.trackAjax("test", "http://asdf", 123, true, 200);
+                    appInsights.trackAjax("0", "test", "http://asdf", 123, true, 200);
                 }
 
                 // Assert
@@ -1673,14 +1673,14 @@ class AppInsightsTests extends TestClass {
 
                 // Act
                 for (var i = 0; i < 100; ++i) {
-                    appInsights.trackAjax("test", "http://asdf", 123, true, 200);
+                    appInsights.trackAjax("0", "test", "http://asdf", 123, true, 200);
                 }
 
                 appInsights.sendPageViewInternal("asdf", "http://microsoft.com", 123);
                 trackStub.reset();
 
                 for (var i = 0; i < 100; ++i) {
-                    appInsights.trackAjax("test", "http://asdf", 123, true, 200);
+                    appInsights.trackAjax("0", "test", "http://asdf", 123, true, 200);
                 }
 
                 // Assert
@@ -1698,13 +1698,13 @@ class AppInsightsTests extends TestClass {
 
                 // Act
                 for (var i = 0; i < 20; ++i) {
-                    appInsights.trackAjax("test", "http://asdf", 123, true, 200);
+                    appInsights.trackAjax("0", "test", "http://asdf", 123, true, 200);
                 }
                 
                 loggingSpy.reset();
 
                 for (var i = 0; i < 100; ++i) {
-                    appInsights.trackAjax("test", "http://asdf", 123, true, 200);
+                    appInsights.trackAjax("0", "test", "http://asdf", 123, true, 200);
                 }
 
                 // Assert
@@ -1724,11 +1724,35 @@ class AppInsightsTests extends TestClass {
 
                 // Act
                 for (var i = 0; i < ajaxCallsCount; ++i) {
-                    appInsights.trackAjax("test", "http://asdf", 123, true, 200);
+                    appInsights.trackAjax("0", "test", "http://asdf", 123, true, 200);
                 }
 
                 // Assert
                 Assert.equal(ajaxCallsCount, trackStub.callCount, "Expected " + ajaxCallsCount + " invokations of trackAjax (no limit)");
+            }
+        });
+        
+        this.testCase({
+            name: "Ajax - root/parent id are set and passed correctly",
+            test: () => {
+                var snippet = this.getAppInsightsSnippet();
+                snippet.disableAjaxTracking = false;
+                snippet.maxBatchInterval = 0;
+                var appInsights = new Microsoft.ApplicationInsights.AppInsights(snippet);
+                var trackStub = this.sandbox.spy(appInsights.context, "track");
+                var expectedRootId = appInsights.context.operation.id;
+                Assert.ok(expectedRootId.length > 0, "root id was initialized to non empty string");
+                
+                // Act
+                var xhr = new XMLHttpRequest();
+                xhr.open("GET", "/bla");
+                xhr.send();
+                
+                // Emulate response                
+                (<any>xhr).respond("200", {}, "");
+
+                // Assert
+                
             }
         });
     }

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -24,7 +24,8 @@ class AppInsightsTests extends TestClass {
             disableAjaxTracking: true,
             overridePageViewDuration: false,
             maxAjaxCallsPerView: 20,
-            disableDataLossAnalysis: true
+            disableDataLossAnalysis: true,
+            disableCorrelationHeaders: false
         };
 
         // set default values

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -1739,7 +1739,7 @@ class AppInsightsTests extends TestClass {
                 snippet.disableAjaxTracking = false;
                 snippet.maxBatchInterval = 0;
                 var appInsights = new Microsoft.ApplicationInsights.AppInsights(snippet);
-                var trackStub = this.sandbox.spy(appInsights.context, "track");
+                var trackStub = this.sandbox.spy(appInsights, "trackAjax");
                 var expectedRootId = appInsights.context.operation.id;
                 Assert.ok(expectedRootId.length > 0, "root id was initialized to non empty string");
                 
@@ -1747,12 +1747,17 @@ class AppInsightsTests extends TestClass {
                 var xhr = new XMLHttpRequest();
                 xhr.open("GET", "/bla");
                 xhr.send();
+
+                var expectedAjaxId = (<any>xhr).ajaxData.id;
+                Assert.ok(expectedAjaxId.length > 0, "ajax id was initialized");
                 
-                // Emulate response                
+                // Emulate response                               
                 (<any>xhr).respond("200", {}, "");
 
                 // Assert
-                
+                Assert.equal(expectedAjaxId, (<any>xhr).requestHeaders['x-ms-request-id'], "x-ms-request-id id set correctly");
+                Assert.equal(expectedRootId, (<any>xhr).requestHeaders['x-ms-request-root-id'], "x-ms-request-root-id set correctly");
+                Assert.equal(expectedAjaxId, trackStub.args[0][0], "ajax id passed to trackAjax correctly");
             }
         });
     }

--- a/JavaScript/JavaScriptSDK/AppInsights.ts
+++ b/JavaScript/JavaScriptSDK/AppInsights.ts
@@ -36,6 +36,7 @@ module Microsoft.ApplicationInsights {
         overridePageViewDuration: boolean;
         maxAjaxCallsPerView: number;
         disableDataLossAnalysis: boolean;
+        disableCorrelationHeaders: boolean;
     }
 
     /**

--- a/JavaScript/JavaScriptSDK/AppInsights.ts
+++ b/JavaScript/JavaScriptSDK/AppInsights.ts
@@ -267,10 +267,10 @@ module Microsoft.ApplicationInsights {
             }
         }
 
-        public trackAjax(absoluteUrl: string, pathName: string, totalTime: number, success: boolean, resultCode: number) {
+        public trackAjax(id: string, absoluteUrl: string, pathName: string, totalTime: number, success: boolean, resultCode: number) {
             if (this.config.maxAjaxCallsPerView === -1 ||
                 this._trackAjaxAttempts < this.config.maxAjaxCallsPerView) {
-                var dependency = new Telemetry.RemoteDependencyData(absoluteUrl, pathName, totalTime, success, resultCode);
+                var dependency = new Telemetry.RemoteDependencyData(id, absoluteUrl, pathName, totalTime, success, resultCode);
                 var dependencyData = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.RemoteDependencyData>(
                     Telemetry.RemoteDependencyData.dataType, dependency);
                 var envelope = new Telemetry.Common.Envelope(dependencyData, "Microsoft.ApplicationInsights." + this.config.instrumentationKey.replace(/-/g, "") + ".RemoteDependency");

--- a/JavaScript/JavaScriptSDK/Initialization.ts
+++ b/JavaScript/JavaScriptSDK/Initialization.ts
@@ -172,6 +172,10 @@ module Microsoft.ApplicationInsights {
                 false;
 
             config.maxAjaxCallsPerView = !isNaN(config.maxAjaxCallsPerView) ? config.maxAjaxCallsPerView : 500;
+
+            config.disableCorrelationHeaders = (config.disableCorrelationHeaders !== undefined && config.disableCorrelationHeaders !== null) ?
+                Util.stringToBoolOrDefault(config.disableCorrelationHeaders) :
+                true;
             
             return config;
         }

--- a/JavaScript/JavaScriptSDK/Telemetry/RemoteDependencyData.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/RemoteDependencyData.ts
@@ -11,6 +11,7 @@ module Microsoft.ApplicationInsights.Telemetry {
         public static dataType = "RemoteDependencyData";
 
         public aiDataContract = {
+            id: FieldType.Required,
             ver: FieldType.Required,
             name: FieldType.Default,
             kind: FieldType.Required,
@@ -32,9 +33,10 @@ module Microsoft.ApplicationInsights.Telemetry {
         /**
          * Constructs a new instance of the RemoteDependencyData object
          */
-        constructor(name: string, commandName: string, value: number, success: boolean, resultCode: number) {
+        constructor(id: string, name: string, commandName: string, value: number, success: boolean, resultCode: number) {
             super();
 
+            this.id = id;
             this.name = name;
             this.commandName = commandName;
             this.value = value;

--- a/JavaScript/JavaScriptSDK/ajax/ajax.ts
+++ b/JavaScript/JavaScriptSDK/ajax/ajax.ts
@@ -88,7 +88,7 @@ module Microsoft.ApplicationInsights {
         }
 
         private openHandler(xhr: XMLHttpRequestInstrumented, method, url, async) {
-            var ajaxData = new ajaxRecord();
+            var ajaxData = new ajaxRecord(Util.newId());
             ajaxData.method = method;
             ajaxData.requestUrl = url;
             ajaxData.xhrMonitoringState.openDone = true
@@ -194,6 +194,7 @@ module Microsoft.ApplicationInsights {
             }
             else {
                 this.appInsights.trackAjax(
+                    xhr.ajaxData.id,
                     xhr.ajaxData.getAbsoluteUrl(),
                     xhr.ajaxData.getPathName(),
                     xhr.ajaxData.ajaxTotalDuration,

--- a/JavaScript/JavaScriptSDK/ajax/ajax.ts
+++ b/JavaScript/JavaScriptSDK/ajax/ajax.ts
@@ -135,7 +135,7 @@ module Microsoft.ApplicationInsights {
 
         private sendHandler(xhr: XMLHttpRequestInstrumented, content) {
             xhr.ajaxData.requestSentTime = dateTime.Now();
-            if (UrlHelper.parseUrl(xhr.ajaxData.getAbsoluteUrl()).host == this.currentWindowHost) {
+            if (!this.appInsights.config.disableCorrelationHeaders && (UrlHelper.parseUrl(xhr.ajaxData.getAbsoluteUrl()).host == this.currentWindowHost)) {
                 xhr.setRequestHeader("x-ms-request-root-id", this.appInsights.context.operation.id);
                 xhr.setRequestHeader("x-ms-request-id", xhr.ajaxData.id);
             }

--- a/JavaScript/JavaScriptSDK/ajax/ajaxRecord.ts
+++ b/JavaScript/JavaScriptSDK/ajax/ajaxRecord.ts
@@ -54,6 +54,14 @@ module Microsoft.ApplicationInsights {
         //<summary>Determines whether or not JavaScript exception occured in xhr.onreadystatechange code. 1 if occured, otherwise 0.</summary>
         public clientFailure = 0;
 
+
+        public id: string;
+
+        constructor(id: string) {
+            this.id = id;
+        }
+
+
         public getAbsoluteUrl() {
             return this.requestUrl ? UrlHelper.getAbsoluteUrl(this.requestUrl) : null;
         }


### PR DESCRIPTION
In this PR - setting x-ms-request-id and x-ms-root-id headers to each ajax call. 
Applies on to ajax calls to the same host to prevent CORS issues.
Making sure ajax telemetry gets correct ctx.id, ctx.parentid and rdd.id.

Assumptions: 
- in current implementation a page is considered a root (we might implement request to page relationship later). 
- Therefore ctx.id (root id) equals ctx.parentid  
- Dependency.ctx.parentid equals ctx.id (root id) (and equals ctx.parentid)