### PR TITLE
Bug fix for duplicate telemetry issue in vNext ( 4088796)

### DIFF
--- a/vNext/channels/applicationinsights-channel-js/Tests/Sender.tests.ts
+++ b/vNext/channels/applicationinsights-channel-js/Tests/Sender.tests.ts
@@ -230,7 +230,7 @@ export class SenderTests extends TestClass {
 
                 // Assert Event name
                 Assert.ok(baseData.name);
-                Assert.equal("PageUnloadData", baseData.name);
+                Assert.equal("PageUnloadData", baseData.properties['baseTypeSource']);
 
                 // Assert ver
                 Assert.ok(baseData.ver);

--- a/vNext/channels/applicationinsights-channel-js/src/EnvelopeCreator.ts
+++ b/vNext/channels/applicationinsights-channel-js/src/EnvelopeCreator.ts
@@ -248,10 +248,14 @@ export class EventEnvelopeCreator extends EnvelopeCreator {
             this._logger.throwInternal(
                 LoggingSeverity.CRITICAL,
                 _InternalMessageId.TelemetryEnvelopeInvalid, "telemetryItem.baseData cannot be null.");
-        }
-
+            }
+            
         let customProperties = {};
         let customMeasurements = {};
+        if (telemetryItem.baseType !== Event.dataType) {
+            customProperties['baseTypeSource'] = telemetryItem.baseType; // save the passed in base type as a property
+        }
+
         if (telemetryItem.baseType === Event.dataType) { // take collection
             customProperties = telemetryItem.baseData.properties || {};
             customMeasurements = telemetryItem.baseData.measurements || {};

--- a/vNext/channels/applicationinsights-channel-js/src/Sender.ts
+++ b/vNext/channels/applicationinsights-channel-js/src/Sender.ts
@@ -435,8 +435,7 @@ export class Sender implements IChannelControlsAI {
             case RemoteDependencyData.dataType:
                 return DependencyEnvelopeCreator.DependencyEnvelopeCreator.Create(logger, envelope);
             default:
-                // default create custom event type with name mapping to unknown type
-                envelope.baseData.name = envelope.baseType;
+
                 return EventEnvelopeCreator.EventEnvelopeCreator.Create(logger, envelope);
         }
     }

--- a/vNext/shared/AppInsightsCore/src/JavaScriptSDK.Interfaces/IConfiguration.ts
+++ b/vNext/shared/AppInsightsCore/src/JavaScriptSDK.Interfaces/IConfiguration.ts
@@ -72,7 +72,8 @@ export interface IConfiguration {
     extensions?: ITelemetryPlugin[];
 
     /**
-     * Channel queues that is setup by caller in desired order
+     * Channel queues that is setup by caller in desired order. 
+     * If channels are provided here, core will ignore any channels that are already setup, example if there is a SKU with an initialized channel
      */
     channels?: Array<IChannelControls[]>;
 }

--- a/vNext/shared/AppInsightsCore/src/JavaScriptSDK.Tests/Selenium/ApplicationInsightsCore.Tests.ts
+++ b/vNext/shared/AppInsightsCore/src/JavaScriptSDK.Tests/Selenium/ApplicationInsightsCore.Tests.ts
@@ -54,6 +54,40 @@ export class ApplicationInsightsCoreTests extends TestClass {
                 } catch (error) {
                     Assert.ok(true, "Validates instrumentationKey");
                 }
+
+                let channelPlugin1 = new ChannelPlugin();
+                channelPlugin1.priority = 1001;
+
+                let config3 = {
+                    extensions: [channelPlugin1],
+                    endpointUrl: "https://dc.services.visualstudio.com/v2/track",
+                    instrumentationKey: "",
+                    extensionConfig: {}
+                };
+                try {
+                    appInsightsCore.initialize(config3, [samplingPlugin]);
+                } catch (error) {
+                    Assert.ok(true, "Validates channels cannot be passed in through extensions");
+                }
+
+                let channelPlugin2 = new ChannelPlugin();
+                channelPlugin2.priority = 200;
+
+                let config4 = {
+                    channels: [[channelPlugin2]],
+                    endpointUrl: "https://dc.services.visualstudio.com/v2/track",
+                    instrumentationKey: "",
+                    extensionConfig: {}
+                };
+
+                let thrown = false;
+                try {
+                    appInsightsCore.initialize(config4, [samplingPlugin]);
+                } catch (error) {
+                    thrown = true;
+                }
+                Assert.ok(thrown, "Validates channels passed in through config, priority cannot be less Channel controller priority");
+
             }
         });
 
