### PR TITLE
version update 1.0.10 -> 1.0.11

### DIFF
--- a/Global.props
+++ b/Global.props
@@ -90,12 +90,12 @@
     -->
     <SemanticVersionMajor>1</SemanticVersionMajor>
     <SemanticVersionMinor>0</SemanticVersionMinor>
-    <SemanticVersionPatch>10</SemanticVersionPatch>
+    <SemanticVersionPatch>11</SemanticVersionPatch>
     <!-- 
       Date when Semantic Version was changed. 
       Update for every public release.
     -->
-    <SemanticVersionDate>2017-07-07</SemanticVersionDate>
+    <SemanticVersionDate>2017-07-11</SemanticVersionDate>
     <!-- 
       Pre-release version is used to distinguish internally built NuGet packages.
       Pre-release version = Minutes since semantic version was set, divided by 5 (to make it fit in a UInt16).

--- a/JavaScript/JavaScriptSDK/AppInsights.ts
+++ b/JavaScript/JavaScriptSDK/AppInsights.ts
@@ -13,7 +13,7 @@ module Microsoft.ApplicationInsights {
 
     "use strict";
 
-    export var Version = "1.0.10";
+    export var Version = "1.0.11";
 
     /**
     * Internal interface to pass appInsights object to subcomponents without coupling 

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name":  "applicationinsights-js",
     "main":  "dist/ai.0.js",
-    "version":  "1.0.10",
+    "version":  "1.0.11",
     "homepage":  "https://github.com/Microsoft/ApplicationInsights-JS",
     "authors":  [
                     "Application Insights <appinsights@microsoft.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name":  "applicationinsights-js",
-    "version":  "1.0.10",
+    "version":  "1.0.11",
     "description":  "Microsoft Application Insights JavaScript SDK",
     "main":  "JavaScript/JavaScriptSDK.Module/AppInsightsModule.js",
     "keywords":  [


### PR DESCRIPTION
A new version is required to publish a fixed npm package. See #488. 