### PR TITLE
Create E2ETests as a directory.

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/PostBuild.ps1
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/PostBuild.ps1
@@ -100,6 +100,6 @@ $content = $content -replace '//PREFIX_PLACEHOLDER', $strSnippet
 $content | out-file "$($projectDir)\Selenium\testPageWithAppInsights.html"
 
 # copy E2E files
-Copy-Item "$($projectDir)\E2ETests\*.js" "$($outputDir)\E2ETests"
-Copy-Item "$($projectDir)\E2ETests\*.htm" "$($outputDir)\E2ETests"
-Copy-Item "$($projectDir)\E2ETests\*.html" "$($outputDir)\E2ETests"
+Copy-Item "$($projectDir)\E2ETests\*.js" "$($outputDir)\E2ETests\"
+Copy-Item "$($projectDir)\E2ETests\*.htm" "$($outputDir)\E2ETests\"
+Copy-Item "$($projectDir)\E2ETests\*.html" "$($outputDir)\E2ETests\"


### PR DESCRIPTION
Create E2ETests as a directory instead of a file by appending '\' to the route.