### PR TITLE
Test getting sessionStorage in case private browsing throws an error

### DIFF
--- a/JavaScript/JavaScriptSDK/Util.ts
+++ b/JavaScript/JavaScriptSDK/Util.ts
@@ -110,6 +110,8 @@ module Microsoft.ApplicationInsights {
         private static _getSessionStorageObject(): Storage {
             try {
                 if (window.sessionStorage) {
+                    // Test getting items in case private browsing throws an error.
+                    window.sessionStorage.getItem('');
                     return window.sessionStorage;
                 } else {
                     return null;


### PR DESCRIPTION
Issue #144 details how Private browsing in iOS Safari causes the page to crash due to an infinite loop of console warnings due to session storage being inaccessible.

This PR fixes the issue by adding an additional check to the code that validates whether the `sessionStorage` object is available. 

Private browsing in iOS Safari does provide a sessionStorage object, but it throws an error when getting or setting an item. Therefore the current availability check isn't sufficient.

By getting the empty string key during the validation, it would cause an error to throw, which is caught by the existing try/catch that detects whether session storage is available. The getter would otherwise return null or the value for the empty string key (shortest), which is unlikely to be defined.

I was unable to run the unit tests locally. No tests are detected when I run the PS script.