### PR TITLE
update fields with properies & measurements

### DIFF
--- a/AISKU/README.md
+++ b/AISKU/README.md
@@ -70,7 +70,7 @@ If initialized using the snippet, your Application Insights instance is located 
 appInsights.trackEvent({name: 'some event'});
 appInsights.trackPageView({name: 'some page'});
 appInsights.trackPageViewPerformance({name : 'some page', url: 'some url'});
-appInsights.trackException({error: new Error('some error')}, customProperties);
+appInsights.trackException({error: new Error('some error')});
 appInsights.trackTrace({message: 'some trace'});
 appInsights.trackMetric({name: 'some metric', average: 42});
 appInsights.trackDependencyData({absoluteUrl: 'some url', resultCode: 200, method: 'GET', id: 'some id'});

--- a/AISKU/src/Initialization.ts
+++ b/AISKU/src/Initialization.ts
@@ -71,17 +71,15 @@ export class Initialization implements IApplicationInsights {
     /**
      * Log a user action or other occurrence.
      * @param {IEventTelemetry} event
-     * @param {{ [key:string]: any }} [customProperties]
      * @memberof Initialization
      */
-    public trackEvent(event: IEventTelemetry, customProperties?: { [key:string]: any }) {
-        this.appInsights.trackEvent(event, customProperties);
+    public trackEvent(event: IEventTelemetry) {
+        this.appInsights.trackEvent(event);
     }
 
     /**
      * Logs that a page, or similar container was displayed to the user.
      * @param {IPageViewTelemetry} pageView
-     * @param {{ [key: string]: any; }} [customProperties]
      * @memberof Initialization
      */
     public trackPageView(pageView: IPageViewTelemetry) {
@@ -91,7 +89,6 @@ export class Initialization implements IApplicationInsights {
     /**
      * Log a bag of performance information via the customProperties field.
      * @param {IPageViewPerformanceTelemetry} pageViewPerformance
-     * @param {{ [key:string]: any }} [customProperties]
      * @memberof Initialization
      */
     public trackPageViewPerformance(pageViewPerformance: IPageViewPerformanceTelemetry): void {
@@ -101,7 +98,6 @@ export class Initialization implements IApplicationInsights {
     /**
      * Log an exception that you have caught.
      * @param {IExceptionTelemetry} exception
-     * @param {{ [key: string]: any; }} [customProperties]
      * @memberof Initialization
      */
     public trackException(exception: IExceptionTelemetry): void {

--- a/AISKU/src/Initialization.ts
+++ b/AISKU/src/Initialization.ts
@@ -209,12 +209,10 @@ export class Initialization implements IApplicationInsights {
     /**
      * Log a dependency call (e.g. ajax)
      * @param {IDependencyTelemetry} dependency
-     * @param {{[key: string]: any}} [customProperties]
-     * @param {{[key: string]: any}} [systemProperties]
      * @memberof Initialization
      */
-    public trackDependencyData(dependency: IDependencyTelemetry, customProperties?: {[key: string]: any}): void {
-        this.dependencies.trackDependencyData(dependency, customProperties);
+    public trackDependencyData(dependency: IDependencyTelemetry): void {
+        this.dependencies.trackDependencyData(dependency);
     }
 
     // Misc


### PR DESCRIPTION
Fixes #768 
Removes `customProperties` to API fields where `properties`/`measurements` named argument is present.