### PR TITLE
Set exception method to "<no_method>" if it's empty

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Initialization.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Initialization.tests.ts
@@ -30,7 +30,8 @@ class InitializationTests extends TestClass {
             overridePageViewDuration: false,
             maxAjaxCallsPerView: 44,
             disableDataLossAnalysis: true,
-            disableCorrelationHeaders: false
+            disableCorrelationHeaders: false,
+            disableFlushOnBeforeUnload: false
         };
 
         // set default values
@@ -256,6 +257,28 @@ class InitializationTests extends TestClass {
                 Assert.ok(addEventHandlerStub.calledOnce);
                 Assert.equal(addEventHandlerStub.getCall(0).args[0], 'beforeunload');
                 Assert.ok(addEventHandlerStub.getCall(0).args[1] !== undefined, 'addEventHandler was called with undefined callback');
+            }
+        });
+
+        this.testCase({
+            name: "InitializationTests: disableFlushOnBeforeUnload switch works",
+            test: () => {
+                // Assemble
+                var userConfig = this.getAppInsightsSnippet();
+                userConfig.disableFlushOnBeforeUnload = true;
+                var snippet = <Microsoft.ApplicationInsights.Snippet>{
+                    config: userConfig,
+                    queue: []
+                };
+                var addEventHandlerStub = this.sandbox.stub(Microsoft.ApplicationInsights.Util, 'addEventHandler').returns(true);
+                var init = new Microsoft.ApplicationInsights.Initialization(snippet);
+                var appInsightsLocal = init.loadAppInsights();
+                
+                // Act
+                init.addHousekeepingBeforeUnload(appInsightsLocal);
+                
+                // Assert
+                Assert.ok(addEventHandlerStub.notCalled);                
             }
         });
     }

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/Exception.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/Exception.tests.ts
@@ -184,6 +184,17 @@ Error: testmessage2\n\
                 Assert.equal(expectedHandledAt, actual.handledAt);
             }
         });
+
+        this.testCase({
+            name: "Stack trace with no method serializes as <no_method>",
+            test: () => {
+                // Act
+                var sut = new Microsoft.ApplicationInsights.Telemetry._StackFrame("    at http://myScript.js:40:50", 1);
+
+                // Verify
+                Assert.equal("<no_method>", sut.method);
+            }
+        });
     }
 }
 new ExceptionTelemetryTests().registerTests();

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -24,7 +24,8 @@ class AppInsightsTests extends TestClass {
             overridePageViewDuration: false,
             maxAjaxCallsPerView: 20,
             disableDataLossAnalysis: true,
-            disableCorrelationHeaders: false
+            disableCorrelationHeaders: false,
+            disableFlushOnBeforeUnload: false
         };
 
         // set default values

--- a/JavaScript/JavaScriptSDK/AppInsights.ts
+++ b/JavaScript/JavaScriptSDK/AppInsights.ts
@@ -36,6 +36,7 @@ module Microsoft.ApplicationInsights {
         maxAjaxCallsPerView: number;
         disableDataLossAnalysis: boolean;
         disableCorrelationHeaders: boolean;
+        disableFlushOnBeforeUnload: boolean;
     }
 
     /**

--- a/JavaScript/JavaScriptSDK/Initialization.ts
+++ b/JavaScript/JavaScriptSDK/Initialization.ts
@@ -114,7 +114,7 @@ module Microsoft.ApplicationInsights {
         public addHousekeepingBeforeUnload(appInsightsInstance: AppInsights): void {
             // Add callback to push events when the user navigates away
 
-            if ('onbeforeunload' in window) {
+            if (!appInsightsInstance.config.disableFlushOnBeforeUnload && ('onbeforeunload' in window)) {
                 var performHousekeeping = function () {
                     // Adds the ability to flush all data before the page unloads.
                     // Note: This approach tries to push an async request with all the pending events onbeforeunload.
@@ -170,6 +170,10 @@ module Microsoft.ApplicationInsights {
             config.disableCorrelationHeaders = (config.disableCorrelationHeaders !== undefined && config.disableCorrelationHeaders !== null) ?
                 Util.stringToBoolOrDefault(config.disableCorrelationHeaders) :
                 true;
+
+            config.disableFlushOnBeforeUnload = (config.disableFlushOnBeforeUnload !== undefined && config.disableFlushOnBeforeUnload !== null) ?
+                Util.stringToBoolOrDefault(config.disableFlushOnBeforeUnload) :
+                false;
            
             return config;
         }

--- a/JavaScript/JavaScriptSDK/Telemetry/Exception.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/Exception.ts
@@ -140,7 +140,7 @@ module Microsoft.ApplicationInsights.Telemetry {
         }
     }
 
-    class _StackFrame extends AI.StackFrame implements ISerializable {
+    export class _StackFrame extends AI.StackFrame implements ISerializable {
         
         // regex to match stack frames from ie/chrome/ff
         // methodName=$2, fileName=$4, lineNo=$5, column=$6
@@ -159,11 +159,11 @@ module Microsoft.ApplicationInsights.Telemetry {
         constructor(frame: string, level: number) {
             super();
             this.level = level;
-            this.method = "unavailable";
+            this.method = "<no_method>";
             this.assembly = Util.trim(frame);
             var matches = frame.match(_StackFrame.regex);
             if (matches && matches.length >= 5) {
-                this.method = Util.trim(matches[2]);
+                this.method = Util.trim(matches[2]) || this.method;
                 this.fileName = Util.trim(matches[4]);
                 this.line = parseInt(matches[5]) || 0;
             }


### PR DESCRIPTION
Our backend rejects empty methods on exception stack. 