### PR TITLE
Sent buffer overflow

### DIFF
--- a/JavaScript/JavaScriptSDK/SendBuffer.ts
+++ b/JavaScript/JavaScriptSDK/SendBuffer.ts
@@ -187,6 +187,16 @@ module Microsoft.ApplicationInsights {
             var sentElements = this.getBuffer(SessionStorageSendBuffer.SENT_BUFFER_KEY);
             sentElements = sentElements.concat(payload);
 
+            if (sentElements.length > SessionStorageSendBuffer.MAX_BUFFER_SIZE) {
+                // We send telemetry normally. If the SENT_BUFFER is too big we don't add new elements
+                // until we receive a response from the backend and the buffer has free space again (see clearSent method)
+                _InternalLogging.throwInternalUserActionable(LoggingSeverity.CRITICAL,
+                    new _InternalLogMessage(_InternalMessageId.USRACT_SessionStorageBufferFull,
+                        "Sent buffer reached its maximum size: " + sentElements.length));
+
+                sentElements.length = SessionStorageSendBuffer.MAX_BUFFER_SIZE;
+            }
+
             this._buffer = this.removePayloadsFromBuffer(payload, this._buffer);
 
             this.setBuffer(SessionStorageSendBuffer.BUFFER_KEY, this._buffer);

--- a/JavaScript/JavaScriptSDK/SendBuffer.ts
+++ b/JavaScript/JavaScriptSDK/SendBuffer.ts
@@ -128,6 +128,10 @@ module Microsoft.ApplicationInsights {
 
             this._buffer = bufferItems.concat(notDeliveredItems);
 
+            if (this._buffer.length > SessionStorageSendBuffer.MAX_BUFFER_SIZE) {
+                this._buffer.length = SessionStorageSendBuffer.MAX_BUFFER_SIZE;
+            }
+
             // update DataLossAnalyzer with the number of recovered items
             DataLossAnalyzer.itemsRestoredFromSessionBuffer = this._buffer.length;
 

--- a/JavaScript/JavaScriptSDK/SendBuffer.ts
+++ b/JavaScript/JavaScriptSDK/SendBuffer.ts
@@ -128,6 +128,7 @@ module Microsoft.ApplicationInsights {
 
             this._buffer = bufferItems.concat(notDeliveredItems);
 
+            // If the buffer has too many items, drop items from the end.
             if (this._buffer.length > SessionStorageSendBuffer.MAX_BUFFER_SIZE) {
                 this._buffer.length = SessionStorageSendBuffer.MAX_BUFFER_SIZE;
             }


### PR DESCRIPTION
If the back-end is not responding or is responding very slow, the SENT_BUFFER can grow above the max buffer size limit. This can cause a situation when the restored buffer has more than MAX_BUFFER_SIZE elements. 