### PR TITLE
Release 1.0.0-beta.11

### DIFF
--- a/AISKU/package.json
+++ b/AISKU/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-web",
-    "version": "1.0.0-beta.10",
+    "version": "1.0.0-beta.11",
     "description": "Microsoft Application Insights Javascript SDK API 1.0 beta",
     "main": "dist/applicationinsights-web.js",
     "module": "dist-esm/applicationinsights-web.js",
@@ -22,10 +22,10 @@
     },
     "dependencies": {
         "@microsoft/applicationinsights-analytics-js": "^1.0.0-beta.12",
-        "@microsoft/applicationinsights-channel-js": "^1.0.0-beta.11",
-        "@microsoft/applicationinsights-common": "^1.0.0-beta.13",
-        "@microsoft/applicationinsights-core-js": "^1.0.0-beta.3",
-        "@microsoft/applicationinsights-dependencies-js": "^1.0.0-beta.11",
-        "@microsoft/applicationinsights-properties-js": "^1.0.0-beta.8"
+        "@microsoft/applicationinsights-channel-js": "^1.0.0-beta.12",
+        "@microsoft/applicationinsights-common": "^1.0.0-beta.14",
+        "@microsoft/applicationinsights-core-js": "^1.0.0-beta.4",
+        "@microsoft/applicationinsights-dependencies-js": "^1.0.0-beta.12",
+        "@microsoft/applicationinsights-properties-js": "^1.0.0-beta.9"
     }
 }

--- a/AISKU/package.json
+++ b/AISKU/package.json
@@ -24,7 +24,7 @@
         "@microsoft/applicationinsights-analytics-js": "^1.0.0-beta.12",
         "@microsoft/applicationinsights-channel-js": "^1.0.0-beta.12",
         "@microsoft/applicationinsights-common": "^1.0.0-beta.14",
-        "@microsoft/applicationinsights-core-js": "^1.0.0-beta.4",
+        "@microsoft/applicationinsights-core-js": "^1.0.0-beta.5",
         "@microsoft/applicationinsights-dependencies-js": "^1.0.0-beta.12",
         "@microsoft/applicationinsights-properties-js": "^1.0.0-beta.9"
     }

