### PR TITLE
Log the response code (status) in request onError handler

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Sender.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Sender.tests.ts
@@ -76,13 +76,16 @@ class SenderTests extends TestClass {
         Assert.equal("POST", method, "requets method is 'POST'");
     };
 
-    private logAsserts(expectedCount) {
+    private logAsserts(expectedCount, expectedMessage?: string) {
         var isValidCallCount = this.loggingSpy.callCount === expectedCount;
         Assert.ok(isValidCallCount, "logging spy was called " + expectedCount + " time(s)");
         if (!isValidCallCount) {
             for (var i = 0; i < this.loggingSpy.args.length; i++) {
                 Assert.ok(false, "[warning thrown]: " + this.loggingSpy.args[i]);
             }
+        }
+        if (expectedMessage) {
+            Assert.ok(this.loggingSpy.args[0][0].indexOf(expectedMessage) !== -1);
         }
     }
 
@@ -159,7 +162,7 @@ class SenderTests extends TestClass {
 
                 // verify
                 this.requestAsserts();
-                this.fakeServer.requests.pop().respond(200, { "Content-Type": "application/json" }, '{"test":"success"}"');
+                this.fakeServer.requests.pop().respond(200, { "Content-Type": "application/json" }, '{"test":"success"}');
                 this.successAsserts(sender);
                 this.logAsserts(0);
                 sender.successSpy.reset();
@@ -172,9 +175,9 @@ class SenderTests extends TestClass {
 
                 // verify
                 this.requestAsserts();
-                this.fakeServer.requests.pop().respond(404, { "Content-Type": "application/json" }, '{"test":"not found"}"');
+                this.fakeServer.requests.pop().respond(404, { "Content-Type": "application/json" }, 'some_error');
                 this.errorAsserts(sender);
-                this.logAsserts(1);
+                this.logAsserts(1, "message:XMLHttpRequest,Status:404,Response:some_error");
                 sender.successSpy.reset();
                 sender.errorSpy.reset();
             }
@@ -227,7 +230,7 @@ class SenderTests extends TestClass {
                 this.requestAsserts();
                 this.fakeServer.requests[0].respond(404, { "Content-Type": "application/json" }, '400');
                 this.errorAsserts(sender);
-                this.logAsserts(1);
+                this.logAsserts(1, "message:XDomainRequest,Response:400");
                 sender.successSpy.reset();
                 sender.errorSpy.reset();
             }

--- a/JavaScript/JavaScriptSDK/Sender.ts
+++ b/JavaScript/JavaScriptSDK/Sender.ts
@@ -370,11 +370,15 @@ module Microsoft.ApplicationInsights {
             this._setupTimer();
         }
 
-        private _formatErrorMessage(xhr: XMLHttpRequest, xdr: XDomainRequest, message?: string): string {
+        private _formatErrorMessageXhr(xhr: XMLHttpRequest, message?: string): string {
             if (xhr) {
                 return "XMLHttpRequest,Status:" + xhr.status + ",Response:" + xhr.responseText || xhr.response || "";
             }
 
+            return message;
+        }
+
+        private _formatErrorMessageXdr(xdr: XDomainRequest, message?: string): string {
             if (xdr) {
                 return "XDomainRequest,Response:" + xdr.responseText || "";
             }
@@ -393,7 +397,7 @@ module Microsoft.ApplicationInsights {
             xhr.open("POST", this._config.endpointUrl(), isAsync);
             xhr.setRequestHeader("Content-type", "application/json");
             xhr.onreadystatechange = () => this._xhrReadyStateChange(xhr, payload, payload.length);
-            xhr.onerror = (event: ErrorEvent) => this._onError(payload, this._formatErrorMessage(xhr,null), event);
+            xhr.onerror = (event: ErrorEvent) => this._onError(payload, this._formatErrorMessageXhr(xhr), event);
 
             // compose an array of payloads
             var batch = this._buffer.batchPayloads(payload);
@@ -413,7 +417,7 @@ module Microsoft.ApplicationInsights {
         private _xdrSender(payload: string[], isAsync: boolean) {
             var xdr = new XDomainRequest();
             xdr.onload = () => this._xdrOnLoad(xdr, payload);
-            xdr.onerror = (event: ErrorEvent) => this._onError(payload, this._formatErrorMessage(null, xdr), event);
+            xdr.onerror = (event: ErrorEvent) => this._onError(payload, this._formatErrorMessageXdr(xdr), event);
 
             // XDomainRequest requires the same protocol as the hosting page. 
             // If the protocol doesn't match, we can't send the telemetry :(. 
@@ -471,7 +475,7 @@ module Microsoft.ApplicationInsights {
                             _InternalMessageId.TransmissionFailed, ". " +
                             "Response code " + xhr.status + ". Will retry to send " + payload.length + " items.");
                     } else {
-                        this._onError(payload, this._formatErrorMessage(xhr, null));
+                        this._onError(payload, this._formatErrorMessageXhr(xhr));
                     }
                 } else {
                     if (xhr.status === 206) {
@@ -480,7 +484,7 @@ module Microsoft.ApplicationInsights {
                         if (response && !this._config.isRetryDisabled()) {
                             this._onPartialSuccess(payload, response);
                         } else {
-                            this._onError(payload, this._formatErrorMessage(xhr, null));
+                            this._onError(payload, this._formatErrorMessageXhr(xhr));
                         }
                     } else {
                         this._consecutiveErrors = 0;
@@ -504,7 +508,7 @@ module Microsoft.ApplicationInsights {
                     && !this._config.isRetryDisabled()) {
                     this._onPartialSuccess(payload, results);
                 } else {
-                    this._onError(payload, this._formatErrorMessage(null, xdr));
+                    this._onError(payload, this._formatErrorMessageXdr(xdr));
                 }
             }
         }
@@ -533,7 +537,7 @@ module Microsoft.ApplicationInsights {
             }
 
             if (failed.length > 0) {
-                this._onError(failed, this._formatErrorMessage(null,null, ['partial success', results.itemsAccepted, 'of', results.itemsReceived].join(' ')));
+                this._onError(failed, this._formatErrorMessageXhr(null, ['partial success', results.itemsAccepted, 'of', results.itemsReceived].join(' ')));
             }
 
             if (retry.length > 0) {


### PR DESCRIPTION
With this change, the SDK will log the response code (status) in request `onError` handler.