@@ -355,13 +389,13 @@ export class ApplicationInsightsCoreTests extends TestClass {
             test: () => {
 
                 let channelPlugin1 = new ChannelPlugin();
-                channelPlugin1.priority = 201;
+                channelPlugin1.priority = 1001;
 
                 let channelPlugin2 = new ChannelPlugin();
-                channelPlugin2.priority = 202;
+                channelPlugin2.priority = 1002;
 
                 let channelPlugin3 = new ChannelPlugin();
-                channelPlugin3.priority = 201;
+                channelPlugin3.priority = 1001;
 
                 let appInsightsCore = new AppInsightsCore();
                 appInsightsCore.initialize(

--- a/vNext/shared/AppInsightsCore/src/JavaScriptSDK/AppInsightsCore.ts
+++ b/vNext/shared/AppInsightsCore/src/JavaScriptSDK/AppInsightsCore.ts
@@ -46,10 +46,6 @@ export class AppInsightsCore implements IAppInsightsCore {
         this._notificationManager = new NotificationManager();        
         this.config.extensions = CoreUtils.isNullOrUndefined(this.config.extensions) ? [] : this.config.extensions;
 
-        // if (this.config.channels && this.config.channels.length > 0) {
-        //     for (let i = 0; i this.config.extensions
-        // }
-
         // add notification to the extensions in the config so other plugins can access it
         this.config.extensionConfig = CoreUtils.isNullOrUndefined(this.config.extensionConfig) ? {} : this.config.extensionConfig;
         this.config.extensionConfig.NotificationManager = this._notificationManager;

--- a/vNext/shared/AppInsightsCore/src/JavaScriptSDK/AppInsightsCore.ts
+++ b/vNext/shared/AppInsightsCore/src/JavaScriptSDK/AppInsightsCore.ts
@@ -43,8 +43,12 @@ export class AppInsightsCore implements IAppInsightsCore {
 
         this.config = config;
 
-        this._notificationManager = new NotificationManager();
+        this._notificationManager = new NotificationManager();        
         this.config.extensions = CoreUtils.isNullOrUndefined(this.config.extensions) ? [] : this.config.extensions;
+
+        // if (this.config.channels && this.config.channels.length > 0) {
+        //     for (let i = 0; i this.config.extensions
+        // }
 
         // add notification to the extensions in the config so other plugins can access it
         this.config.extensionConfig = CoreUtils.isNullOrUndefined(this.config.extensionConfig) ? {} : this.config.extensionConfig;
@@ -61,15 +65,24 @@ export class AppInsightsCore implements IAppInsightsCore {
 
         if (this.config.extensions.length > 0) {
             let isValid = true;
+            let containsChannels = false;
             this.config.extensions.forEach(item =>
             {
                 if (CoreUtils.isNullOrUndefined(item)) {
                     isValid = false;
                 }
+
+                if (item.priority > ChannelControllerPriority) {
+                    containsChannels = true;
+                }
             });
 
             if (!isValid) {
                 throw Error(validationError);
+            }
+
+            if (containsChannels) {
+                throw Error(validationErrorInExt);
             }
         }
         // Initial validation complete
@@ -317,14 +330,25 @@ class ChannelController implements ITelemetryPlugin {
     initialize(config: IConfiguration, core: IAppInsightsCore, extensions: IPlugin[]) {
         this.channelQueue = new Array<IChannelControls[]>();
         if (config.channels) {
+            let invalidChannelIdentifier = undefined;
             config.channels.forEach(queue => {
+
                 if(queue && queue.length > 0) {
                     queue = queue.sort((a,b) => { // sort based on priority within each queue
                         return a.priority - b.priority;
                     });
 
                     // Initialize each plugin
-                    queue.forEach(queueItem => queueItem.initialize(config, core, extensions));
+                    queue.forEach(queueItem => {
+                        if (queueItem.priority < ChannelControllerPriority) {
+                            invalidChannelIdentifier = queueItem.identifier;
+                        }
+                        queueItem.initialize(config, core, extensions)
+                    });
+
+                    if (invalidChannelIdentifier) {
+                        throw Error(ChannelValidationMessage + invalidChannelIdentifier);
+                    }
 
                     for (let i = 1; i < queue.length; i++) {
                         queue[i - 1].setNextPlugin(queue[i]); // setup processing chain
@@ -364,5 +388,6 @@ class ChannelController implements ITelemetryPlugin {
 }
 
 const validationError = "Extensions must provide callback to initialize";
+const validationErrorInExt = "Channels must be provided through config.channels only";
 const ChannelControllerPriority = 500;
-const duplicatePriority = "One or more extensions are set at same priority";
+const ChannelValidationMessage = "Channel has invalid priority";


### PR DESCRIPTION
Allow channel configuration to be passed in only through config.channels parameter. Disallow through config.extensions parameter, add unit tests. Fixes bug with multiple items being sent in telemetry in fabrikam.

