### PR TITLE
Remove measurements field from MessageData

### DIFF
--- a/JavaScript/JavaScriptSDK/Telemetry/Trace.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/Trace.ts
@@ -13,7 +13,6 @@ module Microsoft.ApplicationInsights.Telemetry {
             ver: FieldType.Required,
             message: FieldType.Required,
             severityLevel: FieldType.Default,
-            measurements: FieldType.Default,
             properties: FieldType.Default
         };
 


### PR DESCRIPTION
`MessageData` doesn't have a measurements field. Ref[MessageData schema](https://github.com/Microsoft/ApplicationInsights-Home/blob/master/EndpointSpecs/Schemas/Docs/MessageData.md)