### PR TITLE
Add sdk-context request header only for internal AI services connection

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Context/Session.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Context/Session.tests.ts
@@ -507,6 +507,7 @@ class SessionContextTests extends TestClass {
             sessionExpirationMs: () => null,
             sampleRate: () => null,
             endpointUrl: () => null,
+            isInternalEndpointUrl: () => null,
             cookieDomain: () => null,
             emitLineDelimitedJson: () => null,
             maxBatchSizeInBytes: () => null,

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Context/User.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Context/User.tests.ts
@@ -404,6 +404,7 @@ class UserContextTests extends TestClass {
             sessionExpirationMs: () => null,
             sampleRate: () => null,
             endpointUrl: () => null,
+            isInternalEndpointUrl: () => null,
             cookieDomain: () => null,
             emitLineDelimitedJson: () => null,
             maxBatchSizeInBytes: () => null,

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/SendBuffer.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/SendBuffer.tests.ts
@@ -16,6 +16,7 @@ class SendBufferTests extends TestClass {
             emitLineDelimitedJson: () => false,
             enableSessionStorageBuffer: () => false,
             endpointUrl: () => null,
+            isInternalEndpointUrl: () => null,
             maxBatchSizeInBytes: () => null,
             maxBatchInterval: () => null,
             disableTelemetry: () => null,

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/TelemetryContext.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/TelemetryContext.tests.ts
@@ -16,6 +16,7 @@ class TelemetryContextTests extends TestClass {
             sessionRenewalMs: () => 10,
             sessionExpirationMs: () => 10,
             endpointUrl: () => "asdf",
+            isInternalEndpointUrl: () => true,
             emitLineDelimitedJson: () => false,
             maxBatchSizeInBytes: () => 1000000,
             maxBatchInterval: () => 1,

--- a/JavaScript/JavaScriptSDK.Tests/CheckinTests/Util.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/CheckinTests/Util.tests.ts
@@ -459,6 +459,18 @@ class UtilTests extends TestClass {
                 Assert.equal(8, Util.getIEVersion("Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 10.0; Win64; x64; Trident/7.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729"), "Should return IE version for IE browser");
             }
         });
+
+        this.testCase({
+            name: "isInternalApplicationInsightsEndpoint function handles endpoints correctly",
+            test: () => {
+
+                // Assert
+                Assert.equal(true, Util.isInternalApplicationInsightsEndpoint("https://dc.services.visualstudio.com/v2/track"));
+                Assert.equal(true, Util.isInternalApplicationInsightsEndpoint("https://breeze.aimon.applicationinsights.io/v2/track"));
+                Assert.equal(true, Util.isInternalApplicationInsightsEndpoint("https://dc-int.services.visualstudio.com/v2/track"));
+                Assert.equal(false, Util.isInternalApplicationInsightsEndpoint("https://somethingelse.com/v2/track"));
+            }
+        });
     }
 
     private getMockStorage() {

--- a/JavaScript/JavaScriptSDK.Tests/Selenium/ai.tests.d.ts
+++ b/JavaScript/JavaScriptSDK.Tests/Selenium/ai.tests.d.ts
@@ -368,6 +368,7 @@ declare module Microsoft.ApplicationInsights {
         private static _canUseCookies;
         private static _canUseLocalStorage;
         private static _canUseSessionStorage;
+        private static _internalEndpoints;
         static NotSpecified: string;
         static disableStorage(): void;
         /**
@@ -382,6 +383,13 @@ declare module Microsoft.ApplicationInsights {
          * @return {Storage} Returns storage object verified that it is usable
          */
         private static _getVerifiedStorageObject(storageType);
+        /**
+         *  Checks if endpoint URL is application insights internal injection service URL.
+         *
+         *  @param endpointUrl Endpoint URL to check.
+         *  @returns {boolean} True if if endpoint URL is application insights internal injection service URL.
+         */
+        static isInternalApplicationInsightsEndpoint(endpointUrl: string): boolean;
         /**
          *  Check if the browser supports local storage.
          *
@@ -1593,6 +1601,10 @@ declare module Microsoft.ApplicationInsights {
          * The url to which payloads will be sent
          */
         endpointUrl: () => string;
+        /**
+         * True if endpoint URL is application insights internal injection service URL
+         */
+        isInternalEndpointUrl: () => boolean;
         /**
         * The JSON format (normal vs line delimited). True means line delimited JSON.
         */
@@ -2934,6 +2946,7 @@ declare class SenderTests extends TestClass {
     private loggingSpy;
     private testTelemetry;
     private endpointUrl;
+    private isInternalEndpointUrl;
     private emitLineDelimitedJson;
     private maxBatchSizeInBytes;
     private maxBatchInterval;

--- a/JavaScript/JavaScriptSDK/AppInsights.ts
+++ b/JavaScript/JavaScriptSDK/AppInsights.ts
@@ -68,6 +68,7 @@ module Microsoft.ApplicationInsights {
                 sessionRenewalMs: () => this.config.sessionRenewalMs,
                 sessionExpirationMs: () => this.config.sessionExpirationMs,
                 endpointUrl: () => this.config.endpointUrl,
+                isInternalEndpointUrl: () => Util.isInternalApplicationInsightsEndpoint(this.config.endpointUrl),
                 emitLineDelimitedJson: () => this.config.emitLineDelimitedJson,
                 maxBatchSizeInBytes: () => {
                     return (!this.config.isBeaconApiDisabled && Util.IsBeaconApiSupported()) ?

--- a/JavaScript/JavaScriptSDK/Initialization.ts
+++ b/JavaScript/JavaScriptSDK/Initialization.ts
@@ -145,7 +145,7 @@ module Microsoft.ApplicationInsights {
             }
 
             // set default values
-            config.endpointUrl = config.endpointUrl || "https://dc.services.visualstudio.com/v2/track";
+            config.endpointUrl = (config.endpointUrl || "https://dc.services.visualstudio.com/v2/track").toLowerCase();
             config.sessionRenewalMs = 30 * 60 * 1000;
             config.sessionExpirationMs = 24 * 60 * 60 * 1000;
             config.maxBatchSizeInBytes = config.maxBatchSizeInBytes > 0 ? config.maxBatchSizeInBytes : 102400; // 100kb

--- a/JavaScript/JavaScriptSDK/Sender.ts
+++ b/JavaScript/JavaScriptSDK/Sender.ts
@@ -35,6 +35,11 @@ module Microsoft.ApplicationInsights {
         endpointUrl: () => string;
 
         /**
+         * True if endpoint URL is application insights internal injection service URL
+         */
+        isInternalEndpointUrl: () => boolean;
+
+        /**
         * The JSON format (normal vs line delimited). True means line delimited JSON.
         */
         emitLineDelimitedJson: () => boolean;
@@ -403,6 +408,12 @@ module Microsoft.ApplicationInsights {
             xhr[AjaxMonitor.DisabledPropertyName] = true;
             xhr.open("POST", this._config.endpointUrl(), isAsync);
             xhr.setRequestHeader("Content-type", "application/json");
+
+            // append Sdk-Context request header only in case of breeze endpoint
+            if (this._config.isInternalEndpointUrl()) {
+                xhr.setRequestHeader(RequestHeaders.sdkContextHeader, RequestHeaders.sdkContextHeaderAppIdRequest);
+            }
+
             xhr.onreadystatechange = () => this._xhrReadyStateChange(xhr, payload, payload.length);
             xhr.onerror = (event: ErrorEvent) => this._onError(payload, this._formatErrorMessageXhr(xhr), event);
 

--- a/JavaScript/JavaScriptSDK/Util.ts
+++ b/JavaScript/JavaScriptSDK/Util.ts
@@ -14,6 +14,12 @@ module Microsoft.ApplicationInsights {
         private static _canUseCookies: boolean = undefined;
         private static _canUseLocalStorage: boolean = undefined;
         private static _canUseSessionStorage: boolean = undefined;
+        // listing only non-geo specific locations
+        private static _internalEndpoints: string[] = [
+            "https://dc.services.visualstudio.com/v2/track",
+            "https://breeze.aimon.applicationinsights.io/v2/track",
+            "https://dc-int.services.visualstudio.com/v2/track"
+        ]
         public static NotSpecified = "not_specified";
 
         /*
@@ -61,6 +67,17 @@ module Microsoft.ApplicationInsights {
 
             return storage;
         }
+
+        /**
+         *  Checks if endpoint URL is application insights internal injection service URL.
+         *
+         *  @param endpointUrl Endpoint URL to check.
+         *  @returns {boolean} True if if endpoint URL is application insights internal injection service URL.
+         */
+        public static isInternalApplicationInsightsEndpoint(endpointUrl: string): boolean {           
+            return Util._internalEndpoints.indexOf(endpointUrl) !== -1;
+        }
+
 
         /**
          *  Check if the browser supports local storage.


### PR DESCRIPTION
Sdk-Context header is currently required by Breeze to provide appId in the response body, but sending new custom header may break communication with non-default endpoints like Vortex because it rejects any custom header not explicitly listed in the allowed ones on their side. 

This PR adds Sdk-Context header only for our own internal endpoints - Breeze in Prod/AIMON/INT and doesn't send it if user manually overwrote the endpoint in the config.