### PR TITLE
Reference TS compiler in tests, removing hardcoded VS version

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/JavaScriptSDK.Tests.csproj
+++ b/JavaScript/JavaScriptSDK.Tests/JavaScriptSDK.Tests.csproj
@@ -29,6 +29,7 @@
     <TypeScriptSourceMap>true</TypeScriptSourceMap>
     <TypeScriptModuleKind>CommonJS</TypeScriptModuleKind>
     <EnableTypeScript>true</EnableTypeScript>
+    <TypeScriptCompilerPath>..\..\..\packages\Microsoft.TypeScript.Compiler.1.8.11\tools\tsc.exe</TypeScriptCompilerPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -256,13 +257,13 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="BeforeBuild">
     <Message Text="Compiling TypeScript files" />
-    <Exec Command="tsc --module amd @(SeleniumCheckinTests ->'&quot;%(fullpath)&quot;', ' ') --out Selenium\checkinTests.js" />
-    <Exec Command="tsc --module amd @(SeleniumPerformance ->'&quot;%(fullpath)&quot;', ' ') --out Selenium\performanceTests.js" />
-    <Exec Command="tsc --module amd @(AutoCollectionTests ->'&quot;%(fullpath)&quot;', ' ') --out E2ETests\autoCollection.tests.js" />
-    <Exec Command="tsc --module amd @(PublicApiTests ->'&quot;%(fullpath)&quot;', ' ') --out E2ETests\PublicApiTests.js" />
-    <Exec Command="tsc --module amd @(SanitizerE2ETests ->'&quot;%(fullpath)&quot;', ' ') --out E2ETests\SanitizerE2E.tests.js" />
-    <Exec Command="tsc --module amd @(SnippetTests ->'&quot;%(fullpath)&quot;', ' ') --out E2ETests\snippet.tests.js" />
-    <Exec Command="tsc --module amd @(DisableTelemetryTests ->'&quot;%(fullpath)&quot;', ' ') --out E2ETests\DisableTelemetryTests.js" />
+    <Exec Command="$(TypeScriptCompilerPath) --module amd @(SeleniumCheckinTests ->'&quot;%(fullpath)&quot;', ' ') --out Selenium\checkinTests.js" />
+    <Exec Command="$(TypeScriptCompilerPath) --module amd @(SeleniumPerformance ->'&quot;%(fullpath)&quot;', ' ') --out Selenium\performanceTests.js" />
+    <Exec Command="$(TypeScriptCompilerPath) --module amd @(AutoCollectionTests ->'&quot;%(fullpath)&quot;', ' ') --out E2ETests\autoCollection.tests.js" />
+    <Exec Command="$(TypeScriptCompilerPath) --module amd @(PublicApiTests ->'&quot;%(fullpath)&quot;', ' ') --out E2ETests\PublicApiTests.js" />
+    <Exec Command="$(TypeScriptCompilerPath) --module amd @(SanitizerE2ETests ->'&quot;%(fullpath)&quot;', ' ') --out E2ETests\SanitizerE2E.tests.js" />
+    <Exec Command="$(TypeScriptCompilerPath) --module amd @(SnippetTests ->'&quot;%(fullpath)&quot;', ' ') --out E2ETests\snippet.tests.js" />
+    <Exec Command="$(TypeScriptCompilerPath) --module amd @(DisableTelemetryTests ->'&quot;%(fullpath)&quot;', ' ') --out E2ETests\DisableTelemetryTests.js" />
     <Exec Command="Powershell.exe -ExecutionPolicy ByPass -File &quot;$(ProjectDir)E2ETests\PostBuild.ps1&quot; -projectDir $(ProjectDir)" />
   </Target>
   <PropertyGroup>

--- a/JavaScript/JavaScriptSDK.Tests/packages.config
+++ b/JavaScript/JavaScriptSDK.Tests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.TypeScript.Compiler" version="1.8.11" targetFramework="net45" developmentDependency="true" />
   <package id="Selenium.WebDriver" version="2.48.0" targetFramework="net45" />
 </packages>

--- a/JavaScript/JavaScriptSDK/JavaScriptSDK.csproj
+++ b/JavaScript/JavaScriptSDK/JavaScriptSDK.csproj
@@ -16,7 +16,6 @@
     <IISExpressUseClassicPipelineMode />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <VisualStudioVersion>12.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <RootNamespace>ApplicationInsights.Javascript</RootNamespace>
     <!-- What version is being built? -->


### PR DESCRIPTION
* JavaScriptSDK.Tests project is referencing tsc in Exec tasks, assuming it is available in PATH (which it is not, unless installed on the box). I'm referencing TS compiler package and referencing it from packages path
* Removing hardcoded VS version, so that solution can be opened and built with VS2015