### PR TITLE
Log verb as part of dependency name

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/RemoteDependency.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/RemoteDependency.tests.ts
@@ -6,6 +6,7 @@ class RemoteDependencyTests extends ContractTestHelper {
 
     private exception;
     private static id = "someid";
+    private static metod = "GET";
     private static name = "testName"
     private static url = "http://myurl.com"
     private static totalTime = 123;
@@ -15,7 +16,7 @@ class RemoteDependencyTests extends ContractTestHelper {
     constructor() {
         super(
             () => new Microsoft.ApplicationInsights.Telemetry.RemoteDependencyData(
-                RemoteDependencyTests.id, RemoteDependencyTests.name, RemoteDependencyTests.url, RemoteDependencyTests.totalTime, RemoteDependencyTests.success, RemoteDependencyTests.resultCode),
+                RemoteDependencyTests.id, RemoteDependencyTests.name, RemoteDependencyTests.url, RemoteDependencyTests.totalTime, RemoteDependencyTests.success, RemoteDependencyTests.resultCode, RemoteDependencyTests.metod),
             "RemoteDependencyTelemetryTests");
     }
 
@@ -27,13 +28,13 @@ class RemoteDependencyTests extends ContractTestHelper {
             name: name + "Constructor parameters are set correctly",
             test: () => {
                 var telemetry = new Microsoft.ApplicationInsights.Telemetry.RemoteDependencyData(
-                    RemoteDependencyTests.id, RemoteDependencyTests.name, RemoteDependencyTests.url, RemoteDependencyTests.totalTime, RemoteDependencyTests.success, RemoteDependencyTests.resultCode);
+                    RemoteDependencyTests.id, RemoteDependencyTests.name, RemoteDependencyTests.url, RemoteDependencyTests.totalTime, RemoteDependencyTests.success, RemoteDependencyTests.resultCode, RemoteDependencyTests.metod);
 
                 Assert.equal(RemoteDependencyTests.url, telemetry.commandName, "commandName should be set to url");
                 Assert.equal(RemoteDependencyTests.totalTime, telemetry.value, "value should be set correctly");
                 Assert.equal(RemoteDependencyTests.success, telemetry.success, "success should be set correctly");
                 Assert.equal(RemoteDependencyTests.resultCode, telemetry.resultCode, "resultCode should be set correctly");
-                Assert.equal(RemoteDependencyTests.name, telemetry.name, "name gets correct value");
+                Assert.equal(RemoteDependencyTests.metod + " " + RemoteDependencyTests.name, telemetry.name, "name gets correct value");
             }
         });
 
@@ -47,7 +48,7 @@ class RemoteDependencyTests extends ContractTestHelper {
                 }
 
                 var telemetry = new Microsoft.ApplicationInsights.Telemetry.RemoteDependencyData(
-                    RemoteDependencyTests.id, RemoteDependencyTests.name, longUrl, RemoteDependencyTests.totalTime, RemoteDependencyTests.success, RemoteDependencyTests.resultCode);
+                    RemoteDependencyTests.id, RemoteDependencyTests.name, longUrl, RemoteDependencyTests.totalTime, RemoteDependencyTests.success, RemoteDependencyTests.resultCode, RemoteDependencyTests.metod);
 
                 Assert.equal(2048, telemetry.commandName.length, "commandName should be truncated");
             }
@@ -56,10 +57,11 @@ class RemoteDependencyTests extends ContractTestHelper {
         this.testCase({
             name: name + "default properties are set correctly",
             test: () => {
-                var telemetry = new Microsoft.ApplicationInsights.Telemetry.RemoteDependencyData("", "", "", 0, false, 0);
+                var telemetry = new Microsoft.ApplicationInsights.Telemetry.RemoteDependencyData("", "", "", 0, false, 0, null);
                 
                 Assert.equal(AI.DependencyKind.Http, telemetry.dependencyKind, "dependencyKind gets correct default value");
                 Assert.equal("Ajax", telemetry.dependencyTypeName, "dependencyTypeName gets correct default value");
+                Assert.equal("", telemetry.name, "name gets correct default value");
             }
         });
     }

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/appInsights.tests.ts
@@ -1556,12 +1556,12 @@ class AppInsightsTests extends TestClass {
                 var resultCode = 404;
 
                 // Act
-                appInsights.trackAjax("0", name, url, duration, success, resultCode);
+                appInsights.trackAjax("0", name, url, duration, success, resultCode, "Get");
 
                 // Assert
                 Assert.ok(trackStub.called, "Track should be called");
                 var rdd = <Microsoft.ApplicationInsights.Telemetry.RemoteDependencyData>(<any>trackStub.args[0][0]).data.baseData;
-                Assert.equal(name, rdd.name);
+                Assert.equal("GET " + name, rdd.name);
                 Assert.equal(url, rdd.commandName);
                 Assert.equal(duration, rdd.value);
                 Assert.equal(success, rdd.success);
@@ -1591,7 +1591,7 @@ class AppInsightsTests extends TestClass {
                 };
 
                 // act
-                test(() => appInsights.trackAjax("0", "test", "http://asdf", 123, true, 200), Microsoft.ApplicationInsights.Telemetry.RemoteDependencyData.envelopeType,
+                test(() => appInsights.trackAjax("0", "test", "http://asdf", 123, true, 200, "GET"), Microsoft.ApplicationInsights.Telemetry.RemoteDependencyData.envelopeType,
                     Microsoft.ApplicationInsights.Telemetry.RemoteDependencyData.dataType);
             }
         });
