### PR TITLE
properties plugin: export Session, make interface fields optional

### DIFF
--- a/vNext/extensions/applicationinsights-properties-js/src/Context/Session.ts
+++ b/vNext/extensions/applicationinsights-properties-js/src/Context/Session.ts
@@ -3,14 +3,14 @@
 
 import { ISession } from '@microsoft/applicationinsights-common';
 import {
-    Util, DateTimeUtils 
+    Util, DateTimeUtils
 } from '@microsoft/applicationinsights-common';
 import { IDiagnosticLogger, _InternalMessageId, LoggingSeverity, CoreUtils, DiagnosticLogger } from '@microsoft/applicationinsights-core-js';
 
 export interface ISessionConfig {
-    sessionRenewalMs: () => number;
-    sessionExpirationMs: () => number;
-    cookieDomain: () => string;
+    sessionRenewalMs?: () => number;
+    sessionExpirationMs?: () => number;
+    cookieDomain?: () => string;
     namePrefix?: () => string;
 }
 
@@ -18,20 +18,20 @@ export class Session implements ISession {
     /**
      * The session ID.
      */
-    public id: string;
+    public id?: string;
 
     /**
      * The date at which this guid was genereated.
      * Per the spec the ID will be regenerated if more than acquisitionSpan milliseconds ellapse from this time.
      */
-    public acquisitionDate: number;
+    public acquisitionDate?: number;
 
     /**
      * The date at which this session ID was last reported.
      * This value should be updated whenever telemetry is sent using this ID.
      * Per the spec the ID will be regenerated if more than renewalSpan milliseconds elapse from this time with no activity.
      */
-    public renewalDate: number;
+    public renewalDate?: number;
 }
 
 export class _SessionManager {
@@ -84,7 +84,7 @@ export class _SessionManager {
 
         // renew if acquisitionSpan or renewalSpan has ellapsed
         if (acquisitionExpired || renewalExpired) {
-            // update automaticSession so session state has correct id                
+            // update automaticSession so session state has correct id
             this.renew();
         } else {
             // do not update the cookie more often than cookieUpdateInterval

--- a/vNext/extensions/applicationinsights-properties-js/src/applicationinsights-properties-js.ts
+++ b/vNext/extensions/applicationinsights-properties-js/src/applicationinsights-properties-js.ts
@@ -4,5 +4,6 @@
 import PropertiesPlugin from "./PropertiesPlugin";
 import { TelemetryTrace } from "./Context/TelemetryTrace";
 import { TelemetryContext } from './TelemetryContext'
+import { ISessionConfig, Session, _SessionManager } from "./Context/Session";
 
-export { PropertiesPlugin, TelemetryTrace, TelemetryContext };
+export { PropertiesPlugin, TelemetryTrace, TelemetryContext, User, Session, ISessionConfig, _SessionManager as SessionManager };

--- a/vNext/extensions/applicationinsights-properties-js/src/applicationinsights-properties-js.ts
+++ b/vNext/extensions/applicationinsights-properties-js/src/applicationinsights-properties-js.ts
@@ -6,4 +6,4 @@ import { TelemetryTrace } from "./Context/TelemetryTrace";
 import { TelemetryContext } from './TelemetryContext'
 import { ISessionConfig, Session, _SessionManager } from "./Context/Session";
 
-export { PropertiesPlugin, TelemetryTrace, TelemetryContext, User, Session, ISessionConfig, _SessionManager as SessionManager };
+export { PropertiesPlugin, TelemetryTrace, TelemetryContext, Session, ISessionConfig, _SessionManager as SessionManager };

--- a/vNext/shared/AppInsightsCommon/src/Interfaces/Context/ISession.ts
+++ b/vNext/shared/AppInsightsCommon/src/Interfaces/Context/ISession.ts
@@ -5,18 +5,18 @@ export interface ISession {
     /**
     * The session ID.
     */
-    id: string;
+    id?: string;
 
     /**
      * The date at which this guid was genereated.
      * Per the spec the ID will be regenerated if more than acquisitionSpan milliseconds ellapse from this time.
      */
-    acquisitionDate: number;
+    acquisitionDate?: number;
 
     /**
      * The date at which this session ID was last reported.
      * This value should be updated whenever telemetry is sent using this ID.
      * Per the spec the ID will be regenerated if more than renewalSpan milliseconds elapse from this time with no activity.
      */
-    renewalDate: number;
+    renewalDate?: number;
 }


### PR DESCRIPTION
For extending properties plugin, interfaces fields should be optional.