### PR TITLE
XDomain sender should drop the telemetry if the Endpoint protocol and the hosting page protocol don't match

### DIFF
--- a/JavaScript/JavaScriptSDK/Sender.ts
+++ b/JavaScript/JavaScriptSDK/Sender.ts
@@ -364,8 +364,6 @@ module Microsoft.ApplicationInsights {
             xhr.onreadystatechange = () => this._xhrReadyStateChange(xhr, payload, payload.length);
             xhr.onerror = (event: ErrorEvent) => this._onError(payload, xhr.responseText || xhr.response || "", event);
 
-            console.log("XMLHttpRequest");
-
             // compose an array of payloads
             var batch = this._buffer.batchPayloads(payload);
             xhr.send(batch);

--- a/JavaScript/JavaScriptSDK/Sender.ts
+++ b/JavaScript/JavaScriptSDK/Sender.ts
@@ -364,6 +364,8 @@ module Microsoft.ApplicationInsights {
             xhr.onreadystatechange = () => this._xhrReadyStateChange(xhr, payload, payload.length);
             xhr.onerror = (event: ErrorEvent) => this._onError(payload, xhr.responseText || xhr.response || "", event);
 
+            console.log("XMLHttpRequest");
+
             // compose an array of payloads
             var batch = this._buffer.batchPayloads(payload);
             xhr.send(batch);
@@ -384,7 +386,18 @@ module Microsoft.ApplicationInsights {
             xdr.onload = () => this._xdrOnLoad(xdr, payload);
             xdr.onerror = (event: ErrorEvent) => this._onError(payload, xdr.responseText || "", event);
 
-            // AI is sending all telemetry with HTTPS, but XDomainRequest requires the same scheme as the hosting page
+            // XDomainRequest requires the same protocol as the hosting page. 
+            // If the protocol doesn't match, we can't send the telemetry :(. 
+            var hostingProtocol = window.location.protocol
+            if (this._config.endpointUrl().lastIndexOf(hostingProtocol, 0) !== 0) {
+                _InternalLogging.throwInternalNonUserActionable(LoggingSeverity.WARNING,
+                    new _InternalLogMessage(_InternalMessageId.NONUSRACT_TransmissionFailed, ". " +
+                        "Cannot send XDomain request. The endpoint URL protocol doesn't match the hosting page protocol."));
+
+                this._buffer.clear();
+                return;
+            }
+
             var endpointUrl = this._config.endpointUrl().replace(/^(https?:)/, "");
             xdr.open('POST', endpointUrl);
 

--- a/JavaScript/JavaScriptSDK/Telemetry/Common/Envelope.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/Common/Envelope.ts
@@ -29,7 +29,7 @@ module Microsoft.ApplicationInsights.Telemetry.Common {
                     return (this.sampleRate == 100) ? FieldType.Hidden : FieldType.Required;
                 },
                 tags: FieldType.Required,
-                data: FieldType.Required,
+                data: FieldType.Required
             };
         }
     }

--- a/JavaScript/JavaScriptSDK/Telemetry/Event.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/Event.ts
@@ -13,7 +13,7 @@ module Microsoft.ApplicationInsights.Telemetry {
             ver: FieldType.Required,
             name: FieldType.Required,
             properties: FieldType.Default,
-            measurements: FieldType.Default,
+            measurements: FieldType.Default
         }
 
         /**

--- a/JavaScript/JavaScriptSDK/Telemetry/Exception.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/Exception.ts
@@ -17,7 +17,7 @@ module Microsoft.ApplicationInsights.Telemetry {
             exceptions: FieldType.Required,
             severityLevel: FieldType.Default,
             properties: FieldType.Default,
-            measurements: FieldType.Default,
+            measurements: FieldType.Default
         }
 
         /**
@@ -76,7 +76,7 @@ module Microsoft.ApplicationInsights.Telemetry {
             message: FieldType.Required,
             hasFullStack: FieldType.Default,
             stack: FieldType.Default,
-            parsedStack: FieldType.Array,
+            parsedStack: FieldType.Array
         };
 
         constructor(exception: Error) {
@@ -157,7 +157,7 @@ module Microsoft.ApplicationInsights.Telemetry {
             method: FieldType.Required,
             assembly: FieldType.Default,
             fileName: FieldType.Default,
-            line: FieldType.Default,
+            line: FieldType.Default
         };
 
         constructor(frame: string, level: number) {

--- a/JavaScript/JavaScriptSDK/Telemetry/Metric.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/Metric.ts
@@ -13,7 +13,7 @@ module Microsoft.ApplicationInsights.Telemetry {
         public aiDataContract = {
             ver: FieldType.Required,
             metrics: FieldType.Required,
-            properties: FieldType.Default,
+            properties: FieldType.Default
         }
 
         /**

--- a/JavaScript/JavaScriptSDK/Telemetry/PageView.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/PageView.ts
@@ -15,7 +15,7 @@ module Microsoft.ApplicationInsights.Telemetry {
             url: FieldType.Default,
             duration: FieldType.Default,
             properties: FieldType.Default,
-            measurements: FieldType.Default,
+            measurements: FieldType.Default
         }
 
         /**

--- a/JavaScript/JavaScriptSDK/Telemetry/PerformanceAnalyzer.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/PerformanceAnalyzer.ts
@@ -84,7 +84,7 @@
                             "connectEnd": resource.connectEnd,
                             "requestStart": resource.requestStart,
                             "responseStart": resource.responseStart,
-                            "responseEnd": resource.responseEnd,
+                            "responseEnd": resource.responseEnd
                         };
                     }
 


### PR DESCRIPTION
XDomainRequest requires the same protocol as the hosting page. If the protocol doesn't match, we can't send the telemetry :(

Fixes #314 