### PR TITLE
Do not flood the console!

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Logging.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Logging.tests.ts
@@ -389,7 +389,7 @@ class LoggingTests extends TestClass {
                 var message2 = new this.InternalLoggingMessage(2, "2");
 
                 // disable session storage
-                var utilCanUserSession = Microsoft.ApplicationInsights.Util.canUseSessionStorage;
+                var utilCanUseSession = Microsoft.ApplicationInsights.Util.canUseSessionStorage;
                 Microsoft.ApplicationInsights.Util.canUseSessionStorage = () => {
                     return false;
                 };
@@ -413,7 +413,7 @@ class LoggingTests extends TestClass {
                 Assert.equal(this.InternalLogging.queue[1], message2);
 
                 // clean up - reset session storage
-                Microsoft.ApplicationInsights.Util.canUseSessionStorage = utilCanUserSession;
+                Microsoft.ApplicationInsights.Util.canUseSessionStorage = utilCanUseSession;
             }
         });
         

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Logging.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Logging.tests.ts
@@ -200,6 +200,64 @@ class LoggingTests extends TestClass {
         });
 
         this.testCase({
+            name: "LoggingTests: throwInternalUserActionable logs only one message of a given type to console (without verboseLogging)",
+            test: () => {
+                // setup
+                var throwSpy = null;
+                try {
+                    throwSpy = this.sandbox.spy(console, "warn");
+                    this.InternalLogging.enableDebugExceptions = () => false;
+                    this.InternalLogging.verboseLogging = () => false;
+
+                    var message1 = new this.InternalLoggingMessage(1, "error!");
+                    var message2 = new this.InternalLoggingMessage(2, "error 2!");
+
+                    // act
+                    // send 4 messages, with 2 distinct types
+                    this.InternalLogging.throwInternalUserActionable(Microsoft.ApplicationInsights.LoggingSeverity.CRITICAL, message1);
+                    this.InternalLogging.throwInternalUserActionable(Microsoft.ApplicationInsights.LoggingSeverity.CRITICAL, message2);
+                    this.InternalLogging.throwInternalUserActionable(Microsoft.ApplicationInsights.LoggingSeverity.CRITICAL, message1);
+                    this.InternalLogging.throwInternalUserActionable(Microsoft.ApplicationInsights.LoggingSeverity.CRITICAL, message2);
+
+                    // verify
+                    Assert.ok(throwSpy.calledTwice, "console.warn was called only once per each message type");
+
+                } catch (e) {
+                    Assert.ok(true, "IE8 breaks sinon spies on window objects\n" + e.toString());
+                }
+            }
+        });
+
+        this.testCase({
+            name: "LoggingTests: throwInternalUserActionable always log to console with verbose logging",
+            test: () => {
+                // setup
+                var throwSpy = null;
+                try {
+                    throwSpy = this.sandbox.spy(console, "warn");
+                    this.InternalLogging.enableDebugExceptions = () => false;
+                    this.InternalLogging.verboseLogging = () => true;
+
+                    var message1 = new this.InternalLoggingMessage(1, "error!");
+                    var message2 = new this.InternalLoggingMessage(2, "error 2!");
+
+                    // act
+                    // send 4 messages, with 2 distinct types
+                    this.InternalLogging.throwInternalUserActionable(Microsoft.ApplicationInsights.LoggingSeverity.CRITICAL, message1);
+                    this.InternalLogging.throwInternalUserActionable(Microsoft.ApplicationInsights.LoggingSeverity.CRITICAL, message2);
+                    this.InternalLogging.throwInternalUserActionable(Microsoft.ApplicationInsights.LoggingSeverity.CRITICAL, message1);
+                    this.InternalLogging.throwInternalUserActionable(Microsoft.ApplicationInsights.LoggingSeverity.CRITICAL, message2);
+
+                    // verify
+                    Assert.equal(4, throwSpy.callCount, "console.warn was called for each message");
+
+                } catch (e) {
+                    Assert.ok(true, "IE8 breaks sinon spies on window objects\n" + e.toString());
+                }
+            }
+        });
+
+        this.testCase({
             name: "LoggingTests: warnToConsole does not add to the queue ",
             test: () => {
                 // setup

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Sender.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Sender.tests.ts
@@ -639,7 +639,7 @@ class SenderTests extends TestClass {
         this.testCase({
             name: "SenderTests: does not use SessionStorageBuffer when enableSessionStorageBuffer is true and SessionStorage is not supported",
             test: () => {
-                var utilCanUserSession = Microsoft.ApplicationInsights.Util.canUseSessionStorage;
+                var utilCanUseSession = Microsoft.ApplicationInsights.Util.canUseSessionStorage;
 
                 // setup
                 var config: Microsoft.ApplicationInsights.ISenderConfig = {
@@ -663,7 +663,7 @@ class SenderTests extends TestClass {
                 Assert.ok(sender._buffer instanceof Microsoft.ApplicationInsights.ArraySendBuffer, "sender should use Array buffer");
 
                 // clean up
-                Microsoft.ApplicationInsights.Util.canUseSessionStorage = utilCanUserSession;
+                Microsoft.ApplicationInsights.Util.canUseSessionStorage = utilCanUseSession;
             }
         });
 

--- a/JavaScript/JavaScriptSDK/Logging.ts
+++ b/JavaScript/JavaScriptSDK/Logging.ts
@@ -146,7 +146,10 @@
          */
         private static _messageCount = 0;
 
-       private static _messageLogged: { [type: string]: boolean } = {};
+        /**
+         * Holds information about what message types were already logged to console or sent to server.
+         */
+        private static _messageLogged: { [type: string]: boolean } = {};
 
         /**
          * This method will throw exceptions in debug mode or attempt to log the error as a console warning.
@@ -183,7 +186,21 @@
                 if (typeof (message) !== "undefined" && !!message) {
                     if (typeof (message.message) !== "undefined") {
                         message.message = this.AiUserActionablePrefix + message.message;
-                        this.warnToConsole(message.message);
+
+                        // check if this message type was already logged to console for this page view and if so, don't log it again
+                        var logToConsole = true;
+
+                        var messageKey = _InternalMessageId[message.messageId];
+                        if (this._messageLogged[messageKey] && !this.verboseLogging()) {
+                            logToConsole = false;
+                        } else {
+                            this._messageLogged[messageKey] = true;
+                        }
+
+                        if (logToConsole) {
+                            this.warnToConsole(message.message);
+                        }
+
                         this.logInternalMessage(severity, message);
                     }
                 }

--- a/JavaScript/JavaScriptSDK/Logging.ts
+++ b/JavaScript/JavaScriptSDK/Logging.ts
@@ -188,17 +188,11 @@
                         message.message = this.AiUserActionablePrefix + message.message;
 
                         // check if this message type was already logged to console for this page view and if so, don't log it again
-                        var logToConsole = true;
-
                         var messageKey = _InternalMessageId[message.messageId];
-                        if (this._messageLogged[messageKey] && !this.verboseLogging()) {
-                            logToConsole = false;
-                        } else {
-                            this._messageLogged[messageKey] = true;
-                        }
 
-                        if (logToConsole) {
+                        if (!this._messageLogged[messageKey] || this.verboseLogging()) {
                             this.warnToConsole(message.message);
+                            this._messageLogged[messageKey] = true;
                         }
 
                         this.logInternalMessage(severity, message);


### PR DESCRIPTION
* Limit console logging to only one message of a given type (if !verboseLogging)
* Limit to only one internal message log per page view when the session storage is not available