### PR TITLE
Add support to allow customers to reference new CDN with config parameter that provides deprecated api support.

### DIFF
--- a/AISKU/Tests/ApplicationInsightsDeprecatedTests.ts
+++ b/AISKU/Tests/ApplicationInsightsDeprecatedTests.ts
@@ -29,11 +29,12 @@ export class ApplicationInsightsDeprecatedTests extends TestClass {
                     disableAjaxTracking: false,
                     disableFetchTracking: false
                 },
-                queue: []
+                queue: [],
+                oldApiSupport: true // parameter indicates provide existing api support, default is false
             }
 
             let container = new ApplicationInsightsContainer();
-            this._aiDeprecated = <IAppInsightsDeprecated>(container.getAppInsights(this._snippet, true)); // second parameter indicates provide existing api support, default is false
+            this._aiDeprecated = <IAppInsightsDeprecated>(container.getAppInsights(this._snippet)); 
             // Setup Sinon stuff
             let appInsights = (<any>this._aiDeprecated).appInsightsNew;
             const sender: Sender = appInsights.core['_channelController'].channelQueue[0][0];
@@ -53,14 +54,14 @@ export class ApplicationInsightsDeprecatedTests extends TestClass {
     public registerTests() {
 
         this.addApiTests();
-        // this.testCase({
-        //     name: 'config.oldApiSupport set to true returns support for 1.0 apis',
-        //     test: () => {
+        this.testCase({
+            name: 'config.oldApiSupport set to true returns support for 1.0 apis',
+            test: () => {
 
-        //         Assert.ok(this._aiDeprecated, 'ApplicationInsights SDK exists');
-        //         Assert.ok((<IAppInsightsDeprecated>this._aiDeprecated).downloadAndSetup); // has legacy method
-        //     }
-        // });
+                Assert.ok(this._aiDeprecated, 'ApplicationInsights SDK exists');
+                Assert.ok((<IAppInsightsDeprecated>this._aiDeprecated).downloadAndSetup); // has legacy method
+            }
+        });
     }
 
     public addApiTests(): void {

--- a/AISKU/Tests/ApplicationInsightsDeprecatedTests.ts
+++ b/AISKU/Tests/ApplicationInsightsDeprecatedTests.ts
@@ -1,34 +1,161 @@
 import { IAppInsightsDeprecated } from "../src/ApplicationInsightsDeprecated";
 import { ApplicationInsightsContainer } from "../src/ApplicationInsightsContainer";
 import { Snippet, IApplicationInsights } from "../src/Initialization";
+import { Sender } from "@microsoft/applicationinsights-channel-js";
 
 export class ApplicationInsightsDeprecatedTests extends TestClass {
-    private static readonly _instrumentationKey = '2865A442-8F5E-41EB-AB96-F1922B9E7C09';
-    private _aiDeprecated: IAppInsightsDeprecated | IApplicationInsights;
+    private static readonly _instrumentationKey = 'b7170927-2d1c-44f1-acec-59f4e1751c11';
+    private _aiDeprecated: IAppInsightsDeprecated;
     private _snippet: Snippet;
+
+    // Sinon
+    private errorSpy: SinonSpy;
+    private successSpy: SinonSpy;
+    private loggingSpy: SinonSpy;
+    private clearSpy: SinonSpy;
+    private _name = "ApplicationInsightsDeprecatedTests: ";
     
     public testInitialize() {
-        this._snippet = {
-            config: {
-                instrumentationKey: ApplicationInsightsDeprecatedTests._instrumentationKey,
-                disableAjaxTracking: false,
-                disableFetchTracking: false
-            },
-            queue: []
-        }
+        try {
 
-        let container = new ApplicationInsightsContainer();
-        this._aiDeprecated = container.getAppInsights(this._snippet, true);
+            this.useFakeServer = false;
+            (<any>sinon.fakeServer).restore();
+            this.useFakeTimers = false;
+            this.clock.restore();
+
+            this._snippet = {
+                config: {
+                    instrumentationKey: ApplicationInsightsDeprecatedTests._instrumentationKey,
+                    disableAjaxTracking: false,
+                    disableFetchTracking: false
+                },
+                queue: []
+            }
+
+            let container = new ApplicationInsightsContainer();
+            this._aiDeprecated = <IAppInsightsDeprecated>(container.getAppInsights(this._snippet, true));
+            // Setup Sinon stuff
+            let appInsights = (<any>this._aiDeprecated).appInsightsNew;
+            const sender: Sender = appInsights.core['_channelController'].channelQueue[0][0];
+            this.errorSpy = this.sandbox.spy(sender, '_onError');
+            this.successSpy = this.sandbox.spy(sender, '_onSuccess');
+            this.loggingSpy = this.sandbox.stub(appInsights.core.logger, 'throwInternal');
+        } catch (e) {
+            console.error('Failed to initialize');
+        }
+    }
+
+    public testCleanup() {
+        this.useFakeServer = true;
+        this.useFakeTimers = true;
     }
 
     public registerTests() {
-        this.testCase({
-            name: 'config.oldApiSupport set to true returns support for 1.0 apis',
-            test: () => {
 
-                Assert.ok(this._aiDeprecated, 'ApplicationInsights SDK exists');
-                Assert.ok((<IAppInsightsDeprecated>this._aiDeprecated).downloadAndSetup); // has legacy method
-            }
+        this.addApiTests();
+        // this.testCase({
+        //     name: 'config.oldApiSupport set to true returns support for 1.0 apis',
+        //     test: () => {
+
+        //         Assert.ok(this._aiDeprecated, 'ApplicationInsights SDK exists');
+        //         Assert.ok((<IAppInsightsDeprecated>this._aiDeprecated).downloadAndSetup); // has legacy method
+        //     }
+        // });
+    }
+
+    public addApiTests(): void {
+        this.testCaseAsync({
+            name: this._name + 'ApplicationInsightsDeprecatedTests: trackEvent sends to backend',
+            stepDelay: 1,
+            steps: [() => {
+                this._aiDeprecated.trackEvent('event');
+            }].concat(this.asserts(1))
+        });
+
+        this.testCaseAsync({
+            name: this._name + 'trackTrace sends to backend',
+            stepDelay: 1,
+            steps: [() => {
+                this._aiDeprecated.trackTrace('trace');
+            }].concat(this.asserts(1))
+        });
+
+        this.testCaseAsync({
+            name: this._name + 'trackException sends to backend',
+            stepDelay: 1,
+            steps: [() => {
+                let exception: Error = null;
+                try {
+                    window['a']['b']();
+                    Assert.ok(false, 'trackException test not run');
+                } catch (e) {
+                    exception = e;
+                    this._aiDeprecated.trackException(exception);
+                }
+                Assert.ok(exception);
+            }].concat(this.asserts(1))
+        });
+
+        this.testCaseAsync({
+            name: this._name + "track metric",
+            stepDelay: 1,
+            steps: [
+                () => {
+                    console.log("* calling trackMetric " + new Date().toISOString());
+                    for (var i = 0; i < 100; i++) {
+                        this._aiDeprecated.trackMetric("test" + i,Math.round(100 * Math.random()));
+                    }
+                    console.log("* done calling trackMetric " + new Date().toISOString());
+                }
+            ].concat(this.asserts(100))
+        });
+
+        this.testCaseAsync({
+            name: this._name + "track page view",
+            stepDelay: 1,
+            steps: [
+                () => {
+                    this._aiDeprecated.trackPageView(); // sends 2
+                }
+            ].concat(this.asserts(2))
         });
     }
+
+    private boilerPlateAsserts = () => {
+        Assert.ok(this.successSpy.called, "success");
+        Assert.ok(!this.errorSpy.called, "no error sending");
+        var isValidCallCount = this.loggingSpy.callCount === 0;
+        Assert.ok(isValidCallCount, "logging spy was called 0 time(s)");
+        if (!isValidCallCount) {
+            while (this.loggingSpy.args.length) {
+                Assert.ok(false, "[warning thrown]: " + this.loggingSpy.args.pop());
+            }
+        }
+    }
+    private asserts: any = (expectedCount: number) => [() => {
+        var message = "polling: " + new Date().toISOString();
+        Assert.ok(true, message);
+        console.log(message);
+
+        if (this.successSpy.called) {
+            this.boilerPlateAsserts();
+            this.testCleanup();
+        } else if (this.errorSpy.called || this.loggingSpy.called) {
+            this.boilerPlateAsserts();
+        }
+    },
+    (PollingAssert.createPollingAssert(() => {
+        Assert.ok(true, "* checking success spy " + new Date().toISOString());
+
+        if(this.successSpy.called) {
+            let currentCount: number = 0;
+            this.successSpy.args.forEach(call => {
+                currentCount += call[1];
+            });
+            console.log('curr: ' + currentCount + ' exp: ' + expectedCount);
+            return currentCount === expectedCount;
+        } else {
+            return false;
+        }
+    }, "sender succeeded", 30, 1000))];
 }

--- a/AISKU/Tests/ApplicationInsightsDeprecatedTests.ts
+++ b/AISKU/Tests/ApplicationInsightsDeprecatedTests.ts
@@ -33,7 +33,7 @@ export class ApplicationInsightsDeprecatedTests extends TestClass {
             }
 
             let container = new ApplicationInsightsContainer();
-            this._aiDeprecated = <IAppInsightsDeprecated>(container.getAppInsights(this._snippet, true));
+            this._aiDeprecated = <IAppInsightsDeprecated>(container.getAppInsights(this._snippet, true)); // second parameter indicates provide existing api support, default is false
             // Setup Sinon stuff
             let appInsights = (<any>this._aiDeprecated).appInsightsNew;
             const sender: Sender = appInsights.core['_channelController'].channelQueue[0][0];

--- a/AISKU/Tests/ApplicationInsightsDeprecatedTests.ts
+++ b/AISKU/Tests/ApplicationInsightsDeprecatedTests.ts
@@ -1,0 +1,34 @@
+import { IAppInsightsDeprecated } from "../src/ApplicationInsightsDeprecated";
+import { ApplicationInsightsContainer } from "../src/ApplicationInsightsContainer";
+import { Snippet, IApplicationInsights } from "../src/Initialization";
+
+export class ApplicationInsightsDeprecatedTests extends TestClass {
+    private static readonly _instrumentationKey = '2865A442-8F5E-41EB-AB96-F1922B9E7C09';
+    private _aiDeprecated: IAppInsightsDeprecated | IApplicationInsights;
+    private _snippet: Snippet;
+    
+    public testInitialize() {
+        this._snippet = {
+            config: {
+                instrumentationKey: ApplicationInsightsDeprecatedTests._instrumentationKey,
+                disableAjaxTracking: false,
+                disableFetchTracking: false
+            },
+            queue: []
+        }
+
+        let container = new ApplicationInsightsContainer();
+        this._aiDeprecated = container.getAppInsights(this._snippet, true);
+    }
+
+    public registerTests() {
+        this.testCase({
+            name: 'config.oldApiSupport set to true returns support for 1.0 apis',
+            test: () => {
+
+                Assert.ok(this._aiDeprecated, 'ApplicationInsights SDK exists');
+                Assert.ok((<IAppInsightsDeprecated>this._aiDeprecated).downloadAndSetup); // has legacy method
+            }
+        });
+    }
+}

--- a/AISKU/Tests/Selenium/appinsights-sdk.tests.ts
+++ b/AISKU/Tests/Selenium/appinsights-sdk.tests.ts
@@ -2,8 +2,10 @@ import { ApplicationInsightsTests } from '../applicationinsights.e2e.tests';
 import { SanitizerE2ETests } from '../sanitizer.e2e.tests';
 import { ValidateE2ETests } from '../validate.e2e.tests';
 import { SenderE2ETests } from '../sender.e2e.tests';
+import { ApplicationInsightsDeprecatedTests } from '../ApplicationInsightsDeprecatedTests';
 
 new ApplicationInsightsTests().registerTests();
+new ApplicationInsightsDeprecatedTests().registerTests();
 new SanitizerE2ETests().registerTests();
 new ValidateE2ETests().registerTests();
 new SenderE2ETests().registerTests();

--- a/AISKU/src/ApplicationInsightsContainer.ts
+++ b/AISKU/src/ApplicationInsightsContainer.ts
@@ -1,0 +1,14 @@
+import { IAppInsightsDeprecated, AppInsightsDeprecated } from "./ApplicationInsightsDeprecated";
+import { Initialization, Snippet, IApplicationInsights } from "./Initialization";
+
+export class ApplicationInsightsContainer {
+
+    getAppInsights(snippet: Snippet, hasDeprecatedSupport: boolean = false) : IApplicationInsights | IAppInsightsDeprecated {
+        let init = new Initialization(snippet);
+        if (!hasDeprecatedSupport) {
+            return init;
+        } else {
+            return new AppInsightsDeprecated(snippet, init.loadAppInsights());
+        }
+    }
+}

--- a/AISKU/src/ApplicationInsightsContainer.ts
+++ b/AISKU/src/ApplicationInsightsContainer.ts
@@ -1,14 +1,16 @@
 import { IAppInsightsDeprecated, AppInsightsDeprecated } from "./ApplicationInsightsDeprecated";
-import { Initialization, Snippet, IApplicationInsights } from "./Initialization";
+import { Initialization as ApplicationInsights, Snippet, IApplicationInsights } from "./Initialization";
 
 export class ApplicationInsightsContainer {
 
-    getAppInsights(snippet: Snippet, hasDeprecatedSupport: boolean = false) : IApplicationInsights | IAppInsightsDeprecated {
-        let init = new Initialization(snippet);
-        if (!hasDeprecatedSupport) {
-            return init;
+    getAppInsights(snippet: Snippet, oldApiSupport: boolean = false) : IApplicationInsights | IAppInsightsDeprecated {
+        let initialization = new ApplicationInsights(snippet);
+        initialization.loadAppInsights();
+        
+        if (!oldApiSupport) {
+            return initialization;
         } else {
-            return new AppInsightsDeprecated(snippet, init.loadAppInsights());
+            return new AppInsightsDeprecated(snippet, initialization);
         }
     }
 }

--- a/AISKU/src/ApplicationInsightsContainer.ts
+++ b/AISKU/src/ApplicationInsightsContainer.ts
@@ -1,13 +1,14 @@
 import { IAppInsightsDeprecated, AppInsightsDeprecated } from "./ApplicationInsightsDeprecated";
 import { Initialization as ApplicationInsights, Snippet, IApplicationInsights } from "./Initialization";
+import { CoreUtils } from "@microsoft/applicationinsights-core-js";
 
 export class ApplicationInsightsContainer {
 
-    getAppInsights(snippet: Snippet, oldApiSupport: boolean = false) : IApplicationInsights | IAppInsightsDeprecated {
+    getAppInsights(snippet: Snippet) : IApplicationInsights | IAppInsightsDeprecated {
         let initialization = new ApplicationInsights(snippet);
         initialization.loadAppInsights();
         
-        if (!oldApiSupport) {
+        if (snippet && CoreUtils.isNullOrUndefined(snippet.oldApiSupport)) {
             return initialization;
         } else {
             return new AppInsightsDeprecated(snippet, initialization);

--- a/AISKU/src/ApplicationInsightsDeprecated.ts
+++ b/AISKU/src/ApplicationInsightsDeprecated.ts
@@ -1,6 +1,6 @@
 import { IConfig, PageViewPerformance, SeverityLevel, Util, IPageViewPerformanceTelemetry, 
     IPageViewTelemetry, ITraceTelemetry, IMetricTelemetry, 
-    IAutoExceptionTelemetry, IDependencyTelemetry, IExceptionTelemetry } from "@microsoft/applicationinsights-common";
+    IAutoExceptionTelemetry, IDependencyTelemetry, IExceptionTelemetry, IEventTelemetry } from "@microsoft/applicationinsights-common";
 import { ITelemetryContext } from "@microsoft/applicationinsights-properties-js/types/Interfaces/ITelemetryContext";
 import { Snippet, IApplicationInsights } from "./Initialization";
 
@@ -35,7 +35,7 @@ export class AppInsightsDeprecated implements IAppInsightsDeprecated {
     }
 
     trackEvent(name: string, properties?: Object, measurements?: Object) {
-        throw new Error("Method not implemented.");
+        this.appInsightsNew.trackEvent(<IEventTelemetry>{ name: name});
     }
     trackDependency(id: string, method: string, absoluteUrl: string, pathName: string, totalTime: number, success: boolean, resultCode: number) {
         this.appInsightsNew.trackDependencyData(

--- a/AISKU/src/ApplicationInsightsDeprecated.ts
+++ b/AISKU/src/ApplicationInsightsDeprecated.ts
@@ -1,0 +1,302 @@
+import { IConfig, PageViewPerformance, SeverityLevel, Util, IPageViewPerformanceTelemetry, IPageViewTelemetry, IEventTelemetry, ITraceTelemetry, IMetricTelemetry, IExceptionTelemetry, IAutoExceptionTelemetry } from "@microsoft/applicationinsights-common";
+import { ITelemetryContext } from "@microsoft/applicationinsights-properties-js/types/Interfaces/ITelemetryContext";
+import { Snippet, IApplicationInsights } from "./Initialization";
+
+export class AppInsightsDeprecated implements IAppInsightsDeprecated {
+    public config: IConfig;
+    public snippet: Snippet;
+    public context: ITelemetryContext;
+    queue: (() => void)[];
+    private appInsightsNew: IApplicationInsights;
+
+    constructor(snippet: Snippet, appInsightsNew: IApplicationInsights) {
+        this.config = AppInsightsDeprecated.getDefaultConfig(snippet.config);
+        this.appInsightsNew = appInsightsNew;
+    }
+
+    startTrackPage(name?: string) {
+        this.appInsightsNew.startTrackPage(name);
+    }
+
+    stopTrackPage(name?: string, url?: string, properties?: { [name: string]: string; }, measurements?: { [name: string]: number; }) {
+        this.appInsightsNew.stopTrackPage(name, url, properties); // update
+    }
+
+    trackPageView(name?: string, url?: string, properties?: Object, measurements?: Object, duration?: number) {
+        let telemetry: IPageViewTelemetry = {
+            name: name,
+            uri: url
+        };
+
+        // fix for props, measurements, duration
+        this.appInsightsNew.trackPageView(telemetry);
+    }
+
+    startTrackEvent(name: string) {
+        this.appInsightsNew.trackEvent(<IEventTelemetry>{ name: name});
+    }
+
+    stopTrackEvent(name: string, properties?: { [name: string]: string; }, measurements?: { [name: string]: number; }) {
+        throw new Error("Method not implemented.");
+    }
+
+    trackEvent(name: string, properties?: Object, measurements?: Object) {
+        throw new Error("Method not implemented.");
+    }
+    trackDependency(id: string, method: string, absoluteUrl: string, pathName: string, totalTime: number, success: boolean, resultCode: number) {
+        throw new Error("Method not implemented.");
+    }
+    trackException(exception: Error, handledAt?: string, properties?: { [name: string]: string; }, measurements?: { [name: string]: number; }, severityLevel?: any) {
+        throw new Error("Method not implemented.");
+    }
+
+    trackMetric(name: string, average: number, sampleCount?: number, min?: number, max?: number, properties?: { [name: string]: string; }) {
+        this.appInsightsNew.trackMetric(<IMetricTelemetry>{name: name, average: average, sampleCount: sampleCount, min: min, max: max});
+    }
+
+    trackTrace(message: string, properties?: { [name: string]: string; }, severityLevel?: any) {
+        this.appInsightsNew.trackTrace(<ITraceTelemetry>{ message: message, severityLevel: severityLevel });
+    }
+
+    flush(async?: boolean) {
+        this.appInsightsNew.flush(async);
+    }
+
+    setAuthenticatedUserContext(authenticatedUserId: string, accountId?: string, storeInCookie?: boolean) {
+        this.appInsightsNew.setAuthenticatedUserContext(authenticatedUserId, accountId, storeInCookie);
+    }
+
+    clearAuthenticatedUserContext() {
+        this.appInsightsNew.clearAuthenticatedUserContext();
+    }
+    
+    _onerror(message: string, url: string, lineNumber: number, columnNumber: number, error: Error) {
+        this.appInsightsNew._onerror(<IAutoExceptionTelemetry>{ message: message, url: url, lineNumber: lineNumber, columnNumber: columnNumber, error: error });
+    }
+    
+    
+    downloadAndSetup?(config: IConfig): void {
+        throw new Error("downloadAndSetup not implemented in web SKU");
+    }
+
+    // note: these are split into methods to enable unit tests
+    public loadAppInsights() {
+
+        // initialize global instance of appInsights
+        //var appInsights = new Microsoft.ApplicationInsights.AppInsights(this.config);
+
+        // implement legacy version of trackPageView for 0.10<
+        if (this.config["iKey"]) {
+            var originalTrackPageView = this.trackPageView;
+            this.trackPageView = (pagePath?: string, properties?: Object, measurements?: Object) => {
+                originalTrackPageView.apply(this, [null, pagePath, properties, measurements]);
+            }
+        }
+
+        // implement legacy pageView interface if it is present in the snippet
+        var legacyPageView = "logPageView";
+        if (typeof this.snippet[legacyPageView] === "function") {
+            this[legacyPageView] = (pagePath?: string, properties?: Object, measurements?: Object) => {
+                this.trackPageView(null, pagePath, properties, measurements);
+            }
+        }
+
+        // implement legacy event interface if it is present in the snippet
+        var legacyEvent = "logEvent";
+        if (typeof this.snippet[legacyEvent] === "function") {
+            this[legacyEvent] = (name: string, props?: Object, measurements?: Object) => {
+                this.trackEvent(name, props, measurements);
+            }
+        }
+
+        return this;
+    }
+
+    private static getDefaultConfig(config?: any): any {
+        if (!config) {
+            config = <any>{};
+        }
+
+        // set default values
+        config.endpointUrl = config.endpointUrl || "https://dc.services.visualstudio.com/v2/track";
+        config.sessionRenewalMs = 30 * 60 * 1000;
+        config.sessionExpirationMs = 24 * 60 * 60 * 1000;
+        config.maxBatchSizeInBytes = config.maxBatchSizeInBytes > 0 ? config.maxBatchSizeInBytes : 102400; // 100kb
+        config.maxBatchInterval = !isNaN(config.maxBatchInterval) ? config.maxBatchInterval : 15000;
+        config.enableDebug = Util.stringToBoolOrDefault(config.enableDebug);
+        config.disableExceptionTracking = Util.stringToBoolOrDefault(config.disableExceptionTracking);
+        config.disableTelemetry = Util.stringToBoolOrDefault(config.disableTelemetry);
+        config.verboseLogging = Util.stringToBoolOrDefault(config.verboseLogging);
+        config.emitLineDelimitedJson = Util.stringToBoolOrDefault(config.emitLineDelimitedJson);
+        config.diagnosticLogInterval = config.diagnosticLogInterval || 10000;
+        config.autoTrackPageVisitTime = Util.stringToBoolOrDefault(config.autoTrackPageVisitTime);
+
+        if (isNaN(config.samplingPercentage) || config.samplingPercentage <= 0 || config.samplingPercentage >= 100) {
+            config.samplingPercentage = 100;
+        }
+
+        config.disableAjaxTracking = Util.stringToBoolOrDefault(config.disableAjaxTracking);
+        config.maxAjaxCallsPerView = !isNaN(config.maxAjaxCallsPerView) ? config.maxAjaxCallsPerView : 500;
+      
+        config.isBeaconApiDisabled = Util.stringToBoolOrDefault(config.isBeaconApiDisabled, true);
+        config.disableCorrelationHeaders = Util.stringToBoolOrDefault(config.disableCorrelationHeaders);
+        config.correlationHeaderExcludedDomains = config.correlationHeaderExcludedDomains || [
+            "*.blob.core.windows.net", 
+            "*.blob.core.chinacloudapi.cn",
+            "*.blob.core.cloudapi.de",
+            "*.blob.core.usgovcloudapi.net"];
+        config.disableFlushOnBeforeUnload = Util.stringToBoolOrDefault(config.disableFlushOnBeforeUnload);
+        config.enableSessionStorageBuffer = Util.stringToBoolOrDefault(config.enableSessionStorageBuffer, true);
+        config.isRetryDisabled = Util.stringToBoolOrDefault(config.isRetryDisabled);
+        config.isCookieUseDisabled = Util.stringToBoolOrDefault(config.isCookieUseDisabled);
+        config.isStorageUseDisabled = Util.stringToBoolOrDefault(config.isStorageUseDisabled);
+        config.isBrowserLinkTrackingEnabled = Util.stringToBoolOrDefault(config.isBrowserLinkTrackingEnabled);
+        config.enableCorsCorrelation = Util.stringToBoolOrDefault(config.enableCorsCorrelation);
+
+        return config;
+    }
+}
+
+export interface IAppInsightsDeprecated {
+
+    /*
+    * Config object used to initialize AppInsights
+    */
+    config: IConfig;
+
+    context: ITelemetryContext;
+
+    /*
+    * Initialization queue. Contains functions to run when appInsights initializes
+    */
+    queue: Array<() => void>;
+
+    /**
+    * Starts timing how long the user views a page or other item. Call this when the page opens.
+    * This method doesn't send any telemetry. Call `stopTrackPage` to log the page when it closes.
+    * @param   name  A string that idenfities this item, unique within this HTML document. Defaults to the document title.
+    */
+    startTrackPage(name?: string);
+
+    /**
+    * Logs how long a page or other item was visible, after `startTrackPage`. Call this when the page closes.
+    * @param   name  The string you used as the name in startTrackPage. Defaults to the document title.
+    * @param   url   String - a relative or absolute URL that identifies the page or other item. Defaults to the window location.
+    * @param   properties  map[string, string] - additional data used to filter pages and metrics in the portal. Defaults to empty.
+    * @param   measurements    map[string, number] - metrics associated with this page, displayed in Metrics Explorer on the portal. Defaults to empty.
+    */
+    stopTrackPage(name?: string, url?: string, properties?: { [name: string]: string; }, measurements?: { [name: string]: number; });
+
+    /**
+     * Logs that a page or other item was viewed.
+     * @param   name  The string you used as the name in `startTrackPage`. Defaults to the document title.
+     * @param   url   String - a relative or absolute URL that identifies the page or other item. Defaults to the window location.
+     * @param   properties  map[string, string] - additional data used to filter pages and metrics in the portal. Defaults to empty.
+     * @param   measurements    map[string, number] - metrics associated with this page, displayed in Metrics Explorer on the portal. Defaults to empty.
+     * @param   duration    number - the number of milliseconds it took to load the page. Defaults to undefined. If set to default value, page load time is calculated internally.
+     */
+    trackPageView(name?: string, url?: string, properties?: { [name: string]: string; }, measurements?: { [name: string]: number; }, duration?: number);
+
+    /**
+     * Start timing an extended event. Call `stopTrackEvent` to log the event when it ends.
+     * @param   name    A string that identifies this event uniquely within the document.
+     */
+    startTrackEvent(name: string);
+
+
+    /**
+     * Log an extended event that you started timing with `startTrackEvent`.
+     * @param   name    The string you used to identify this event in `startTrackEvent`.
+     * @param   properties  map[string, string] - additional data used to filter events and metrics in the portal. Defaults to empty.
+     * @param   measurements    map[string, number] - metrics associated with this event, displayed in Metrics Explorer on the portal. Defaults to empty.
+     */
+    stopTrackEvent(name: string, properties?: { [name: string]: string; }, measurements?: { [name: string]: number; });
+
+    /**
+    * Log a user action or other occurrence.
+    * @param   name    A string to identify this event in the portal.
+    * @param   properties  map[string, string] - additional data used to filter events and metrics in the portal. Defaults to empty.
+    * @param   measurements    map[string, number] - metrics associated with this event, displayed in Metrics Explorer on the portal. Defaults to empty.
+    */
+    trackEvent(name: string, properties?: { [name: string]: string; }, measurements?: { [name: string]: number; });
+
+    /**
+     * Log a dependency call
+     * @param id    unique id, this is used by the backend o correlate server requests. Use Util.newId() to generate a unique Id.
+     * @param method    represents request verb (GET, POST, etc.)
+     * @param absoluteUrl   absolute url used to make the dependency request
+     * @param pathName  the path part of the absolute url
+     * @param totalTime total request time
+     * @param success   indicates if the request was sessessful
+     * @param resultCode    response code returned by the dependency request
+     */
+    trackDependency(id: string, method: string, absoluteUrl: string, pathName: string, totalTime: number, success: boolean, resultCode: number);
+
+    /**
+     * Log an exception you have caught.
+     * @param   exception   An Error from a catch clause, or the string error message.
+     * @param   handledAt   Not used
+     * @param   properties  map[string, string] - additional data used to filter events and metrics in the portal. Defaults to empty.
+     * @param   measurements    map[string, number] - metrics associated with this event, displayed in Metrics Explorer on the portal. Defaults to empty.
+     * @param   severityLevel   SeverityLevel - severity level
+     */
+    trackException(exception: Error, handledAt?: string, properties?: { [name: string]: string; }, measurements?: { [name: string]: number; }, severityLevel?: SeverityLevel);
+
+    /**
+     * Log a numeric value that is not associated with a specific event. Typically used to send regular reports of performance indicators.
+     * To send a single measurement, use just the first two parameters. If you take measurements very frequently, you can reduce the
+     * telemetry bandwidth by aggregating multiple measurements and sending the resulting average at intervals.
+     * @param   name    A string that identifies the metric.
+     * @param   average Number representing either a single measurement, or the average of several measurements.
+     * @param   sampleCount The number of measurements represented by the average. Defaults to 1.
+     * @param   min The smallest measurement in the sample. Defaults to the average.
+     * @param   max The largest measurement in the sample. Defaults to the average.
+     */
+    trackMetric(name: string, average: number, sampleCount?: number, min?: number, max?: number, properties?: { [name: string]: string; });
+
+    /**
+    * Log a diagnostic message.
+    * @param   message A message string
+    * @param   properties  map[string, string] - additional data used to filter traces in the portal. Defaults to empty.
+    * @param   severityLevel   SeverityLevel - severity level
+    */
+    trackTrace(message: string, properties?: { [name: string]: string; }, severityLevel?: SeverityLevel);
+
+
+    /**
+     * Immediately send all queued telemetry.
+     * @param {boolean} async - If flush should be call asynchronously
+     */
+    flush(async?: boolean);
+
+
+    /**
+    * Sets the autheticated user id and the account id in this session.
+    * User auth id and account id should be of type string. They should not contain commas, semi-colons, equal signs, spaces, or vertical-bars.
+    *
+    * @param authenticatedUserId {string} - The authenticated user id. A unique and persistent string that represents each authenticated user in the service.
+    * @param accountId {string} - An optional string to represent the account associated with the authenticated user.
+    */
+    setAuthenticatedUserContext(authenticatedUserId: string, accountId?: string, storeInCookie?: boolean);
+
+
+    /**
+     * Clears the authenticated user id and the account id from the user context.
+     */
+    clearAuthenticatedUserContext();
+
+    /*
+    * Downloads and initializes AppInsights. You can override default script download location by specifying url property of `config`.
+    */
+    downloadAndSetup?(config: IConfig): void;
+
+    /**
+     * The custom error handler for Application Insights
+     * @param {string} message - The error message
+     * @param {string} url - The url where the error was raised
+     * @param {number} lineNumber - The line number where the error was raised
+     * @param {number} columnNumber - The column number for the line where the error was raised
+     * @param {Error}  error - The Error object
+     */
+    _onerror(message: string, url: string, lineNumber: number, columnNumber: number, error: Error);
+}

--- a/AISKU/src/ApplicationInsightsDeprecated.ts
+++ b/AISKU/src/ApplicationInsightsDeprecated.ts
@@ -4,6 +4,7 @@ import { IConfig, PageViewPerformance, SeverityLevel, Util, IPageViewPerformance
 import { ITelemetryContext } from "@microsoft/applicationinsights-properties-js/types/Interfaces/ITelemetryContext";
 import { Snippet, IApplicationInsights } from "./Initialization";
 
+// ToDo: fix properties and measurements once updates are done to common
 export class AppInsightsDeprecated implements IAppInsightsDeprecated {
     public config: IConfig;
     public snippet: Snippet;

--- a/AISKU/src/ApplicationInsightsDeprecated.ts
+++ b/AISKU/src/ApplicationInsightsDeprecated.ts
@@ -1,4 +1,6 @@
-import { IConfig, PageViewPerformance, SeverityLevel, Util, IPageViewPerformanceTelemetry, IPageViewTelemetry, IEventTelemetry, ITraceTelemetry, IMetricTelemetry, IExceptionTelemetry, IAutoExceptionTelemetry } from "@microsoft/applicationinsights-common";
+import { IConfig, PageViewPerformance, SeverityLevel, Util, IPageViewPerformanceTelemetry, 
+    IPageViewTelemetry, ITraceTelemetry, IMetricTelemetry, 
+    IAutoExceptionTelemetry, IDependencyTelemetry, IExceptionTelemetry } from "@microsoft/applicationinsights-common";
 import { ITelemetryContext } from "@microsoft/applicationinsights-properties-js/types/Interfaces/ITelemetryContext";
 import { Snippet, IApplicationInsights } from "./Initialization";
 
@@ -32,22 +34,26 @@ export class AppInsightsDeprecated implements IAppInsightsDeprecated {
         this.appInsightsNew.trackPageView(telemetry);
     }
 
-    startTrackEvent(name: string) {
-        this.appInsightsNew.trackEvent(<IEventTelemetry>{ name: name});
-    }
-
-    stopTrackEvent(name: string, properties?: { [name: string]: string; }, measurements?: { [name: string]: number; }) {
-        throw new Error("Method not implemented.");
-    }
-
     trackEvent(name: string, properties?: Object, measurements?: Object) {
         throw new Error("Method not implemented.");
     }
     trackDependency(id: string, method: string, absoluteUrl: string, pathName: string, totalTime: number, success: boolean, resultCode: number) {
-        throw new Error("Method not implemented.");
+        this.appInsightsNew.trackDependencyData(
+            <IDependencyTelemetry>{ 
+                id: id, 
+                absoluteUrl: absoluteUrl, 
+                commandName: pathName, 
+                duration: totalTime,
+                method: method, 
+                success: success, 
+                resultCode: resultCode
+            });
     }
+
     trackException(exception: Error, handledAt?: string, properties?: { [name: string]: string; }, measurements?: { [name: string]: number; }, severityLevel?: any) {
-        throw new Error("Method not implemented.");
+        this.appInsightsNew.trackException(<IExceptionTelemetry>{
+            error: exception
+        });
     }
 
     trackMetric(name: string, average: number, sampleCount?: number, min?: number, max?: number, properties?: { [name: string]: string; }) {
@@ -75,6 +81,14 @@ export class AppInsightsDeprecated implements IAppInsightsDeprecated {
     }
     
     
+    startTrackEvent(name: string) {
+        throw new Error("Method not implemented.");
+    }
+
+    stopTrackEvent(name: string, properties?: { [name: string]: string; }, measurements?: { [name: string]: number; }) {
+        throw new Error("Method not implemented.");
+    }
+
     downloadAndSetup?(config: IConfig): void {
         throw new Error("downloadAndSetup not implemented in web SKU");
     }
@@ -184,6 +198,7 @@ export interface IAppInsightsDeprecated {
     * @param   url   String - a relative or absolute URL that identifies the page or other item. Defaults to the window location.
     * @param   properties  map[string, string] - additional data used to filter pages and metrics in the portal. Defaults to empty.
     * @param   measurements    map[string, number] - metrics associated with this page, displayed in Metrics Explorer on the portal. Defaults to empty.
+    * @deprecated API is deprecated; supported only if input configuration specifies deprecated=true
     */
     stopTrackPage(name?: string, url?: string, properties?: { [name: string]: string; }, measurements?: { [name: string]: number; });
 

--- a/AISKU/src/Init.ts
+++ b/AISKU/src/Init.ts
@@ -26,7 +26,7 @@ try {
                 // overwrite snippet with full appInsights
 
                 let appInsightsContainer = new ApplicationInsightsContainer();
-                var initialization = appInsightsContainer.getAppInsights(snippet, oldApiSupport);
+                var initialization = appInsightsContainer.getAppInsights(snippet);
                 
                 // apply full appInsights to the global instance that was initialized in the snippet
                 for (var field in initialization) {

--- a/AISKU/src/Init.ts
+++ b/AISKU/src/Init.ts
@@ -22,7 +22,7 @@ try {
             if (window[aiName].initialize) { // initialize if required
                 // this is the typical case for browser+snippet
                 var snippet: Snippet = window[aiName] || <any>{};
-                let oldApiSupport = snippet && snippet.config && snippet.config.oldApiSupport === true;
+                let oldApiSupport = snippet && snippet.oldApiSupport === true;
                 // overwrite snippet with full appInsights
 
                 let appInsightsContainer = new ApplicationInsightsContainer();

--- a/AISKU/src/Init.ts
+++ b/AISKU/src/Init.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { Initialization as ApplicationInsights, Snippet } from "./Initialization";
+import { Initialization as ApplicationInsights, Snippet, IApplicationInsights } from "./Initialization";
+import { ApplicationInsightsContainer } from "./ApplicationInsightsContainer";
 
 export { Initialization as ApplicationInsights, Snippet } from "./Initialization";
 
@@ -21,15 +22,16 @@ try {
             if (window[aiName].initialize) { // initialize if required
                 // this is the typical case for browser+snippet
                 var snippet: Snippet = window[aiName] || <any>{};
-
+                let oldApiSupport = snippet && snippet.config && snippet.config.oldApiSupport === true;
                 // overwrite snippet with full appInsights
-                var initialization = new ApplicationInsights(snippet);
 
+                let appInsightsContainer = new ApplicationInsightsContainer();
+                var initialization = appInsightsContainer.getAppInsights(snippet, oldApiSupport);
+                
                 // apply full appInsights to the global instance that was initialized in the snippet
                 for (var field in initialization) {
                     snippet[field] = initialization[field];
-                }
-                initialization.loadAppInsights();
+                }                
             }
         }
     }

--- a/AISKU/src/Initialization.ts
+++ b/AISKU/src/Initialization.ts
@@ -3,7 +3,7 @@
 
 import { IConfiguration, AppInsightsCore, IAppInsightsCore, LoggingSeverity, _InternalMessageId, ITelemetryItem } from "@microsoft/applicationinsights-core-js";
 import { ApplicationInsights } from "@microsoft/applicationinsights-analytics-js";
-import { Util, IConfig, IDependencyTelemetry, PageViewPerformance, IPageViewPerformanceTelemetry,
+import { Util, IConfig, IDependencyTelemetry, IPageViewPerformanceTelemetry,
          IPageViewTelemetry, IExceptionTelemetry, IAutoExceptionTelemetry, ITraceTelemetry,
          IMetricTelemetry, IEventTelemetry, IAppInsights, ConfigurationManager } from "@microsoft/applicationinsights-common";
 import { Sender } from "@microsoft/applicationinsights-channel-js";
@@ -38,9 +38,10 @@ export class Initialization implements IApplicationInsights {
     public snippet: Snippet;
     public config: IConfiguration & IConfig;
     public appInsights: ApplicationInsights;
-    private properties: PropertiesPlugin;
+    public core: IAppInsightsCore;
+    
     private dependencies: DependenciesPlugin;
-    private core: IAppInsightsCore;
+    private properties: PropertiesPlugin;
 
     constructor(snippet: Snippet) {
         // initialize the queue and config in case they are undefined
@@ -181,7 +182,6 @@ export class Initialization implements IApplicationInsights {
          this.properties.user.setAuthenticatedUserContext(authenticatedUserId, accountId, storeInCookie);
     }
 
-
     /**
      * Clears the authenticated user id and account id. The associated cookie is cleared, if present.
      * @memberof Initialization
@@ -298,9 +298,7 @@ export class Initialization implements IApplicationInsights {
 
                 //appInsightsInstance.context._sender.triggerSend();
 
-                appInsightsInstance.appInsights.core.getTransmissionControls().forEach(queues => {
-                    queues.forEach(channel => channel.flush(true));
-                });
+                appInsightsInstance.flush(false);
 
                 // Back up the current session to local storage
                 // This lets us close expired sessions after the cookies themselves expire
@@ -320,7 +318,7 @@ export class Initialization implements IApplicationInsights {
         }
     }
 
-    public getSKUDefaults() {
+    private getSKUDefaults() {
         let enableOldTags = ConfigurationManager.getConfig(this.config, "enableOldTags", propertiesPlugin, true);
         this.config.enableOldTags = <boolean>enableOldTags;
         this.config.diagnosticLogInterval =

--- a/AISKU/src/Initialization.ts
+++ b/AISKU/src/Initialization.ts
@@ -20,6 +20,7 @@ import { AjaxPlugin as DependenciesPlugin, IDependenciesPlugin } from '@microsof
 export interface Snippet {
     queue: Array<() => void>;
     config: IConfiguration & IConfig;
+    oldApiSupport?: boolean;
 }
 
 export interface IApplicationInsights extends IAppInsights, IDependenciesPlugin, IPropertiesPlugin {
@@ -163,6 +164,21 @@ export class Initialization implements IApplicationInsights {
     public stopTrackPage(name?: string, url?: string, customProperties?: Object) {
         this.appInsights.stopTrackPage(name, url, customProperties);
     }
+
+    public startTrackEvent(name?: string): void {
+        this.appInsights.startTrackEvent(name);
+    }
+
+    /**
+     * Log an extended event that you started timing with `startTrackEvent`.
+     * @param   name    The string you used to identify this event in `startTrackEvent`.
+     * @param   properties  map[string, string] - additional data used to filter events and metrics in the portal. Defaults to empty.
+     * @param   measurements    map[string, number] - metrics associated with this event, displayed in Metrics Explorer on the portal. Defaults to empty.
+     */
+    public stopTrackEvent(name: string, properties?: Object, measurements?: Object) {
+        this.appInsights.stopTrackEvent(name, undefined, properties); // Todo: Fix to pass measurements once type is updated
+    }
+
     public addTelemetryInitializer(telemetryInitializer: (item: ITelemetryItem) => boolean | void) {
         return this.appInsights.addTelemetryInitializer(telemetryInitializer);
     }

--- a/AISKU/src/applicationinsights-web.ts
+++ b/AISKU/src/applicationinsights-web.ts
@@ -1,8 +1,11 @@
 export {
-    Initialization as ApplicationInsights,
     IApplicationInsights,
-    Snippet
+    Snippet,
+    Initialization as ApplicationInsights
 } from "./Initialization";
+
+export { ApplicationInsightsContainer } from "./ApplicationInsightsContainer";
+
 
 // Re-exports
 export {

--- a/ApplicationInsights/package.json
+++ b/ApplicationInsights/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-analytics-js",
-    "version": "1.0.0-beta.9",
+    "version": "1.0.0-beta.10",
     "description": "Microsoft Application Insights Javascript SDK apis",
     "main": "dist/applicationinsights-analytics-js.js",
     "module": "dist-esm/applicationinsights-analytics-js.js",


### PR DESCRIPTION
This provides an easy mechanism for customers to try out new SDK bits without changing their instrumentation code.
- Will add more test cases
- need to also add support for context.addTelemetryInitializer