### PR TITLE
Allow flush to be sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.suo
 *.user
 *.sln.docstates
+.idea/
 
 # Build results
 [Dd]ebug/

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 *.suo
 *.user
 *.sln.docstates
-.idea/
 
 # Build results
 [Dd]ebug/

--- a/JavaScript/JavaScriptSDK.Interfaces/IAppInsights.ts
+++ b/JavaScript/JavaScriptSDK.Interfaces/IAppInsights.ts
@@ -116,7 +116,7 @@ module Microsoft.ApplicationInsights {
          * Immediately send all queued telemetry.
          * @param {boolean} async - If flush should be call asynchronously
          */
-        flush(async?: boolean);
+        flush(async = true);
 
 
         /**

--- a/JavaScript/JavaScriptSDK.Interfaces/IAppInsights.ts
+++ b/JavaScript/JavaScriptSDK.Interfaces/IAppInsights.ts
@@ -114,8 +114,9 @@ module Microsoft.ApplicationInsights {
 
         /**
          * Immediately send all queued telemetry.
+         * @param {boolean} async - If flush should be call asynchronously
          */
-        flush();
+        flush(async?: boolean);
 
 
         /**

--- a/JavaScript/JavaScriptSDK.Interfaces/IAppInsights.ts
+++ b/JavaScript/JavaScriptSDK.Interfaces/IAppInsights.ts
@@ -116,7 +116,7 @@ module Microsoft.ApplicationInsights {
          * Immediately send all queued telemetry.
          * @param {boolean} async - If flush should be call asynchronously
          */
-        flush(async = true);
+        flush(async?: boolean);
 
 
         /**

--- a/JavaScript/JavaScriptSDK/AppInsights.ts
+++ b/JavaScript/JavaScriptSDK/AppInsights.ts
@@ -409,17 +409,9 @@ module Microsoft.ApplicationInsights {
          * Immediately send all queued telemetry.
          * @param {boolean} async - If flush should be call asynchronously
          */
-        public flush(async?: boolean) {
-            // We are async by default
-            var isAsync = true;
-
-            // Respect the parameter passed to the func
-            if (typeof async === 'boolean') {
-                isAsync = async;
-            }
-
+        public flush(async = true) {
             try {
-                this.context._sender.triggerSend(isAsync);
+                this.context._sender.triggerSend(async);
             } catch (e) {
                 _InternalLogging.throwInternal(LoggingSeverity.CRITICAL,
                     _InternalMessageId.FlushFailed,

--- a/JavaScript/JavaScriptSDK/AppInsights.ts
+++ b/JavaScript/JavaScriptSDK/AppInsights.ts
@@ -407,10 +407,19 @@ module Microsoft.ApplicationInsights {
 
         /**
          * Immediately send all queued telemetry.
+         * @param {boolean} async - If flush should be call asynchronously
          */
-        public flush() {
+        public flush(async?: boolean) {
+            // We are async by default
+            var isAsync = true;
+
+            // Respect the parameter passed to the func
+            if (typeof async === 'boolean') {
+                isAsync = async;
+            }
+
             try {
-                this.context._sender.triggerSend();
+                this.context._sender.triggerSend(isAsync);
             } catch (e) {
                 _InternalLogging.throwInternal(LoggingSeverity.CRITICAL,
                     _InternalMessageId.FlushFailed,

--- a/JavaScript/JavaScriptSDK/Sender.ts
+++ b/JavaScript/JavaScriptSDK/Sender.ts
@@ -251,17 +251,9 @@ module Microsoft.ApplicationInsights {
 
         /**
          * Immediately send buffered data
-         * @param async {boolean} - Indicates if the events should be sent asynchronously (Optional, Defaults to true)
+         * @param async {boolean} - Indicates if the events should be sent asynchronously
          */
-        public triggerSend(async?: boolean) {
-            // We are async by default
-            var isAsync = true;
-
-            // Respect the parameter passed to the func
-            if (typeof async === 'boolean') {
-                isAsync = async;
-            }
-
+        public triggerSend(async = true) {
             try {
                 // Send data only if disableTelemetry is false
                 if (!this._config.disableTelemetry()) {
@@ -270,7 +262,7 @@ module Microsoft.ApplicationInsights {
                         var payload = this._buffer.getItems();
 
                         // invoke send
-                        this._sender(payload, isAsync);
+                        this._sender(payload, async);
                     }
 
                     // update lastSend time to enable throttling


### PR DESCRIPTION
Allows the flush method exposed via the SDK to be called with an optional parameter to perform the flush synchronously.