### PR TITLE
Update API-reference.md

### DIFF
--- a/API-reference.md
+++ b/API-reference.md
@@ -229,7 +229,7 @@ Values that control how the telemetry data is sent.
         // Default 15s
         maxBatchInterval: number;
         
-        // If true, data is sent immediately and not batched.
+        // If true, debugging data is thrown as an exception by the logger. Default false.
         enableDebug: boolean;
                 
         // If true, telemetry data is not collected or sent. Default false.


### PR DESCRIPTION
enableDebug is improperly said to instantly flush telemetry and does not describe the correct behavior