### PR TITLE
Add source maps to un-minified library (ai.js)

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Context/HashCodeScoreGenerator.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Context/HashCodeScoreGenerator.tests.ts
@@ -1,5 +1,5 @@
 ﻿/// <reference path="../../../JavaScriptSDK/appInsights.ts" />
-/// <reference path="../../../JavaScriptSDK/util.ts" />
+/// <reference path="../../../JavaScriptSDK/Util.ts" />
 /// <reference path="../../../JavaScriptSDK/HashCodeScoreGenerator.ts" />
 /// <reference path="../../testframework/common.ts" />
 

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Sender.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Sender.tests.ts
@@ -1,9 +1,9 @@
 ﻿/// <reference path="..\TestFramework\Common.ts" />
 /// <reference path="../../JavaScriptSDK/Util.ts"/>
-/// <reference path="../../JavaScriptSDK/sender.ts" />
+/// <reference path="../../JavaScriptSDK/Sender.ts" />
 /// <reference path="../../JavaScriptSDK/SendBuffer.ts"/>
-/// <reference path="../../javascriptsdk/appinsights.ts" />
-/// <reference path="../../JavaScriptSDK/util.ts" />
+/// <reference path="../../JavaScriptSDK/Appinsights.ts" />
+/// <reference path="../../JavaScriptSDK/Util.ts" />
 
 class SenderWrapper extends Microsoft.ApplicationInsights.Sender {
     errorSpy: SinonSpy;

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Serializer.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Serializer.tests.ts
@@ -1,5 +1,5 @@
 ﻿/// <reference path="..\TestFramework\Common.ts" />
-/// <reference path="../../JavaScriptSDK/serializer.ts" />
+/// <reference path="../../JavaScriptSDK/Serializer.ts" />
 
 class SerializerTests extends TestClass {
 

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/DataSanitizer.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Telemetry/DataSanitizer.tests.ts
@@ -1,5 +1,5 @@
 ﻿/// <reference path="../../testframework/common.ts" />
-/// <reference path="../../../JavaScriptSDK/telemetry/Common/DataSanitizer.ts" />
+/// <reference path="../../../JavaScriptSDK/Telemetry/Common/DataSanitizer.ts" />
 /// <reference path="../../../JavaScriptSDK/Util.ts"/>
 
 class DataSanitizerTests extends TestClass {

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/TelemetryContext.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/TelemetryContext.tests.ts
@@ -1,6 +1,6 @@
 ﻿/// <reference path="../testframework/common.ts" />
-/// <reference path="../../JavaScriptSDK/telemetrycontext.ts" />
-/// <reference path="../../javascriptsdk/appinsights.ts" />
+/// <reference path="../../JavaScriptSDK/TelemetryContext.ts" />
+/// <reference path="../../JavaScriptSDK/AppInsights.ts" />
 /// <reference path="../../JavaScriptSDK/Telemetry/Common/Envelope.ts"/>
 
 class TelemetryContextTests extends TestClass {

--- a/JavaScript/JavaScriptSDK.Tests/TestFramework/ContractTestHelper.ts
+++ b/JavaScript/JavaScriptSDK.Tests/TestFramework/ContractTestHelper.ts
@@ -1,4 +1,4 @@
-﻿/// <reference path="../../JavaScriptSDK/serializer.ts" />
+﻿/// <reference path="../../JavaScriptSDK/Serializer.ts" />
 /// <reference path="./TestClass.ts"/>
 
 class ContractTestHelper extends TestClass {

--- a/JavaScript/JavaScriptSDK/AppInsights.ts
+++ b/JavaScript/JavaScriptSDK/AppInsights.ts
@@ -1,4 +1,4 @@
-/// <reference path="telemetrycontext.ts" />
+/// <reference path="TelemetryContext.ts" />
 /// <reference path="./Telemetry/Common/Data.ts"/>
 /// <reference path="./Util.ts"/>
 /// <reference path="../JavaScriptSDK.Interfaces/Contracts/Generated/SessionState.ts"/>

--- a/JavaScript/JavaScriptSDK/Context/Operation.ts
+++ b/JavaScript/JavaScriptSDK/Context/Operation.ts
@@ -1,4 +1,4 @@
-﻿/// <reference path="../util.ts" />
+﻿/// <reference path="../Util.ts" />
 /// <reference path="../../JavaScriptSDK.Interfaces/Context/IOperation.ts" />
 
 module Microsoft.ApplicationInsights.Context {

--- a/JavaScript/JavaScriptSDK/Context/Session.ts
+++ b/JavaScript/JavaScriptSDK/Context/Session.ts
@@ -1,4 +1,4 @@
-﻿/// <reference path="../util.ts" />
+﻿/// <reference path="../Util.ts" />
 /// <reference path="../../JavaScriptSDK.Interfaces/Contracts/Generated/SessionState.ts"/>
 /// <reference path="../../JavaScriptSDK.Interfaces/Context/ISession.ts" />
 

--- a/JavaScript/JavaScriptSDK/Context/User.ts
+++ b/JavaScript/JavaScriptSDK/Context/User.ts
@@ -1,4 +1,4 @@
-﻿/// <reference path="../util.ts" />
+﻿/// <reference path="../Util.ts" />
 /// <reference path="../../JavaScriptSDK.Interfaces/Context/IUser.ts" />
 
 module Microsoft.ApplicationInsights.Context {

--- a/JavaScript/JavaScriptSDK/Init.ts
+++ b/JavaScript/JavaScriptSDK/Init.ts
@@ -1,4 +1,4 @@
-﻿/// <reference path="initialization.ts" />
+﻿/// <reference path="Initialization.ts" />
 
 module Microsoft.ApplicationInsights {
     "use strict";

--- a/JavaScript/JavaScriptSDK/Initialization.ts
+++ b/JavaScript/JavaScriptSDK/Initialization.ts
@@ -1,4 +1,4 @@
-﻿/// <reference path="appinsights.ts" />
+﻿/// <reference path="AppInsights.ts" />
 
 module Microsoft.ApplicationInsights {
     "use strict";

--- a/JavaScript/JavaScriptSDK/JavaScriptSDK.csproj
+++ b/JavaScript/JavaScriptSDK/JavaScriptSDK.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
-  <Import Project="..\..\..\packages\AjaxMin.5.5.5091.22839\tools\net40\AjaxMin.targets" Condition="Exists('..\..\..\packages\AjaxMin.5.5.5091.22839\tools\net40\AjaxMin.targets')" />
+  <Import Project="..\..\..\packages\AjaxMin.5.14.5506.26202\tools\net40\AjaxMin.targets" Condition="Exists('..\..\..\packages\AjaxMin.5.14.5506.26202\tools\net40\AjaxMin.targets')" />
   <ProjectExtensions>
     <VisualStudio>
       <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
@@ -56,6 +56,15 @@
     <TypeScriptRemoveComments>false</TypeScriptRemoveComments>
     <TypeScriptSourceMap>true</TypeScriptSourceMap>
     <TypeScriptModuleKind>AMD</TypeScriptModuleKind>
+    <TypeScriptJSXEmit>None</TypeScriptJSXEmit>
+    <TypeScriptCompileOnSaveEnabled>True</TypeScriptCompileOnSaveEnabled>
+    <TypeScriptNoImplicitAny>False</TypeScriptNoImplicitAny>
+    <TypeScriptOutFile>min\$(OutFileBaseName).js</TypeScriptOutFile>
+    <TypeScriptOutDir />
+    <TypeScriptNoEmitOnError>True</TypeScriptNoEmitOnError>
+    <TypeScriptMapRoot>
+    </TypeScriptMapRoot>
+    <TypeScriptSourceRoot>https://raw.githubusercontent.com/Microsoft/ApplicationInsights-JS/master/JavaScript</TypeScriptSourceRoot>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <TypeScriptTarget>ES5</TypeScriptTarget>
@@ -96,13 +105,13 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="snippet.js" />
     <Content Include="web.config" />
     <Content Include="min\ai.min.js.map">
       <DependentUpon>ai.min.js</DependentUpon>
+    </Content>
+    <Content Include="packages.config">
+      <SubType>Designer</SubType>
     </Content>
     <None Include="web.Debug.config">
       <DependentUpon>web.config</DependentUpon>
@@ -110,12 +119,6 @@
     <None Include="web.Release.config">
       <DependentUpon>web.config</DependentUpon>
     </None>
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="AjaxMin, Version=5.5.5091.22824, Culture=neutral, PublicKeyToken=21ef50ce11b5d80f, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\AjaxMin.5.5.5091.22839\lib\net40\AjaxMin.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
@@ -271,10 +274,16 @@
       <Name>JavaScriptSDK.Interfaces</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="AjaxMin, Version=5.14.5506.26196, Culture=neutral, PublicKeyToken=21ef50ce11b5d80f, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\AjaxMin.5.14.5506.26202\lib\net40\AjaxMin.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\TypeScript\Microsoft.TypeScript.targets" Condition="Exists('$(VSToolsPath)\TypeScript\Microsoft.TypeScript.targets')" />
   <Target Name="EnsureAjaxMinBuildImported" BeforeTargets="BeforeBuild" Condition="'$(AjaxMinOutputFolder)' == ''">
-    <Error Condition="!Exists('..\..\..\packages\AjaxMin.5.5.5091.22839\tools\net40\AjaxMin.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." />
-    <Error Condition="Exists('..\..\..\packages\AjaxMin.5.5.5091.22839\tools\net40\AjaxMin.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." />
+    <Error Condition="!Exists('..\..\..\packages\AjaxMin.5.14.5506.26202\tools\net40\AjaxMin.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." />
+    <Error Condition="Exists('..\..\..\packages\AjaxMin.5.14.5506.26202\tools\net40\AjaxMin.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." />
   </Target>
   <Target Name="AfterBuild" DependsOnTargets="BuildAjaxMinManifests">
     <Message Text="Build snippet.html" />

--- a/JavaScript/JavaScriptSDK/JavaScriptSDK.csproj
+++ b/JavaScript/JavaScriptSDK/JavaScriptSDK.csproj
@@ -26,6 +26,7 @@
     <TypeScriptGeneratesDeclarations>True</TypeScriptGeneratesDeclarations>
     <TypeScriptModuleKind>AMD</TypeScriptModuleKind>
     <TypeScriptTarget>ES5</TypeScriptTarget>
+    <TypeScriptInlineSources>True</TypeScriptInlineSources>
     <!-- Suppress the "CS2008: No source files specified" warning -->
     <NoWarn>2008</NoWarn>
     <UseGlobalApplicationHostFile />
@@ -56,15 +57,6 @@
     <TypeScriptRemoveComments>false</TypeScriptRemoveComments>
     <TypeScriptSourceMap>true</TypeScriptSourceMap>
     <TypeScriptModuleKind>AMD</TypeScriptModuleKind>
-    <TypeScriptJSXEmit>None</TypeScriptJSXEmit>
-    <TypeScriptCompileOnSaveEnabled>True</TypeScriptCompileOnSaveEnabled>
-    <TypeScriptNoImplicitAny>False</TypeScriptNoImplicitAny>
-    <TypeScriptOutFile>min\$(OutFileBaseName).js</TypeScriptOutFile>
-    <TypeScriptOutDir />
-    <TypeScriptNoEmitOnError>True</TypeScriptNoEmitOnError>
-    <TypeScriptMapRoot>
-    </TypeScriptMapRoot>
-    <TypeScriptSourceRoot>https://raw.githubusercontent.com/Microsoft/ApplicationInsights-JS/master/JavaScript</TypeScriptSourceRoot>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <TypeScriptTarget>ES5</TypeScriptTarget>

--- a/JavaScript/JavaScriptSDK/SendBuffer.ts
+++ b/JavaScript/JavaScriptSDK/SendBuffer.ts
@@ -1,4 +1,4 @@
-﻿/// <reference path="serializer.ts" />
+﻿/// <reference path="Serializer.ts" />
 /// <reference path="Telemetry/Common/Envelope.ts"/>
 /// <reference path="Telemetry/Common/Base.ts" />
 /// <reference path="../JavaScriptSDK.Interfaces/Contracts/Generated/ContextTagKeys.ts"/>

--- a/JavaScript/JavaScriptSDK/Sender.ts
+++ b/JavaScript/JavaScriptSDK/Sender.ts
@@ -1,4 +1,4 @@
-﻿/// <reference path="serializer.ts" />
+﻿/// <reference path="Serializer.ts" />
 /// <reference path="Telemetry/Common/Envelope.ts"/>
 /// <reference path="Telemetry/Common/Base.ts" />
 /// <reference path="../JavaScriptSDK.Interfaces/Contracts/Generated/ContextTagKeys.ts"/>

--- a/JavaScript/JavaScriptSDK/Serializer.ts
+++ b/JavaScript/JavaScriptSDK/Serializer.ts
@@ -1,6 +1,6 @@
 ﻿/// <reference path="../JavaScriptSDK.Interfaces/Telemetry/ISerializable.ts" />
-/// <reference path="logging.ts" />
-/// <reference path="util.ts" />
+/// <reference path="Logging.ts" />
+/// <reference path="Util.ts" />
 
 module Microsoft.ApplicationInsights {
     "use strict";

--- a/JavaScript/JavaScriptSDK/Telemetry/Common/DataSanitizer.ts
+++ b/JavaScript/JavaScriptSDK/Telemetry/Common/DataSanitizer.ts
@@ -1,4 +1,4 @@
-﻿/// <reference path="../../logging.ts" />
+﻿/// <reference path="../../Logging.ts" />
 /// <reference path="../../Util.ts"/>
 
 module Microsoft.ApplicationInsights.Telemetry.Common {

--- a/JavaScript/JavaScriptSDK/TelemetryContext.ts
+++ b/JavaScript/JavaScriptSDK/TelemetryContext.ts
@@ -1,10 +1,10 @@
-﻿/// <reference path="sender.ts"/>
-/// <reference path="telemetry/trace.ts" />
-/// <reference path="telemetry/event.ts" />
-/// <reference path="telemetry/exception.ts" />
-/// <reference path="telemetry/metric.ts" />
-/// <reference path="telemetry/pageview.ts" />
-/// <reference path="telemetry/pageviewperformance.ts" />
+﻿/// <reference path="Sender.ts"/>
+/// <reference path="Telemetry/Trace.ts" />
+/// <reference path="Telemetry/Event.ts" />
+/// <reference path="Telemetry/Exception.ts" />
+/// <reference path="Telemetry/Metric.ts" />
+/// <reference path="Telemetry/PageView.ts" />
+/// <reference path="Telemetry/PageViewPerformance.ts" />
 /// <reference path="./Util.ts"/>
 /// <reference path="../JavaScriptSDK.Interfaces/Contracts/Generated/SessionState.ts"/>
 /// <reference path="../JavaScriptSDK.Interfaces/ITelemetryContext.ts" />

--- a/JavaScript/JavaScriptSDK/Util.ts
+++ b/JavaScript/JavaScriptSDK/Util.ts
@@ -1,4 +1,4 @@
-﻿/// <reference path="./logging.ts" />
+﻿/// <reference path="./Logging.ts" />
 module Microsoft.ApplicationInsights {
 
     /**

--- a/JavaScript/JavaScriptSDK/ajax/ajax.ts
+++ b/JavaScript/JavaScriptSDK/ajax/ajax.ts
@@ -1,5 +1,5 @@
-﻿/// <reference path="../logging.ts" />
-/// <reference path="../util.ts" />
+﻿/// <reference path="../Logging.ts" />
+/// <reference path="../Util.ts" />
 /// <reference path="./ajaxUtils.ts" />
 /// <reference path="./ajaxRecord.ts" />
 

--- a/JavaScript/JavaScriptSDK/ajax/ajaxRecord.ts
+++ b/JavaScript/JavaScriptSDK/ajax/ajaxRecord.ts
@@ -1,5 +1,5 @@
-﻿/// <reference path="../logging.ts" />
-/// <reference path="../util.ts" />
+﻿/// <reference path="../Logging.ts" />
+/// <reference path="../Util.ts" />
 /// <reference path="./ajaxUtils.ts" />
 
 module Microsoft.ApplicationInsights {

--- a/JavaScript/JavaScriptSDK/ajax/ajaxUtils.ts
+++ b/JavaScript/JavaScriptSDK/ajax/ajaxUtils.ts
@@ -1,5 +1,5 @@
-﻿/// <reference path="../logging.ts" />
-/// <reference path="../util.ts" />
+﻿/// <reference path="../Logging.ts" />
+/// <reference path="../Util.ts" />
 
 module Microsoft.ApplicationInsights {
     "use strict";

--- a/JavaScript/JavaScriptSDK/packages.config
+++ b/JavaScript/JavaScriptSDK/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AjaxMin" version="5.5.5091.22839" targetFramework="net45" />
+  <package id="AjaxMin" version="5.14.5506.26202" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This PR fixes source maps in the un-minified `ai.js` file. I'll add source maps to minified library in a next pull request.

Changes: 
* fix import path
* point to typescript source files in source maps (TypeScriptSourceRoot)
