### PR TITLE
bug(AppInsightsModule): fix window issue during server renders

### DIFF
--- a/JavaScript/JavaScriptSDK.Module/AppInsightsModule.ts
+++ b/JavaScript/JavaScriptSDK.Module/AppInsightsModule.ts
@@ -92,6 +92,9 @@ class AppInsightsModule {
     }
 
     public static get appInsightsInstance(): Microsoft.ApplicationInsights.IAppInsights {
+        if (typeof window === 'undefined') {
+            return;
+        }
         if (!window[AppInsightsModule.appInsightsName]) {
             window[AppInsightsModule.appInsightsName] = {
                 downloadAndSetup: AppInsightsModule._download,


### PR DESCRIPTION
 Fixes #387 

When using the library in a server-rendered scenario (ie: angular universal), even when you conditionally wrap the code to make sure it only is ran in an `isPlatformBrowser()` scenario, the `get appInsightsInstance` is still packaged into the server bundle, and errors out due window being used (when it doesn't exist).

This allows a server bundle to continue rendering without errors, and then the client-side JS code can run and connect to Application Insights.

cc/ @KamilSzostak 

--- 

Repro case here (sort of involved as it's an aspnetcore + angular + SSR solution similar to JavaScriptServices)
https://github.com/MarkPieszak/aspnetcore-angular2-universal/tree/app-insights-ssr-bug

An unhandled exception occurred while processing the request.

### Error details:
> Exception: Call to Node module failed with error: Prerendering failed because of error: ReferenceError: window is not defined
> at Function.get [as appInsightsInstance] (C:\Users\mark.pieszak\Documents\GitHub\aspnetcore-angular2-universal\Client\dist\main-server.js:116372:22)

Line it's referencing above:
`if (!window[AppInsightsModule.appInsightsName]) {` <--

Tested added `if (typeof window === 'undefined') { return; }` fixes, and server rendering continues.

---

Linked bugs:
https://github.com/MarkPieszak/aspnetcore-angular2-universal/issues/329
https://github.com/MarkPieszak/angular-application-insights/issues/15