--- a/AISKU/src/ApplicationInsightsContainer.ts
+++ b/AISKU/src/ApplicationInsightsContainer.ts
@@ -3,9 +3,9 @@ import { Initialization as ApplicationInsights, Snippet, IApplicationInsights } 
 
 export class ApplicationInsightsContainer {
 
-    public static getAppInsights(snippet: Snippet, version: number = 2.0, applyAppInsights?: () => void) : IApplicationInsights | IAppInsightsDeprecated {
+    public static getAppInsights(snippet: Snippet, version: number = 2.0) : IApplicationInsights | IAppInsightsDeprecated {
         const initialization = new ApplicationInsights(snippet);
-        if (applyAppInsights) { applyAppInsights(); }
+        initialization.updateSnippetDefinitions(snippet);
         initialization.loadAppInsights();
 
         // Two target scenarios:

--- a/AISKU/src/ApplicationInsightsContainer.ts
+++ b/AISKU/src/ApplicationInsightsContainer.ts
@@ -3,13 +3,14 @@ import { Initialization as ApplicationInsights, Snippet, IApplicationInsights } 
 
 export class ApplicationInsightsContainer {
 
-    public static getAppInsights(snippet: Snippet, version: number) : IApplicationInsights | IAppInsightsDeprecated {
-        let initialization = new ApplicationInsights(snippet);
+    public static getAppInsights(snippet: Snippet, version: number = 2.0, applyAppInsights?: () => void) : IApplicationInsights | IAppInsightsDeprecated {
+        const initialization = new ApplicationInsights(snippet);
+        if (applyAppInsights) { applyAppInsights(); }
         initialization.loadAppInsights();
-        
+
         // Two target scenarios:
         // 1. Customer runs v1 snippet + runtime. If customer updates just cdn location to new SDK, it will run in compat mode so old apis work
-        // 2. Customer updates to new snippet (that uses cdn location to new SDK. This is same as a new customer onboarding 
+        // 2. Customer updates to new snippet (that uses cdn location to new SDK. This is same as a new customer onboarding
         // and all api signatures are expected to map to new SDK
 
         if (version === 2.0) {

--- a/AISKU/src/ApplicationInsightsDeprecated.ts
+++ b/AISKU/src/ApplicationInsightsDeprecated.ts
@@ -1,6 +1,6 @@
-import { IConfig, PageViewPerformance, SeverityLevel, Util, 
-    IPageViewTelemetry, ITraceTelemetry, IMetricTelemetry, 
-    IAutoExceptionTelemetry, IDependencyTelemetry, IExceptionTelemetry, 
+import { IConfig, PageViewPerformance, SeverityLevel, Util,
+    IPageViewTelemetry, ITraceTelemetry, IMetricTelemetry,
+    IAutoExceptionTelemetry, IDependencyTelemetry, IExceptionTelemetry,
     IEventTelemetry, IEnvelope, ProcessLegacy, HttpMethod } from "@microsoft/applicationinsights-common";
 import { Snippet, IApplicationInsights } from "./Initialization";
 import { ITelemetryItem, IDiagnosticLogger, IConfiguration } from "@microsoft/applicationinsights-core-js";
@@ -24,11 +24,11 @@ export class AppInsightsDeprecated implements IAppInsightsDeprecated {
 
         // Add initializer to current processing only if there is any old telemetry initializer
         if (!this._hasLegacyInitializers) {
-            
+
             this.appInsightsNew.addTelemetryInitializer(item => {
                 this._processLegacyInitializers(item); // setup call back for each legacy processor
             })
-            
+
             this._hasLegacyInitializers = true;
         }
 
@@ -36,7 +36,7 @@ export class AppInsightsDeprecated implements IAppInsightsDeprecated {
     }
 
     private _processLegacyInitializers(item: ITelemetryItem): ITelemetryItem {
-        
+
         // instead of mapping new to legacy and then back again and repeating in channel, attach callback for channel to call
         item.tags[ProcessLegacy] = this._queue;
 
@@ -60,7 +60,7 @@ export class AppInsightsDeprecated implements IAppInsightsDeprecated {
         // // construct ItelemetryItem
         // item = TelemetryItemCreator.convertFrom(envelope, this.logger);
         // return !doNotSendItem ? null : item;
-        
+
     }
 
     constructor(snippet: Snippet, appInsightsNew: IApplicationInsights) {
@@ -95,13 +95,13 @@ export class AppInsightsDeprecated implements IAppInsightsDeprecated {
 
     trackDependency(id: string, method: string, absoluteUrl: string, pathName: string, totalTime: number, success: boolean, resultCode: number) {
         this.appInsightsNew.trackDependencyData(
-            <IDependencyTelemetry>{ 
-                id: id, 
-                absoluteUrl: absoluteUrl, 
-                type: pathName, 
+            <IDependencyTelemetry>{
+                id: id,
+                absoluteUrl: absoluteUrl,
+                type: pathName,
                 duration: totalTime,
                 properties: { HttpMethod: method },
-                success: success, 
+                success: success,
                 responseCode: resultCode
             });
     }
@@ -131,12 +131,12 @@ export class AppInsightsDeprecated implements IAppInsightsDeprecated {
     clearAuthenticatedUserContext() {
         this.appInsightsNew.clearAuthenticatedUserContext();
     }
-    
+
     _onerror(message: string, url: string, lineNumber: number, columnNumber: number, error: Error) {
         this.appInsightsNew._onerror(<IAutoExceptionTelemetry>{ message: message, url: url, lineNumber: lineNumber, columnNumber: columnNumber, error: error });
     }
-    
-    
+
+
     startTrackEvent(name: string) {
         throw new Error("Method not implemented.");
     }
@@ -208,11 +208,11 @@ export class AppInsightsDeprecated implements IAppInsightsDeprecated {
 
         config.disableAjaxTracking = Util.stringToBoolOrDefault(config.disableAjaxTracking);
         config.maxAjaxCallsPerView = !isNaN(config.maxAjaxCallsPerView) ? config.maxAjaxCallsPerView : 500;
-      
+
         config.isBeaconApiDisabled = Util.stringToBoolOrDefault(config.isBeaconApiDisabled, true);
         config.disableCorrelationHeaders = Util.stringToBoolOrDefault(config.disableCorrelationHeaders);
         config.correlationHeaderExcludedDomains = config.correlationHeaderExcludedDomains || [
-            "*.blob.core.windows.net", 
+            "*.blob.core.windows.net",
             "*.blob.core.chinacloudapi.cn",
             "*.blob.core.cloudapi.de",
             "*.blob.core.usgovcloudapi.net"];
@@ -374,11 +374,11 @@ export interface IAppInsightsDeprecated {
 }
 
 export interface ITelemetryContext {
-    
+
     /**
-    * Adds a telemetry initializer to the collection. Telemetry initializers will be called one by one, 
-    * in the order they were added, before the telemetry item is pushed for sending. 
+    * Adds a telemetry initializer to the collection. Telemetry initializers will be called one by one,
+    * in the order they were added, before the telemetry item is pushed for sending.
     * If one of the telemetry initializers returns false or throws an error then the telemetry item will not be sent.
     */
-   addTelemetryInitializer(telemetryInitializer: (IEnvelope) => boolean | void);
+   addTelemetryInitializer(telemetryInitializer: (envelope: IEnvelope) => boolean | void);
 }

--- a/AISKU/src/Init.ts
+++ b/AISKU/src/Init.ts
@@ -20,17 +20,21 @@ try {
         if (window[aiName] !== undefined) {
             // this is the typical case for browser+snippet
             var snippet: Snippet = window[aiName] || <any>{ version: 2.0 };
-            
+
             // overwrite snippet with full appInsights
             // for 2.0 initialize only if required
             if ((snippet.version === 2.0 && window[aiName].initialize) || snippet.version === undefined ) {
-            
-                var initialization = ApplicationInsightsContainer.getAppInsights(snippet, snippet.version);
-                
-                // apply full appInsights to the global instance that was initialized in the snippet
-                for (var field in initialization) {
-                    snippet[field] = initialization[field];
+                let initialization;
+
+                const applyAppInsights = function() {
+                    // apply full appInsights to the global instance
+                    // Note: This must be called before loadAppInsights is called
+                    for (var field in initialization) {
+                        snippet[field] = initialization[field];
+                    }
                 }
+
+                initialization = ApplicationInsightsContainer.getAppInsights(snippet, snippet.version, applyAppInsights);
             }
         }
     }

--- a/AISKU/src/Init.ts
+++ b/AISKU/src/Init.ts
@@ -24,17 +24,7 @@ try {
             // overwrite snippet with full appInsights
             // for 2.0 initialize only if required
             if ((snippet.version === 2.0 && window[aiName].initialize) || snippet.version === undefined ) {
-                let initialization;
-
-                const applyAppInsights = function() {
-                    // apply full appInsights to the global instance
-                    // Note: This must be called before loadAppInsights is called
-                    for (var field in initialization) {
-                        snippet[field] = initialization[field];
-                    }
-                }
-
-                initialization = ApplicationInsightsContainer.getAppInsights(snippet, snippet.version, applyAppInsights);
+                ApplicationInsightsContainer.getAppInsights(snippet, snippet.version);
             }
         }
     }

--- a/AISKU/src/Initialization.ts
+++ b/AISKU/src/Initialization.ts
@@ -262,6 +262,22 @@ export class Initialization implements IApplicationInsights {
         return this;
     }
 
+    /**
+     * Overwrite the lazy loaded fields of global window snippet to contain the
+     * actual initialized API methods
+     * @param {Snippet} snippet
+     * @memberof Initialization
+     */
+    public updateSnippetDefinitions(snippet: Snippet) {
+        // apply full appInsights to the global instance
+        // Note: This must be called before loadAppInsights is called
+        for (var field in this) {
+            if (typeof field === 'string') {
+                snippet[field as string] = this[field];
+            }
+        }
+
+    }
 
     /**
      * Call any functions that were queued before the main script was loaded

--- a/AISKULight/package.json
+++ b/AISKULight/package.json
@@ -24,6 +24,6 @@
     "dependencies": {
         "@microsoft/applicationinsights-common": "^1.0.0-beta.14",
         "@microsoft/applicationinsights-channel-js": "^1.0.0-beta.12",
-        "@microsoft/applicationinsights-core-js": "^1.0.0-beta.4"
+        "@microsoft/applicationinsights-core-js": "^1.0.0-beta.5"
     }
 }

--- a/AISKULight/package.json
+++ b/AISKULight/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-web-basic",
-    "version": "1.0.0-beta.12",
+    "version": "1.0.0-beta.13",
     "description": "Microsoft Application Insights Javascript SDK core and channel",
     "main": "dist/applicationinsights-web-basic.js",
     "module": "dist-esm/index.js",
@@ -22,8 +22,8 @@
         "typescript": "2.5.3"
     },
     "dependencies": {
-        "@microsoft/applicationinsights-common": "^1.0.0-beta.13",
-        "@microsoft/applicationinsights-channel-js": "^1.0.0-beta.11",
-        "@microsoft/applicationinsights-core-js": "^1.0.0-beta.3"
+        "@microsoft/applicationinsights-common": "^1.0.0-beta.14",
+        "@microsoft/applicationinsights-channel-js": "^1.0.0-beta.12",
+        "@microsoft/applicationinsights-core-js": "^1.0.0-beta.4"
     }
 }

--- a/API-reference.md
+++ b/API-reference.md
@@ -157,7 +157,7 @@ Log an exception you have caught. (Exceptions caught by the browser are also log
 Parameter | Description
 ---|---
 `exception` | An Error from a catch clause.
-`handledAt` | Defaults to "unhandled".
+`handledAt` | Deprecated. This argument is ignored. Please pass `null`.
 `properties` | Map of string to string: Additional data used to [filter exceptions](https://azure.microsoft.com/documentation/articles/app-insights-api-custom-events-metrics/#properties) in the portal. Defaults to empty.
 `measurements` | Map of string to number: Metrics associated with this page, displayed in Metrics Explorer on the portal. Defaults to empty.
 `severityLevel` | Supported values: [SeverityLevel.ts](https://github.com/Microsoft/ApplicationInsights-JS/blob/master/JavaScript/JavaScriptSDK.Interfaces/Contracts/Generated/SeverityLevel.ts)

--- a/AppInsightsCommon/package.json
+++ b/AppInsightsCommon/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-common",
-    "version": "1.0.0-beta.13",
+    "version": "1.0.0-beta.14",
     "description": "Microsoft Application Insights Common JavaScript Library",
     "main": "./dist/applicationinsights-common.js",
     "module": "./dist-esm/applicationinsights-common.js",
@@ -28,7 +28,7 @@
         "typescript": "2.5.3"
     },
     "dependencies": {
-        "@microsoft/applicationinsights-core-js": "^1.0.0-beta.3"
+        "@microsoft/applicationinsights-core-js": "^1.0.0-beta.4"
     },
     "license": "MIT"
 }

--- a/AppInsightsCommon/package.json
+++ b/AppInsightsCommon/package.json
@@ -28,7 +28,7 @@
         "typescript": "2.5.3"
     },
     "dependencies": {
-        "@microsoft/applicationinsights-core-js": "^1.0.0-beta.4"
+        "@microsoft/applicationinsights-core-js": "^1.0.0-beta.5"
     },
     "license": "MIT"
 }

--- a/AppInsightsCommon/src/TelemetryItemCreator.ts
+++ b/AppInsightsCommon/src/TelemetryItemCreator.ts
@@ -40,7 +40,7 @@ export class TelemetryItemCreator {
         let telemetryItem: ITelemetryItem = {
             name: envelopeName,
             time: new Date().toISOString(),
-            ikey: "", // this will be set in TelemetryContext
+            iKey: "", // this will be set in TelemetryContext
             ctx: systemProperties ? systemProperties : {}, // part A
             tags: [],
             data: {

--- a/AppInsightsCommon/src/TelemetryItemCreator.ts
+++ b/AppInsightsCommon/src/TelemetryItemCreator.ts
@@ -39,8 +39,8 @@ export class TelemetryItemCreator {
 
         let telemetryItem: ITelemetryItem = {
             name: envelopeName,
-            timestamp: new Date(),
-            instrumentationKey: "", // this will be set in TelemetryContext
+            time: new Date().toISOString(),
+            ikey: "", // this will be set in TelemetryContext
             ctx: systemProperties ? systemProperties : {}, // part A
             tags: [],
             data: {
@@ -79,10 +79,10 @@ export class TelemetryItemCreator {
 
                 let dependencyTelemetry = <IDependencyTelemetry>(env.data.baseType);
                 telemetryItem = TelemetryItemCreator.create<IDependencyTelemetry>(
-                    dependencyTelemetry, 
-                    RemoteDependencyData.dataType, 
+                    dependencyTelemetry,
+                    RemoteDependencyData.dataType,
                     RemoteDependencyData.envelopeType,
-                    logger, 
+                    logger,
                     customProperties);
         }
 
@@ -216,18 +216,18 @@ export class TelemetryItemCreator {
         }
 
 
-                
+
         if (env.tags[CtxTagKeys.operationRootId]) {
             item.tags[CtxTagKeys.operationRootId] = env.tags[CtxTagKeys.operationRootId];
             keysFound.push(CtxTagKeys.operationRootId);
         }
 
-                
+
         if (env.tags[CtxTagKeys.operationSyntheticSource]) {
             item.tags[CtxTagKeys.operationSyntheticSource] = env.tags[CtxTagKeys.operationSyntheticSource];
             keysFound.push(CtxTagKeys.operationSyntheticSource);
         }
-                
+
         if (env.tags[CtxTagKeys.operationParentId]) {
             item.tags[CtxTagKeys.operationParentId] = env.tags[CtxTagKeys.operationParentId];
             keysFound.push(CtxTagKeys.operationParentId);

--- a/ApplicationInsights/Tests/ApplicationInsights.tests.ts
+++ b/ApplicationInsights/Tests/ApplicationInsights.tests.ts
@@ -114,7 +114,7 @@ export class ApplicationInsightsTests extends TestClass {
                 var test = (action, expectedEnvelopeType, expectedDataType, test?: () => void) => {
                     action();
                     envelope = this.getFirstResult(action, trackStub);
-                    Assert.equal(iKey, envelope.ikey, "envelope iKey");
+                    Assert.equal(iKey, envelope.iKey, "envelope iKey");
                     Assert.equal(expectedEnvelopeType.replace("{0}", iKeyNoDash), envelope.name, "envelope name");
                     Assert.equal(expectedDataType, envelope.baseType, "data type name");
                     if (typeof test === 'function') {test();}

--- a/ApplicationInsights/Tests/ApplicationInsights.tests.ts
+++ b/ApplicationInsights/Tests/ApplicationInsights.tests.ts
@@ -114,7 +114,7 @@ export class ApplicationInsightsTests extends TestClass {
                 var test = (action, expectedEnvelopeType, expectedDataType, test?: () => void) => {
                     action();
                     envelope = this.getFirstResult(action, trackStub);
-                    Assert.equal(iKey, envelope.instrumentationKey, "envelope iKey");
+                    Assert.equal(iKey, envelope.ikey, "envelope iKey");
                     Assert.equal(expectedEnvelopeType.replace("{0}", iKeyNoDash), envelope.name, "envelope name");
                     Assert.equal(expectedDataType, envelope.baseType, "data type name");
                     if (typeof test === 'function') {test();}

--- a/ApplicationInsights/package.json
+++ b/ApplicationInsights/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-analytics-js",
-    "version": "1.0.0-beta.11",
+    "version": "1.0.0-beta.12",
     "description": "Microsoft Application Insights Javascript SDK apis",
     "main": "dist/applicationinsights-analytics-js.js",
     "module": "dist-esm/applicationinsights-analytics-js.js",
@@ -23,8 +23,8 @@
         "rollup-plugin-uglify": "^6.0.0"
     },
     "dependencies": {
-        "@microsoft/applicationinsights-core-js": "^1.0.0-beta.3",
-        "@microsoft/applicationinsights-common": "^1.0.0-beta.13"
+        "@microsoft/applicationinsights-core-js": "^1.0.0-beta.4",
+        "@microsoft/applicationinsights-common": "^1.0.0-beta.14"
     },
     "license": "MIT"
 }

--- a/ApplicationInsights/package.json
+++ b/ApplicationInsights/package.json
@@ -23,7 +23,7 @@
         "rollup-plugin-uglify": "^6.0.0"
     },
     "dependencies": {
-        "@microsoft/applicationinsights-core-js": "^1.0.0-beta.4",
+        "@microsoft/applicationinsights-core-js": "^1.0.0-beta.5",
         "@microsoft/applicationinsights-common": "^1.0.0-beta.14"
     },
     "license": "MIT"

--- a/ApplicationInsights/src/JavaScriptSDK/ApplicationInsights.ts
+++ b/ApplicationInsights/src/JavaScriptSDK/ApplicationInsights.ts
@@ -584,7 +584,7 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
 
     // Mutate telemetryItem inplace to add boilerplate iKey & name info
     private _setTelemetryNameAndIKey(telemetryItem: ITelemetryItem): void {
-        telemetryItem.ikey = this._globalconfig.instrumentationKey;
+        telemetryItem.iKey = this._globalconfig.instrumentationKey;
 
         var iKeyNoDashes = this._globalconfig.instrumentationKey.replace(/-/g, "");
         telemetryItem.name = telemetryItem.name.replace("{0}", iKeyNoDashes);

--- a/ApplicationInsights/src/JavaScriptSDK/ApplicationInsights.ts
+++ b/ApplicationInsights/src/JavaScriptSDK/ApplicationInsights.ts
@@ -485,13 +485,13 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
 
 
         this._eventTracking = new Timing(this._logger, "trackEvent");
-        this._eventTracking.action = 
+        this._eventTracking.action =
             (name?: string, url?: string, duration?: number, properties?: Object, measurements?: Object) => {
                 if (!measurements) {
                     measurements = {};
                 }
 
-                measurements["duration"] = duration ; // ToDo: fix once IEventTelemetry is updated                
+                measurements["duration"] = duration ; // ToDo: fix once IEventTelemetry is updated
                 this.trackEvent(<IEventTelemetry>{ name: name });
             }
 
@@ -584,7 +584,7 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
 
     // Mutate telemetryItem inplace to add boilerplate iKey & name info
     private _setTelemetryNameAndIKey(telemetryItem: ITelemetryItem): void {
-        telemetryItem.instrumentationKey = this._globalconfig.instrumentationKey;
+        telemetryItem.ikey = this._globalconfig.instrumentationKey;
 
         var iKeyNoDashes = this._globalconfig.instrumentationKey.replace(/-/g, "");
         telemetryItem.name = telemetryItem.name.replace("{0}", iKeyNoDashes);

--- a/extensions/applicationinsights-dependencies-js/Tests/Selenium/ajax.tests.ts
+++ b/extensions/applicationinsights-dependencies-js/Tests/Selenium/ajax.tests.ts
@@ -123,7 +123,6 @@ export class AjaxTests extends TestClass {
                 Assert.ok(fetchSpy.notCalled, "No fetch called yet");
                 fetch("https://httpbin.org/status/200", {method: "post", [DisabledPropertyName]: false});
 
-
                 // Assert
                 Assert.ok(fetchSpy.calledOnce, "createFetchRecord called once after using fetch");
             }

--- a/extensions/applicationinsights-dependencies-js/package.json
+++ b/extensions/applicationinsights-dependencies-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-dependencies-js",
-    "version": "1.0.0-beta.11",
+    "version": "1.0.0-beta.12",
     "description": "Microsoft Application Insights XHR dependencies plugin",
     "main": "dist/applicationinsights-dependencies-js.js",
     "module": "dist-esm/applicationinsights-dependencies-js.js",
@@ -27,8 +27,8 @@
         "rollup-plugin-uglify": "^6.0.0"
     },
     "dependencies": {
-        "@microsoft/applicationinsights-core-js": "^1.0.0-beta.3",
-        "@microsoft/applicationinsights-common": "^1.0.0-beta.13"
+        "@microsoft/applicationinsights-core-js": "^1.0.0-beta.4",
+        "@microsoft/applicationinsights-common": "^1.0.0-beta.14"
     },
     "license": "MIT"
 }

--- a/extensions/applicationinsights-dependencies-js/package.json
+++ b/extensions/applicationinsights-dependencies-js/package.json
@@ -27,7 +27,7 @@
         "rollup-plugin-uglify": "^6.0.0"
     },
     "dependencies": {
-        "@microsoft/applicationinsights-core-js": "^1.0.0-beta.4",
+        "@microsoft/applicationinsights-core-js": "^1.0.0-beta.5",
         "@microsoft/applicationinsights-common": "^1.0.0-beta.14"
     },
     "license": "MIT"

--- a/extensions/applicationinsights-dependencies-js/src/ajax.ts
+++ b/extensions/applicationinsights-dependencies-js/src/ajax.ts
@@ -424,10 +424,10 @@ export class AjaxMonitor implements ITelemetryPlugin, IDependenciesPlugin, IInst
                 // not using original request headers will result in them being lost
                 init.headers = new Headers(init.headers || (input instanceof Request ? (input.headers || {}) : {}));
                 init.headers.set(RequestHeaders.requestIdHeader, ajaxData.id);
-                // let appId: string = this.appInsights.context ? this.appInsights.context.appId() : null;
-                // if (appId) {
-                //     init.headers.set(RequestHeaders.requestContextHeader, RequestHeaders.requestContextAppIdFormat + appId);
-                // }
+                let appId: string = this._config.appId;
+                if (appId) {
+                    init.headers.set(RequestHeaders.requestContextHeader, RequestHeaders.requestContextAppIdFormat + appId);
+                }
 
                 return init;
             }

--- a/extensions/applicationinsights-properties-js/package.json
+++ b/extensions/applicationinsights-properties-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-properties-js",
-    "version": "1.0.0-beta.8",
+    "version": "1.0.0-beta.9",
     "description": "Microsoft Application Insights properties (Part A) plugin",
     "main": "dist/applicationinsights-properties-js.js",
     "module": "dist-esm/applicationinsights-properties-js.js",
@@ -27,8 +27,8 @@
         "rollup-plugin-uglify": "^6.0.0"
     },
     "dependencies": {
-        "@microsoft/applicationinsights-core-js": "^1.0.0-beta.3",
-        "@microsoft/applicationinsights-common": "^1.0.0-beta.13"
+        "@microsoft/applicationinsights-core-js": "^1.0.0-beta.4",
+        "@microsoft/applicationinsights-common": "^1.0.0-beta.14"
     },
     "license": "MIT"
 }

--- a/extensions/applicationinsights-properties-js/package.json
+++ b/extensions/applicationinsights-properties-js/package.json
@@ -27,7 +27,7 @@
         "rollup-plugin-uglify": "^6.0.0"
     },
     "dependencies": {
-        "@microsoft/applicationinsights-core-js": "^1.0.0-beta.4",
+        "@microsoft/applicationinsights-core-js": "^1.0.0-beta.5",
         "@microsoft/applicationinsights-common": "^1.0.0-beta.14"
     },
     "license": "MIT"


### PR DESCRIPTION
- rename `timestamp` to `time`
- rename `instrumentationKey` to `ikey`
- Add request-context field to autocollected fetch requests when `enableCorsCorrelation` is enabled
- In initialization, make `queue`, `version` optional
- rework ordering of `loadAppInsights` call to ensure preinstrumentation autocollection works
- re-enable disabled ajax plugin tests