### PR TITLE
Export types for part B in light sku

### DIFF
--- a/AISKULight/index.ts
+++ b/AISKULight/index.ts
@@ -95,8 +95,6 @@ export class ApplicationInsights {
         this.config.diagnosticLogInterval = 
             this.config.diagnosticLogInterval && this.config.diagnosticLogInterval > 0 ? this.config.diagnosticLogInterval : 10000;
     }
-
-
 }
 
 export {
@@ -107,6 +105,7 @@ export {
     ITelemetryItem
 } from "@microsoft/applicationinsights-core-js";
 export {
+    SeverityLevel,
     IPageViewTelemetry,
     IDependencyTelemetry,
     IAutoExceptionTelemetry,

--- a/AISKULight/index.ts
+++ b/AISKULight/index.ts
@@ -107,13 +107,12 @@ export {
     ITelemetryItem
 } from "@microsoft/applicationinsights-core-js";
 export {
-    SeverityLevel,
-    Event,
-    Exception,
-    Metric,
-    PageView,
-    PageViewPerformance,
-    RemoteDependencyData,
-    Trace
+    IPageViewTelemetry,
+    IDependencyTelemetry,
+    IAutoExceptionTelemetry,
+    IEventTelemetry,
+    IMetricTelemetry,
+    IPageViewPerformanceTelemetry,
+    ITraceTelemetry
 } from "@microsoft/applicationinsights-common";
 export { Sender } from "@microsoft/applicationinsights-channel-js";


### PR DESCRIPTION
When creating part B for track api, it is useful for user to view types that are supported. 