### PR TITLE
Switch to disable 'house keeping'

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Initialization.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Initialization.tests.ts
@@ -30,7 +30,8 @@ class InitializationTests extends TestClass {
             overridePageViewDuration: false,
             maxAjaxCallsPerView: 44,
             disableDataLossAnalysis: true,
-            disableCorrelationHeaders: false
+            disableCorrelationHeaders: false,
+            disableFlushOnBeforeUnload: false
         };
 
         // set default values
@@ -256,6 +257,28 @@ class InitializationTests extends TestClass {
                 Assert.ok(addEventHandlerStub.calledOnce);
                 Assert.equal(addEventHandlerStub.getCall(0).args[0], 'beforeunload');
                 Assert.ok(addEventHandlerStub.getCall(0).args[1] !== undefined, 'addEventHandler was called with undefined callback');
+            }
+        });
+
+        this.testCase({
+            name: "InitializationTests: disableFlushOnBeforeUnload switch works",
+            test: () => {
+                // Assemble
+                var userConfig = this.getAppInsightsSnippet();
+                userConfig.disableFlushOnBeforeUnload = true;
+                var snippet = <Microsoft.ApplicationInsights.Snippet>{
+                    config: userConfig,
+                    queue: []
+                };
+                var addEventHandlerStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, 'addEventHandler').returns(true);
+                var init = new Microsoft.ApplicationInsights.Initialization(snippet);
+                var appInsightsLocal = init.loadAppInsights();
+                
+                // Act
+                init.addHousekeepingBeforeUnload(appInsightsLocal);
+                
+                // Assert
+                Assert.ok(addEventHandlerStub.notCalled);                
             }
         });
     }

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -24,7 +24,8 @@ class AppInsightsTests extends TestClass {
             overridePageViewDuration: false,
             maxAjaxCallsPerView: 20,
             disableDataLossAnalysis: true,
-            disableCorrelationHeaders: false
+            disableCorrelationHeaders: false,
+            disableFlushOnBeforeUnload: false
         };
 
         // set default values

--- a/JavaScript/JavaScriptSDK/AppInsights.ts
+++ b/JavaScript/JavaScriptSDK/AppInsights.ts
@@ -36,6 +36,7 @@ module Microsoft.ApplicationInsights {
         maxAjaxCallsPerView: number;
         disableDataLossAnalysis: boolean;
         disableCorrelationHeaders: boolean;
+        disableFlushOnBeforeUnload: boolean;
     }
 
     /**

--- a/JavaScript/JavaScriptSDK/Initialization.ts
+++ b/JavaScript/JavaScriptSDK/Initialization.ts
@@ -114,7 +114,7 @@ module Microsoft.ApplicationInsights {
         public addHousekeepingBeforeUnload(appInsightsInstance: AppInsights): void {
             // Add callback to push events when the user navigates away
 
-            if ('onbeforeunload' in window) {
+            if (!appInsightsInstance.config.disableFlushOnBeforeUnload && ('onbeforeunload' in window)) {
                 var performHousekeeping = function () {
                     // Adds the ability to flush all data before the page unloads.
                     // Note: This approach tries to push an async request with all the pending events onbeforeunload.
@@ -170,6 +170,10 @@ module Microsoft.ApplicationInsights {
             config.disableCorrelationHeaders = (config.disableCorrelationHeaders !== undefined && config.disableCorrelationHeaders !== null) ?
                 Util.stringToBoolOrDefault(config.disableCorrelationHeaders) :
                 true;
+
+            config.disableFlushOnBeforeUnload = (config.disableFlushOnBeforeUnload !== undefined && config.disableFlushOnBeforeUnload !== null) ?
+                Util.stringToBoolOrDefault(config.disableFlushOnBeforeUnload) :
+                false;
            
             return config;
         }


### PR DESCRIPTION
Disables housekeeping in window.onBeforeUnload. In some cases IE throws an error when you try to send ajax request on beforeunload. The flag 'disableFlushOnBeforeUnload' is intended to help users cope with errors they get in this case.