### PR TITLE
Add IConfig flag for onerror instrumented

### DIFF
--- a/AppInsightsCommon/Interfaces/IConfig.ts
+++ b/AppInsightsCommon/Interfaces/IConfig.ts
@@ -31,4 +31,7 @@ export interface IConfig {
     isBrowserLinkTrackingEnabled?: boolean;
     appId?: string;
     enableCorsCorrelation?: boolean;
+
+    // Internal
+    aiInstrumented?: boolean;
 }

--- a/AppInsightsCommon/amd/package.json
+++ b/AppInsightsCommon/amd/package.json
@@ -1,6 +1,6 @@
 {
     "name": "applicationinsights-common",
-    "version": "0.0.75",
+    "version": "0.0.77",
     "description": "Microsoft Application Insights Common JavaScript Library - AMD version",
     "main": "./bundle/applicationinsights-common.js",
     "types": "./bundle/applicationinsights-common.d.ts",


### PR DESCRIPTION
Internal flag which will be used to determine if window.onerror has been already instrumented by Application Analytics