### PR TITLE
Required field is set to not_specified if value is missing

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/DataSanitizer.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/DataSanitizer.tests.ts
@@ -170,6 +170,14 @@ class DataSanitizerTests extends TestClass {
                 Assert.equal("val", actual["prop2"]);
             }
         });
+
+        this.testCase({
+            name: "DataSanitizerTests: Validate sanitizeString handles null and undefined",
+            test: () => {
+                Assert.ok(null === Microsoft.ApplicationInsights.Telemetry.Common.DataSanitizer.sanitizeString(null));
+                Assert.ok(undefined === Microsoft.ApplicationInsights.Telemetry.Common.DataSanitizer.sanitizeString(undefined));
+            }
+        });
     }
 }
 

--- a/JavaScript/JavaScriptSDK/Telemetry/Common/Envelope.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/Common/Envelope.ts
@@ -17,7 +17,7 @@ module Microsoft.ApplicationInsights.Telemetry.Common {
         constructor(data: Microsoft.Telemetry.Base, name: string) {
             super();
 
-            this.name = name || Util.NotSpecified;
+            this.name = Common.DataSanitizer.sanitizeString(name) || Util.NotSpecified;
             this.data = data;
             this.time = Util.toISOStringForIE8(new Date());
 

--- a/JavaScript/JavaScriptSDK/Telemetry/Common/Envelope.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/Common/Envelope.ts
@@ -17,7 +17,7 @@ module Microsoft.ApplicationInsights.Telemetry.Common {
         constructor(data: Microsoft.Telemetry.Base, name: string) {
             super();
 
-            this.name = name;
+            this.name = name || Util.NotSpecified;
             this.data = data;
             this.time = Util.toISOStringForIE8(new Date());
 

--- a/JavaScript/JavaScriptSDK/Telemetry/Event.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/Event.ts
@@ -23,7 +23,7 @@ module Microsoft.ApplicationInsights.Telemetry {
             
             super();
 
-            this.name = ApplicationInsights.Telemetry.Common.DataSanitizer.sanitizeString(name);
+            this.name = ApplicationInsights.Telemetry.Common.DataSanitizer.sanitizeString(name) || Util.NotSpecified;
             this.properties = ApplicationInsights.Telemetry.Common.DataSanitizer.sanitizeProperties(properties);
             this.measurements = ApplicationInsights.Telemetry.Common.DataSanitizer.sanitizeMeasurements(measurements);
         }

--- a/JavaScript/JavaScriptSDK/Telemetry/Exception.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/Exception.ts
@@ -77,8 +77,8 @@ module Microsoft.ApplicationInsights.Telemetry {
 
         constructor(exception: Error) {
             super();
-            this.typeName = Common.DataSanitizer.sanitizeString(exception.name || Util.NotSpecified);
-            this.message = Common.DataSanitizer.sanitizeMessage(exception.message || Util.NotSpecified);
+            this.typeName = Common.DataSanitizer.sanitizeString(exception.name) || Util.NotSpecified;
+            this.message = Common.DataSanitizer.sanitizeMessage(exception.message) || Util.NotSpecified;
             var stack = exception["stack"];
             this.parsedStack = this.parseStack(stack);
             this.stack = Common.DataSanitizer.sanitizeException(stack);

--- a/JavaScript/JavaScriptSDK/Telemetry/Metric.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/Metric.ts
@@ -26,7 +26,7 @@ module Microsoft.ApplicationInsights.Telemetry {
             dataPoint.count = count > 0 ? count : undefined;
             dataPoint.max = isNaN(max) || max === null ? undefined : max;
             dataPoint.min = isNaN(min) || min === null ? undefined : min;
-            dataPoint.name = Common.DataSanitizer.sanitizeString(name);
+            dataPoint.name = Common.DataSanitizer.sanitizeString(name) || Util.NotSpecified;
             dataPoint.value = value;
 
             this.metrics = [dataPoint];

--- a/JavaScript/JavaScriptSDK/Telemetry/PageView.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/PageView.ts
@@ -25,7 +25,7 @@ module Microsoft.ApplicationInsights.Telemetry {
             super();
 
             this.url = Common.DataSanitizer.sanitizeUrl(url);
-            this.name = Common.DataSanitizer.sanitizeString(name || Util.NotSpecified);
+            this.name = Common.DataSanitizer.sanitizeString(name) || Util.NotSpecified;
             if (!isNaN(durationMs)) {
                 this.duration = Util.msToTimeSpan(durationMs);
             }

--- a/JavaScript/JavaScriptSDK/Telemetry/PageViewPerformance.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/PageViewPerformance.ts
@@ -98,7 +98,7 @@ module Microsoft.ApplicationInsights.Telemetry {
             }
 
             this.url = Common.DataSanitizer.sanitizeUrl(url);
-            this.name = Common.DataSanitizer.sanitizeString(name || Util.NotSpecified);
+            this.name = Common.DataSanitizer.sanitizeString(name) || Util.NotSpecified;
 
             this.properties = ApplicationInsights.Telemetry.Common.DataSanitizer.sanitizeProperties(properties);
             this.measurements = ApplicationInsights.Telemetry.Common.DataSanitizer.sanitizeMeasurements(measurements);


### PR DESCRIPTION
#184. If name is required set the value to 'not_specified' if value is null or empty. 

Common.DataSanitizer.sanitizeString(exception.name || Util.NotSpecified) didn't handle " " names correctly. It will return 'not_specified' with the fix. 