@@ -1605,7 +1605,7 @@ class AppInsightsTests extends TestClass {
 
                 // Act
                 for (var i = 0; i < 100; ++i) {
-                    appInsights.trackAjax("0", "test", "http://asdf", 123, true, 200);
+                    appInsights.trackAjax("0", "test", "http://asdf", 123, true, 200, "GET");
                 }
 
                 // Assert
@@ -1622,14 +1622,14 @@ class AppInsightsTests extends TestClass {
 
                 // Act
                 for (var i = 0; i < 100; ++i) {
-                    appInsights.trackAjax("0", "test", "http://asdf", 123, true, 200);
+                    appInsights.trackAjax("0", "test", "http://asdf", 123, true, 200, "POST");
                 }
 
                 appInsights.sendPageViewInternal("asdf", "http://microsoft.com", 123);
                 trackStub.reset();
 
                 for (var i = 0; i < 100; ++i) {
-                    appInsights.trackAjax("0", "test", "http://asdf", 123, true, 200);
+                    appInsights.trackAjax("0", "test", "http://asdf", 123, true, 200, "POST");
                 }
 
                 // Assert
@@ -1647,13 +1647,13 @@ class AppInsightsTests extends TestClass {
 
                 // Act
                 for (var i = 0; i < 20; ++i) {
-                    appInsights.trackAjax("0", "test", "http://asdf", 123, true, 200);
+                    appInsights.trackAjax("0", "test", "http://asdf", 123, true, 200, "POST");
                 }
                 
                 loggingSpy.reset();
 
                 for (var i = 0; i < 100; ++i) {
-                    appInsights.trackAjax("0", "test", "http://asdf", 123, true, 200);
+                    appInsights.trackAjax("0", "test", "http://asdf", 123, true, 200, "POST");
                 }
 
                 // Assert
@@ -1673,7 +1673,7 @@ class AppInsightsTests extends TestClass {
 
                 // Act
                 for (var i = 0; i < ajaxCallsCount; ++i) {
-                    appInsights.trackAjax("0", "test", "http://asdf", 123, true, 200);
+                    appInsights.trackAjax("0", "test", "http://asdf", 123, true, 200, "POST");
                 }
 
                 // Assert

--- a/JavaScript/JavaScriptSDK/AppInsights.ts
+++ b/JavaScript/JavaScriptSDK/AppInsights.ts
@@ -275,10 +275,10 @@ module Microsoft.ApplicationInsights {
             }
         }
 
-        public trackAjax(id: string, absoluteUrl: string, pathName: string, totalTime: number, success: boolean, resultCode: number) {
+        public trackAjax(id: string, absoluteUrl: string, pathName: string, totalTime: number, success: boolean, resultCode: number, method?: string) {
             if (this.config.maxAjaxCallsPerView === -1 ||
                 this._trackAjaxAttempts < this.config.maxAjaxCallsPerView) {
-                var dependency = new Telemetry.RemoteDependencyData(id, absoluteUrl, pathName, totalTime, success, resultCode);
+                var dependency = new Telemetry.RemoteDependencyData(id, absoluteUrl, pathName, totalTime, success, resultCode, method);
                 var dependencyData = new ApplicationInsights.Telemetry.Common.Data<ApplicationInsights.Telemetry.RemoteDependencyData>(
                     Telemetry.RemoteDependencyData.dataType, dependency);
                 var envelope = new Telemetry.Common.Envelope(dependencyData, ApplicationInsights.Telemetry.RemoteDependencyData.envelopeType);

--- a/JavaScript/JavaScriptSDK/Telemetry/RemoteDependencyData.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/RemoteDependencyData.ts
@@ -33,11 +33,11 @@ module Microsoft.ApplicationInsights.Telemetry {
         /**
          * Constructs a new instance of the RemoteDependencyData object
          */
-        constructor(id: string, name: string, commandName: string, value: number, success: boolean, resultCode: number) {
+        constructor(id: string, absoluteUrl: string, commandName: string, value: number, success: boolean, resultCode: number, method?: string) {
             super();
 
             this.id = id;
-            this.name = name;
+            this.name = this.formatDependencyName(method, absoluteUrl);
             this.commandName = Common.DataSanitizer.sanitizeUrl(commandName);
             this.value = value;
             this.success = success;  
@@ -45,6 +45,14 @@ module Microsoft.ApplicationInsights.Telemetry {
                       
             this.dependencyKind = AI.DependencyKind.Http;
             this.dependencyTypeName = "Ajax";
+        }
+
+        private formatDependencyName(method: string, absoluteUrl: string) {
+            if (method) {
+                return method.toUpperCase() + " " + absoluteUrl;
+            } else {
+                return absoluteUrl;
+            }
         }
     }
 }

--- a/JavaScript/JavaScriptSDK/ajax/ajax.ts
+++ b/JavaScript/JavaScriptSDK/ajax/ajax.ts
@@ -209,7 +209,8 @@ module Microsoft.ApplicationInsights {
                     xhr.ajaxData.getPathName(),
                     xhr.ajaxData.ajaxTotalDuration,
                     (+(xhr.ajaxData.status)) >= 200 && (+(xhr.ajaxData.status)) < 400,
-                    +xhr.ajaxData.status
+                    +xhr.ajaxData.status,
+                    xhr.ajaxData.method
                 );
 
                 xhr.ajaxData = null;


### PR DESCRIPTION
The `trackAjax` function is public so I added `method` (verb) as an optional parameter. This way it won't affect existing customer. If the value is null only the absolute URL will be used. 

The verb isn't exposed in the UI yet, but it is accessible through Application Analytic. 