### PR TITLE
Fixes from testing bridging functionality for existing PROD sdk 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,4 @@ dist/
 
 # Misc
 statistics.html
+npm

--- a/AISKU/legacy-readme.txt
+++ b/AISKU/legacy-readme.txt
@@ -1,5 +1,0 @@
-To generate the minified bundle:
-1. Complete build> grunt aisku
-2. Copy over contents of bundle directory under node_Modules\ for all appinsights packages and drop into aisku\amd\bundle.
-3. Run > npx webpack --config webpack-dev.config.js  to generate the bundle files under AISKU\dist foldre.
-Finally, run grunt snippetvnext to generated the minified bootstrap script under AISKU\dist folder.

--- a/AISKU/src/ApplicationInsightsContainer.ts
+++ b/AISKU/src/ApplicationInsightsContainer.ts
@@ -5,12 +5,13 @@ export class ApplicationInsightsContainer {
 
     public static getAppInsights(snippet: Snippet, version: number) : IApplicationInsights | IAppInsightsDeprecated {
         let initialization = new ApplicationInsights(snippet);
-        initialization.loadAppInsights();
-        
+        let legacyMode = version === 2.0 ? false : true;
+        initialization.loadAppInsights(legacyMode);
+
         // Two target scenarios:
         // 1. Customer runs v1 snippet + runtime. If customer updates just cdn location to new SDK, it will run in compat mode so old apis work
         // 2. Customer updates to new snippet (that uses cdn location to new SDK. This is same as a new customer onboarding 
-        // and all api signatures are expected to map to new SDK
+        // and all api signatures are expected to map to new SDK. Note new snippet specifies version
 
         if (version === 2.0) {
             return initialization; // default behavior with new snippet

--- a/AISKU/src/ApplicationInsightsDeprecated.ts
+++ b/AISKU/src/ApplicationInsightsDeprecated.ts
@@ -39,28 +39,7 @@ export class AppInsightsDeprecated implements IAppInsightsDeprecated {
         
         // instead of mapping new to legacy and then back again and repeating in channel, attach callback for channel to call
         item.tags[ProcessLegacy] = this._queue;
-
         return item;
-        // // construct legacy envelope
-        // let envelope = Sender.constructEnvelope(null, this.config.instrumentationKey, this.logger);
-        // let doNotSendItem = false;
-
-        // for (let i = 0; i < this._queue.length; i++) {
-        //     // run all processors
-        //     let callBack = this._queue[i];
-        //     try {
-        //         doNotSendItem = (callBack(envelope) !== true);
-        //     } catch (e) {
-        //         this.logger.throwInternal(
-        //             LoggingSeverity.CRITICAL, _InternalMessageId.TelemetryInitializerFailed, "One of telemetry initializers failed, continue processing next: " + Util.getExceptionName(e),
-        //             { exception: Util.dump(e) }, true);
-        //     }
-        // }
-
-        // // construct ItelemetryItem
-        // item = TelemetryItemCreator.convertFrom(envelope, this.logger);
-        // return !doNotSendItem ? null : item;
-        
     }
 
     constructor(snippet: Snippet, appInsightsNew: IApplicationInsights) {
@@ -138,17 +117,16 @@ export class AppInsightsDeprecated implements IAppInsightsDeprecated {
     
     
     startTrackEvent(name: string) {
-        throw new Error("Method not implemented.");
+        this.appInsightsNew.startTrackEvent(name);
     }
 
     stopTrackEvent(name: string, properties?: { [name: string]: string; }, measurements?: { [name: string]: number; }) {
-        throw new Error("Method not implemented.");
+        this.appInsightsNew.stopTrackEvent(name, properties, measurements);
     }
 
     downloadAndSetup?(config: IConfig): void {
         throw new Error("downloadAndSetup not implemented in web SKU");
     }
-
 
     // note: these are split into methods to enable unit tests
     public loadAppInsights() {

--- a/AISKU/src/Init.ts
+++ b/AISKU/src/Init.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { Initialization as ApplicationInsights, Snippet, IApplicationInsights } from "./Initialization";
+import { Initialization as ApplicationInsights, Snippet } from "./Initialization";
 import { ApplicationInsightsContainer } from "./ApplicationInsightsContainer";
 
 export { Initialization as ApplicationInsights, Snippet } from "./Initialization";

--- a/AISKU/src/Initialization.ts
+++ b/AISKU/src/Initialization.ts
@@ -240,7 +240,12 @@ export class Initialization implements IApplicationInsights {
      * @returns {IApplicationInsights}
      * @memberof Initialization
      */
-    public loadAppInsights(): IApplicationInsights {
+    public loadAppInsights(legacyMode: boolean = false): IApplicationInsights {
+
+        // dont allow additional channels/other extensions for legacy mode; legacy mode is only to allow users to switch with no code changes!
+        if (legacyMode && this.config.extensions && this.config.extensions.length > 0) {
+            throw new Error("Extensions not allowed in legacy mode");
+        }
 
         this.core = new AppInsightsCore();
         let extensions = [];
@@ -336,8 +341,6 @@ export class Initialization implements IApplicationInsights {
     }
 
     private getSKUDefaults() {
-        let enableOldTags = ConfigurationManager.getConfig(this.config, "enableOldTags", propertiesPlugin, true);
-        this.config.enableOldTags = <boolean>enableOldTags;
         this.config.diagnosticLogInterval =
             this.config.diagnosticLogInterval && this.config.diagnosticLogInterval > 0 ? this.config.diagnosticLogInterval : 10000;
     }

--- a/AppInsightsCommon/src/Interfaces/IConfig.ts
+++ b/AppInsightsCommon/src/Interfaces/IConfig.ts
@@ -245,8 +245,6 @@ export interface IConfig {
      */
     enableCorsCorrelation?: boolean;
 
-    enableOldTags?: boolean;
-
     // Internal
 
     /**

--- a/ApplicationInsights/src/JavaScriptSDK/ApplicationInsights.ts
+++ b/ApplicationInsights/src/JavaScriptSDK/ApplicationInsights.ts
@@ -4,15 +4,12 @@
  */
 
 import {
-    IConfig,
-    Util, PageViewPerformance,
-    IAppInsights,
-    PageView, IEnvelope, RemoteDependencyData, Event, IEventTelemetry,
+    IConfig, Util, PageViewPerformance, IAppInsights, PageView, RemoteDependencyData, Event, IEventTelemetry,
     TelemetryItemCreator, Data, Metric, Exception, SeverityLevel, Trace, IDependencyTelemetry,
     IExceptionTelemetry, ITraceTelemetry, IMetricTelemetry, IAutoExceptionTelemetry,
-    IPageViewTelemetryInternal, IPageViewTelemetry, IPageViewPerformanceTelemetry,
-    ConfigurationManager
+    IPageViewTelemetryInternal, IPageViewTelemetry, IPageViewPerformanceTelemetry, ConfigurationManager
 } from "@microsoft/applicationinsights-common";
+
 import {
     IPlugin, IConfiguration, IAppInsightsCore,
     ITelemetryPlugin, CoreUtils, ITelemetryItem,

--- a/extensions/applicationinsights-properties-js/src/Interfaces/ITelemetryConfig.ts
+++ b/extensions/applicationinsights-properties-js/src/Interfaces/ITelemetryConfig.ts
@@ -11,5 +11,4 @@ export interface ITelemetryConfig {
     sdkExtension: () => string;
     isBrowserLinkTrackingEnabled: () => boolean;
     appId: () => string;
-    enableOldTags?: () => boolean;
 }

--- a/extensions/applicationinsights-properties-js/src/PropertiesPlugin.ts
+++ b/extensions/applicationinsights-properties-js/src/PropertiesPlugin.ts
@@ -48,8 +48,7 @@ export default class PropertiesPlugin implements ITelemetryPlugin, ITelemetryCon
             cookieDomain: () => null,
             sdkExtension: () => null,
             isBrowserLinkTrackingEnabled: () => false,
-            appId: () => null,
-            enableOldTags: () => false
+            appId: () => null
         }
         return defaultConfig;
     }
@@ -125,7 +124,6 @@ export default class PropertiesPlugin implements ITelemetryPlugin, ITelemetryCon
             }
         }
 
-        //if (this._extensionConfig.enableOldTags()) 
         // set part A  fields
         if (!event.tags) {
             event.tags = [];


### PR DESCRIPTION
- Remove ability (throw error) to add custom extensions when running in legacy code.
- Code clean up for old settings (unused).
- Hook up start/stop trackEvent for legacy apis.
