### PR TITLE
Send telemetry over HTTPS

### DIFF
--- a/JavaScript/JavaScriptSDK/Initialization.ts
+++ b/JavaScript/JavaScriptSDK/Initialization.ts
@@ -142,7 +142,7 @@ module Microsoft.ApplicationInsights {
             }
 
             // set default values
-            config.endpointUrl = config.endpointUrl || "//dc.services.visualstudio.com/v2/track";
+            config.endpointUrl = config.endpointUrl || "https://dc.services.visualstudio.com/v2/track";
             config.sessionRenewalMs = 30 * 60 * 1000;
             config.sessionExpirationMs = 24 * 60 * 60 * 1000;
             config.maxBatchSizeInBytes = config.maxBatchSizeInBytes > 0 ? config.maxBatchSizeInBytes : 1000000;

--- a/JavaScript/JavaScriptSDK/Sender.ts
+++ b/JavaScript/JavaScriptSDK/Sender.ts
@@ -247,7 +247,10 @@ module Microsoft.ApplicationInsights {
             var xdr = new XDomainRequest();
             xdr.onload = () => this._xdrOnLoad(xdr, payload);
             xdr.onerror = (event: ErrorEvent) => this._onError(payload, xdr.responseText || "", event);
-            xdr.open('POST', this._config.endpointUrl());
+
+            // AI is sending all telemetry with HTTPS, but XDomainRequest requires the same scheme as the hosting page
+            var endpointUrl = this._config.endpointUrl().replace(/^(https?:)/, "");
+            xdr.open('POST', endpointUrl);
 
             // compose an array of payloads
             var batch = this._buffer.batchPayloads(payload);


### PR DESCRIPTION
Extra code for XDomainRequests is required because IE8,9 requires the same schema [see point 7 here](https://blogs.msdn.microsoft.com/ieinternals/2010/05/13/xdomainrequest-restrictions-limitations-and-workarounds/)

Fixes: #93 