### PR TITLE
Remove promise chaining syntax

### DIFF
--- a/JavaScript/JavaScriptSDK/ajax/fetch.ts
+++ b/JavaScript/JavaScriptSDK/ajax/fetch.ts
@@ -81,11 +81,11 @@ module Microsoft.ApplicationInsights {
                         fetchMonitorInstance.onFetchFailed(input, ajaxData, reason);
                         throw reason;
                     });
-
                 }
 
                 return promise;
             };
+            
             window.fetch[FetchMonitor.instrumentedByAppInsightsName] = true;
         }
 

--- a/JavaScript/JavaScriptSDK/ajax/fetch.ts
+++ b/JavaScript/JavaScriptSDK/ajax/fetch.ts
@@ -70,15 +70,21 @@ module Microsoft.ApplicationInsights {
                             });
                     }
                 }
-                return originalFetch(input, init)
-                    .then(response => {
+
+                let promise = originalFetch(input, init);
+                if (promise !== null && promise !== undefined) {
+                promise.then(response => {
                         fetchMonitorInstance.onFetchComplete(response, ajaxData);
                         return response;
-                    })
-                    .catch(reason => {
+                    },
+                    reason => {
                         fetchMonitorInstance.onFetchFailed(input, ajaxData, reason);
                         throw reason;
                     });
+
+                }
+
+                return promise;
             };
             window.fetch[FetchMonitor.instrumentedByAppInsightsName] = true;
         }


### PR DESCRIPTION
The issue with the fetch api instrumentation is that fetch api is based on promise and there is no support for promise in older versions of some browsers. While the code is not run in old versions, script load is failing. This may be due to promise chain syntax that we had. so, taking that out and replacing with alternate syntax.
I still think this won't work, as I'm seeing another script error, much earlier in the script though.
Need to test this out some more. We may need to take out fetch support altogether if this doesnt work.