### PR TITLE
stringify part c properties, add refUri

### DIFF
--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/SanitizerE2E.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/SanitizerE2E.tests.ts
@@ -75,7 +75,7 @@ class Sanitizer2ETests extends TestClass {
             ].concat(<any>PollingAssert.createPollingAssert(() => {
                 Assert.ok(true, "waiting for response " + new Date().toISOString());
                 return (aiT1.successSpy.called || aiT1.errorSpy.called || aiT1.loggingSpy.called);
-            }, "Wait for response", 5, 1000))
+            }, "Wait for response"))
                 .concat(() => {
                     boilerPlateAsserts(aiT1);
                 })
@@ -103,7 +103,7 @@ class Sanitizer2ETests extends TestClass {
             ].concat(<any>PollingAssert.createPollingAssert(() => {
                 Assert.ok(true, "waiting for response " + new Date().toISOString());
                 return (aiT2.successSpy.called || aiT2.errorSpy.called || aiT2.loggingSpy.called);
-            }, "Wait for response", 5, 1000))
+            }, "Wait for response"))
                 .concat(() => {
                     boilerPlateAsserts(aiT2);
                 })
@@ -125,7 +125,7 @@ class Sanitizer2ETests extends TestClass {
             ].concat(<any>PollingAssert.createPollingAssert(() => {
                 Assert.ok(true, "waiting for response " + new Date().toISOString());
                 return (aiT3.successSpy.called || aiT3.errorSpy.called || aiT3.loggingSpy.called);
-            }, "Wait for response", 5, 1000))
+            }, "Wait for response"))
                 .concat(() => {
                     boilerPlateAsserts(aiT3);
                 })
@@ -151,7 +151,7 @@ class Sanitizer2ETests extends TestClass {
             ].concat(<any>PollingAssert.createPollingAssert(() => {
                 Assert.ok(true, "waiting for response " + new Date().toISOString());
                 return (aiT4.successSpy.called || aiT4.errorSpy.called || aiT4.loggingSpy.called);
-            }, "Wait for response", 5, 1000))
+            }, "Wait for response"))
                 .concat(() => {
                     boilerPlateAsserts(aiT4);
                 })
@@ -174,7 +174,7 @@ class Sanitizer2ETests extends TestClass {
             ].concat(<any>PollingAssert.createPollingAssert(() => {
                 Assert.ok(true, "waiting for response " + new Date().toISOString());
                 return (aiT5.successSpy.called || aiT5.errorSpy.called || aiT5.loggingSpy.called);
-            }, "Wait for response", 5, 1000))
+            }, "Wait for response"))
                 .concat(() => {
                     boilerPlateAsserts(aiT5);
                 })
@@ -196,11 +196,11 @@ class Sanitizer2ETests extends TestClass {
             ].concat(<any>PollingAssert.createPollingAssert(() => {
                 Assert.ok(true, "waiting for response " + new Date().toISOString());
                 return (aiT6.successSpy.called || aiT6.errorSpy.called || aiT6.loggingSpy.called);
-            }, "Wait for response", 5, 1000))
+            }, "Wait for response"))
                 .concat(() => {
                     boilerPlateAsserts(aiT6);
                 })
         });
     }
 }
-new Sanitizer2ETests().registerTests(); 
+new Sanitizer2ETests().registerTests();

--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/ValidateApi.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/ValidateApi.tests.ts
@@ -139,7 +139,7 @@ class ValidateTests extends TestClass {
     private waitForResponse() {
         return <any>PollingAssert.createPollingAssert(() => {
             return (this.successSpy.called || this.errorSpy.called);
-        }, "Wait for response" + new Date().toISOString(), 5, 1000)
+        }, "Wait for response" + new Date().toISOString())
     }
 
     private boilerPlateAsserts() {

--- a/JavaScript/JavaScriptSDK.Tests/E2ETests/snippet.tests.ts
+++ b/JavaScript/JavaScriptSDK.Tests/E2ETests/snippet.tests.ts
@@ -188,7 +188,7 @@ class SnippetTests extends TestClass {
                 }]
                 .concat(<any>PollingAssert.createPollingAssert(() => {
                     return (!window[this.aiName].hasOwnProperty("queue"))
-                }, "waiting for AI Init() to finish" + new Date().toISOString(), 5, 200))
+                }, "waiting for AI Init() to finish" + new Date().toISOString()))
                 .concat(() => {
                     Assert.ok(!window[this.aiName].hasOwnProperty("queue"), "queue was removed during the init");
                     Assert.equal(this.queueCallCount, this.queueSpy.callCount, "should drain the queue");
@@ -235,7 +235,7 @@ class SnippetTests extends TestClass {
     private waitForResponse() {
         return <any>PollingAssert.createPollingAssert(() => {
             return (this.senderMocks.successSpy.called || this.senderMocks.errorSpy.called);
-        }, "Wait for response" + new Date().toISOString(), 5, 1000)
+        }, "Wait for response" + new Date().toISOString())
     }
 
     private checkConfig() {

--- a/vNext/AISKU/Tests/applicationinsights.e2e.tests.ts
+++ b/vNext/AISKU/Tests/applicationinsights.e2e.tests.ts
@@ -364,7 +364,7 @@ export class ApplicationInsightsTests extends TestClass {
                         }
                     }
                     return false;
-                }, 'user.authenticatedId', 5, 500))
+                }, 'user.authenticatedId'))
         });
 
         this.testCaseAsync({
@@ -394,7 +394,7 @@ export class ApplicationInsightsTests extends TestClass {
                         }
                     }
                     return false;
-                }, 'user.authenticatedId', 5, 500))
+                }, 'user.authenticatedId'))
         });
 
         this.testCaseAsync({
@@ -424,7 +424,7 @@ export class ApplicationInsightsTests extends TestClass {
                         }
                     }
                     return false;
-                }, 'user.authenticatedId', 5, 500))
+                }, 'user.authenticatedId'))
         });
 
         this.testCaseAsync({
@@ -455,7 +455,7 @@ export class ApplicationInsightsTests extends TestClass {
                         }
                     }
                     return false;
-                }, 'user.authenticatedId', 5, 500))
+                }, 'user.authenticatedId'))
         });
 
         // This doesn't need to be e2e

--- a/vNext/AISKU/Tests/sanitizer.e2e.tests.ts
+++ b/vNext/AISKU/Tests/sanitizer.e2e.tests.ts
@@ -4,7 +4,7 @@ import { Sender } from '@microsoft/applicationinsights-channel-js';
 
 export class SanitizerE2ETests extends TestClass {
     private readonly _instrumentationKey = 'b7170927-2d1c-44f1-acec-59f4e1751c11';
-    
+
     private _ai: IApplicationInsights;
 
     // Sinon
@@ -80,7 +80,7 @@ export class SanitizerE2ETests extends TestClass {
             ].concat(<any>PollingAssert.createPollingAssert(() => {
                 Assert.ok(true, "waiting for response " + new Date().toISOString());
                 return (this.successSpy.called || this.errorSpy.called || this.loggingSpy.called);
-            }, "Wait for response", 5, 1000))
+            }, "Wait for response"))
                 .concat(() => {
                     boilerPlateAsserts();
                 })
@@ -105,7 +105,7 @@ export class SanitizerE2ETests extends TestClass {
             ].concat(<any>PollingAssert.createPollingAssert(() => {
                 Assert.ok(true, "waiting for response " + new Date().toISOString());
                 return (this.successSpy.called || this.errorSpy.called || this.loggingSpy.called);
-            }, "Wait for response", 5, 1000))
+            }, "Wait for response"))
                 .concat(() => {
                     boilerPlateAsserts();
                 })
@@ -124,7 +124,7 @@ export class SanitizerE2ETests extends TestClass {
             ].concat(<any>PollingAssert.createPollingAssert(() => {
                 Assert.ok(true, "waiting for response " + new Date().toISOString());
                 return (this.successSpy.called || this.errorSpy.called || this.loggingSpy.called);
-            }, "Wait for response", 5, 1000))
+            }, "Wait for response"))
                 .concat(() => {
                     boilerPlateAsserts();
                 })
@@ -147,7 +147,7 @@ export class SanitizerE2ETests extends TestClass {
             ].concat(<any>PollingAssert.createPollingAssert(() => {
                 Assert.ok(true, "waiting for response " + new Date().toISOString());
                 return (this.successSpy.called || this.errorSpy.called || this.loggingSpy.called);
-            }, "Wait for response", 5, 1000))
+            }, "Wait for response"))
                 .concat(() => {
                     boilerPlateAsserts();
                 })
@@ -167,7 +167,7 @@ export class SanitizerE2ETests extends TestClass {
             ].concat(<any>PollingAssert.createPollingAssert(() => {
                 Assert.ok(true, "waiting for response " + new Date().toISOString());
                 return (this.successSpy.called || this.errorSpy.called || this.loggingSpy.called);
-            }, "Wait for response", 5, 1000))
+            }, "Wait for response"))
                 .concat(() => {
                     boilerPlateAsserts();
                 })
@@ -186,7 +186,7 @@ export class SanitizerE2ETests extends TestClass {
             ].concat(<any>PollingAssert.createPollingAssert(() => {
                 Assert.ok(true, "waiting for response " + new Date().toISOString());
                 return (this.successSpy.called || this.errorSpy.called || this.loggingSpy.called);
-            }, "Wait for response", 5, 1000))
+            }, "Wait for response"))
                 .concat(() => {
                     boilerPlateAsserts();
                 })

--- a/vNext/AISKU/Tests/sender.e2e.tests.ts
+++ b/vNext/AISKU/Tests/sender.e2e.tests.ts
@@ -7,7 +7,7 @@ export class SenderE2ETests extends TestClass {
     private readonly _instrumentationKey = 'b7170927-2d1c-44f1-acec-59f4e1751c11';
     private readonly _bufferName = 'AI_buffer';
     private readonly _sentBufferName = 'AI_sentBuffer';
-    
+
     private _ai: IApplicationInsights;
     private _sender: Sender;
 
@@ -112,8 +112,8 @@ export class SenderE2ETests extends TestClass {
             ]
             .concat(this.waitForResponse())
             .concat(this.boilerPlateAsserts)
-            .concat(<any>PollingAssert.createPollingAssert(() => this.successSpy.called && this.isSessionSentEmpty(), "SentBuffer Session storage is empty", 5, 1000))
-            .concat(<any>PollingAssert.createPollingAssert(() => this.successSpy.called && this.isSessionEmpty(), "Buffer Session storage is empty", 5, 1000))
+            .concat(<any>PollingAssert.createPollingAssert(() => this.successSpy.called && this.isSessionSentEmpty(), "SentBuffer Session storage is empty", 15, 1000))
+            .concat(<any>PollingAssert.createPollingAssert(() => this.successSpy.called && this.isSessionEmpty(), "Buffer Session storage is empty", 15, 1000))
         });
     }
 
@@ -148,17 +148,17 @@ export class SenderE2ETests extends TestClass {
                 }
 
                 return false;
-            }, `Backend accepts ${SENT_ITEMS} items`, 5, 1000))
+            }, `Backend accepts ${SENT_ITEMS} items`, 15, 1000))
             .concat(<any>PollingAssert.createPollingAssert(() => {
                 return this.successSpy.calledOnce;
-            }, "Tracks are sent in ONE batch", 5, 1000))
+            }, "Tracks are sent in ONE batch", 15, 1000))
         });
     }
 
     private waitForResponse() {
         return <any>PollingAssert.createPollingAssert(() => {
             return (this.successSpy.called || this.errorSpy.called);
-        }, "Wait for response" + new Date().toISOString(), 5, 1000)
+        }, "Wait for response" + new Date().toISOString(), 15, 1000)
     }
 
     private boilerPlateAsserts() {

--- a/vNext/AISKU/Tests/validate.e2e.tests.ts
+++ b/vNext/AISKU/Tests/validate.e2e.tests.ts
@@ -4,7 +4,7 @@ import { Sender } from '@microsoft/applicationinsights-channel-js';
 
 export class ValidateE2ETests extends TestClass {
     private readonly _instrumentationKey = 'b7170927-2d1c-44f1-acec-59f4e1751c11';
-    
+
     private _ai: IApplicationInsights;
 
     // Sinon
@@ -122,7 +122,7 @@ export class ValidateE2ETests extends TestClass {
     private waitForResponse() {
         return <any>PollingAssert.createPollingAssert(() => {
             return (this.successSpy.called || this.errorSpy.called);
-        }, "Wait for response" + new Date().toISOString(), 5, 1000)
+        }, "Wait for response" + new Date().toISOString(), 15, 1000)
     }
 
     private boilerPlateAsserts() {

--- a/vNext/AISKU/package.json
+++ b/vNext/AISKU/package.json
@@ -6,6 +6,10 @@
     "module": "dist-esm/applicationinsights-web.js",
     "types": "dist-esm/applicationinsights-web.d.ts",
     "sideEffects": false,
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Microsoft/ApplicationInsights-JS/tree/master/vNext/AISKU"
+    },
     "scripts": {
         "clean": "rm -rfv browser types dist-esm",
         "build": "npm run build:esm && npm run build:browser && grunt snippetvnext",
@@ -40,12 +44,12 @@
         "grunt-tslint": "^5.0.2"
     },
     "dependencies": {
-        "@microsoft/applicationinsights-analytics-js": "^2.0.0-beta.3",
-        "@microsoft/applicationinsights-channel-js": "^2.0.0-beta.3",
-        "@microsoft/applicationinsights-common": "^2.0.0-beta.3",
-        "@microsoft/applicationinsights-core-js": "^2.0.0-beta.3",
-        "@microsoft/applicationinsights-dependencies-js": "^2.0.0-beta.3",
-        "@microsoft/applicationinsights-properties-js": "^2.0.0-beta.3"
+        "@microsoft/applicationinsights-analytics-js": "^2.0.0-beta.4",
+        "@microsoft/applicationinsights-channel-js": "^2.0.0-beta.4",
+        "@microsoft/applicationinsights-common": "^2.0.0-beta.4",
+        "@microsoft/applicationinsights-core-js": "^2.0.0-beta.4",
+        "@microsoft/applicationinsights-dependencies-js": "^2.0.0-beta.4",
+        "@microsoft/applicationinsights-properties-js": "^2.0.0-beta.4"
     },
     "peerDependencies": {
         "tslib": "^1.9.3"

--- a/vNext/AISKULight/package.json
+++ b/vNext/AISKULight/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-web-basic",
-    "version": "2.0.0-beta.3",
+    "version": "2.0.0-beta.4",
     "description": "Microsoft Application Insights Javascript SDK core and channel",
     "main": "dist/applicationinsights-web-basic.js",
     "module": "dist-esm/index.js",
@@ -22,9 +22,9 @@
         "rollup": "^0.66.0"
     },
     "dependencies": {
-        "@microsoft/applicationinsights-common": "^2.0.0-beta.3",
-        "@microsoft/applicationinsights-channel-js": "^2.0.0-beta.3",
-        "@microsoft/applicationinsights-core-js": "^2.0.0-beta.3"
+        "@microsoft/applicationinsights-common": "^2.0.0-beta.4",
+        "@microsoft/applicationinsights-channel-js": "^2.0.0-beta.4",
+        "@microsoft/applicationinsights-core-js": "^2.0.0-beta.4"
     },
     "peerDependencies": {
       "tslib": "^1.9.3"

--- a/vNext/channels/applicationinsights-channel-js/package.json
+++ b/vNext/channels/applicationinsights-channel-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-channel-js",
-    "version": "2.0.0-beta.3",
+    "version": "2.0.0-beta.4",
     "description": "Microsoft Application Insights JavaScript SDK Channel",
     "main": "dist/applicationinsights-channel-js.js",
     "module": "dist-esm/applicationinsights-channel-js.js",
@@ -28,8 +28,8 @@
         "rollup": "^0.66.0"
     },
     "dependencies": {
-        "@microsoft/applicationinsights-core-js": "^2.0.0-beta.3",
-        "@microsoft/applicationinsights-common": "^2.0.0-beta.3",
+        "@microsoft/applicationinsights-core-js": "^2.0.0-beta.4",
+        "@microsoft/applicationinsights-common": "^2.0.0-beta.4",
         "tslib": "^1.9.3"
     },
     "license": "MIT"

--- a/vNext/common/config/rush/npm-shrinkwrap.json
+++ b/vNext/common/config/rush/npm-shrinkwrap.json
@@ -8,9 +8,9 @@
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz"
     },
     "@babel/core": {
-      "version": "7.3.4",
+      "version": "7.4.0",
       "from": "@babel/core@^7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.0.tgz",
       "dependencies": {
         "debug": {
           "version": "4.1.1",
@@ -25,9 +25,9 @@
       }
     },
     "@babel/generator": {
-      "version": "7.3.4",
-      "from": "@babel/generator@^7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.4.tgz"
+      "version": "7.4.0",
+      "from": "@babel/generator@^7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz"
     },
     "@babel/helper-annotate-as-pure": {
       "version": "7.0.0",
@@ -45,19 +45,19 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.3.0.tgz"
     },
     "@babel/helper-call-delegate": {
-      "version": "7.1.0",
-      "from": "@babel/helper-call-delegate@^7.1.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz"
+      "version": "7.4.0",
+      "from": "@babel/helper-call-delegate@^7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.0.tgz"
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.3.4",
-      "from": "@babel/helper-create-class-features-plugin@^7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.3.4.tgz"
+      "version": "7.4.0",
+      "from": "@babel/helper-create-class-features-plugin@^7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.4.0.tgz"
     },
     "@babel/helper-define-map": {
-      "version": "7.1.0",
-      "from": "@babel/helper-define-map@^7.1.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz"
+      "version": "7.4.0",
+      "from": "@babel/helper-define-map@^7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.0.tgz"
     },
     "@babel/helper-explode-assignable-expression": {
       "version": "7.1.0",
@@ -75,9 +75,9 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz"
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.0.0",
-      "from": "@babel/helper-hoist-variables@^7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz"
+      "version": "7.4.0",
+      "from": "@babel/helper-hoist-variables@^7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.0.tgz"
     },
     "@babel/helper-member-expression-to-functions": {
       "version": "7.0.0",
@@ -115,9 +115,9 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz"
     },
     "@babel/helper-replace-supers": {
-      "version": "7.3.4",
-      "from": "@babel/helper-replace-supers@^7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.3.4.tgz"
+      "version": "7.4.0",
+      "from": "@babel/helper-replace-supers@^7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.0.tgz"
     },
     "@babel/helper-simple-access": {
       "version": "7.1.0",
@@ -125,9 +125,9 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz"
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.0.0",
-      "from": "@babel/helper-split-export-declaration@^7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz"
+      "version": "7.4.0",
+      "from": "@babel/helper-split-export-declaration@^7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz"
     },
     "@babel/helper-wrap-function": {
       "version": "7.2.0",
@@ -135,9 +135,9 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz"
     },
     "@babel/helpers": {
-      "version": "7.3.1",
-      "from": "@babel/helpers@^7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.3.1.tgz"
+      "version": "7.4.2",
+      "from": "@babel/helpers@^7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.2.tgz"
     },
     "@babel/highlight": {
       "version": "7.0.0",
@@ -162,9 +162,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.3.4",
-      "from": "@babel/parser@^7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.4.tgz"
+      "version": "7.4.2",
+      "from": "@babel/parser@^7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.2.tgz"
     },
     "@babel/plugin-external-helpers": {
       "version": "7.2.0",
@@ -172,9 +172,9 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-external-helpers/-/plugin-external-helpers-7.2.0.tgz"
     },
     "@babel/plugin-proposal-class-properties": {
-      "version": "7.3.4",
+      "version": "7.4.0",
       "from": "@babel/plugin-proposal-class-properties@^7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.3.4.tgz"
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.4.0.tgz"
     },
     "@babel/plugin-proposal-export-default-from": {
       "version": "7.2.0",
@@ -187,9 +187,9 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.2.0.tgz"
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.3.4",
+      "version": "7.4.0",
       "from": "@babel/plugin-proposal-object-rest-spread@^7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.4.tgz"
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.0.tgz"
     },
     "@babel/plugin-proposal-optional-catch-binding": {
       "version": "7.2.0",
@@ -257,9 +257,9 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz"
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.3.4",
+      "version": "7.4.0",
       "from": "@babel/plugin-transform-async-to-generator@^7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.3.4.tgz"
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.0.tgz"
     },
     "@babel/plugin-transform-block-scoped-functions": {
       "version": "7.2.0",
@@ -267,14 +267,14 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz"
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.3.4",
+      "version": "7.4.0",
       "from": "@babel/plugin-transform-block-scoping@^7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.3.4.tgz"
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.0.tgz"
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.3.4",
+      "version": "7.4.0",
       "from": "@babel/plugin-transform-classes@^7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.3.4.tgz"
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.0.tgz"
     },
     "@babel/plugin-transform-computed-properties": {
       "version": "7.2.0",
@@ -282,9 +282,9 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz"
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.3.2",
+      "version": "7.4.0",
       "from": "@babel/plugin-transform-destructuring@^7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.3.2.tgz"
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.0.tgz"
     },
     "@babel/plugin-transform-exponentiation-operator": {
       "version": "7.2.0",
@@ -292,14 +292,14 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz"
     },
     "@babel/plugin-transform-flow-strip-types": {
-      "version": "7.3.4",
+      "version": "7.4.0",
       "from": "@babel/plugin-transform-flow-strip-types@^7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.3.4.tgz"
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.4.0.tgz"
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.2.0",
+      "version": "7.4.0",
       "from": "@babel/plugin-transform-for-of@^7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.0.tgz"
     },
     "@babel/plugin-transform-function-name": {
       "version": "7.2.0",
@@ -317,9 +317,9 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz"
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.2.0",
+      "version": "7.4.0",
       "from": "@babel/plugin-transform-modules-commonjs@^7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.0.tgz"
     },
     "@babel/plugin-transform-object-assign": {
       "version": "7.2.0",
@@ -332,9 +332,9 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz"
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.3.3",
+      "version": "7.4.0",
       "from": "@babel/plugin-transform-parameters@^7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.3.3.tgz"
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.0.tgz"
     },
     "@babel/plugin-transform-property-literals": {
       "version": "7.2.0",
@@ -357,14 +357,14 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.2.0.tgz"
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.3.4",
+      "version": "7.4.0",
       "from": "@babel/plugin-transform-regenerator@^7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.3.4.tgz"
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.0.tgz"
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.3.4",
+      "version": "7.4.0",
       "from": "@babel/plugin-transform-runtime@^7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.3.4.tgz"
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.0.tgz"
     },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.2.0",
@@ -387,9 +387,9 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.2.0.tgz"
     },
     "@babel/plugin-transform-typescript": {
-      "version": "7.3.2",
+      "version": "7.4.0",
       "from": "@babel/plugin-transform-typescript@^7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.3.2.tgz"
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.4.0.tgz"
     },
     "@babel/plugin-transform-unicode-regex": {
       "version": "7.2.0",
@@ -397,38 +397,38 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.2.0.tgz"
     },
     "@babel/register": {
-      "version": "7.0.0",
+      "version": "7.4.0",
       "from": "@babel/register@^7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.4.0.tgz",
       "dependencies": {
         "core-js": {
-          "version": "2.6.5",
-          "from": "core-js@^2.5.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz"
+          "version": "3.0.0",
+          "from": "core-js@^3.0.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.0.tgz"
         }
       }
     },
     "@babel/runtime": {
-      "version": "7.3.4",
+      "version": "7.4.2",
       "from": "@babel/runtime@^7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
       "dependencies": {
         "regenerator-runtime": {
-          "version": "0.12.1",
-          "from": "regenerator-runtime@^0.12.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz"
+          "version": "0.13.2",
+          "from": "regenerator-runtime@^0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz"
         }
       }
     },
     "@babel/template": {
-      "version": "7.2.2",
-      "from": "@babel/template@^7.2.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz"
+      "version": "7.4.0",
+      "from": "@babel/template@^7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz"
     },
     "@babel/traverse": {
-      "version": "7.3.4",
-      "from": "@babel/traverse@^7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.3.4.tgz",
+      "version": "7.4.0",
+      "from": "@babel/traverse@^7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.0.tgz",
       "dependencies": {
         "debug": {
           "version": "4.1.1",
@@ -443,9 +443,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.3.4",
-      "from": "@babel/types@^7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz"
+      "version": "7.4.0",
+      "from": "@babel/types@^7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz"
     },
     "@rush-temp/applicationinsights-analytics-js": {
       "version": "0.0.0",
@@ -498,9 +498,9 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz"
     },
     "@types/node": {
-      "version": "11.10.5",
+      "version": "11.12.0",
       "from": "@types/node@*",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.10.5.tgz"
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.12.0.tgz"
     },
     "abbrev": {
       "version": "1.1.1",
@@ -675,9 +675,9 @@
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
     },
     "async-each": {
-      "version": "1.0.1",
-      "from": "async-each@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz"
+      "version": "1.0.2",
+      "from": "async-each@^1.0.1",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.2.tgz"
     },
     "async-limiter": {
       "version": "1.0.0",
@@ -723,7 +723,7 @@
     },
     "babel-preset-fbjs": {
       "version": "3.2.0",
-      "from": "babel-preset-fbjs@^3.0.0",
+      "from": "babel-preset-fbjs@^3.2.0",
       "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-3.2.0.tgz"
     },
     "balanced-match": {
@@ -774,9 +774,9 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz"
     },
     "big-integer": {
-      "version": "1.6.42",
+      "version": "1.6.43",
       "from": "big-integer@^1.6.7",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.42.tgz"
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.43.tgz"
     },
     "big.js": {
       "version": "5.2.2",
@@ -784,9 +784,9 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz"
     },
     "binary-extensions": {
-      "version": "1.13.0",
+      "version": "1.13.1",
       "from": "binary-extensions@^1.0.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.0.tgz"
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz"
     },
     "bplist-creator": {
       "version": "0.0.7",
@@ -896,9 +896,9 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz"
     },
     "chokidar": {
-      "version": "2.1.2",
+      "version": "2.1.5",
       "from": "chokidar@^2.0.4",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.5.tgz"
     },
     "chromedriver": {
       "version": "2.46.0",
@@ -1001,13 +1001,13 @@
     },
     "compressible": {
       "version": "2.0.16",
-      "from": "compressible@~2.0.14",
+      "from": "compressible@~2.0.16",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.16.tgz"
     },
     "compression": {
-      "version": "1.7.3",
+      "version": "1.7.4",
       "from": "compression@^1.7.1",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz"
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz"
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1052,9 +1052,9 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
     "cosmiconfig": {
-      "version": "5.1.0",
+      "version": "5.2.0",
       "from": "cosmiconfig@^5.0.5",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.0.tgz",
       "dependencies": {
         "esprima": {
           "version": "4.0.1",
@@ -1062,9 +1062,9 @@
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz"
         },
         "js-yaml": {
-          "version": "3.12.2",
-          "from": "js-yaml@^3.9.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz"
+          "version": "3.13.0",
+          "from": "js-yaml@^3.13.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz"
         },
         "parse-json": {
           "version": "4.0.0",
@@ -1472,9 +1472,9 @@
       "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz"
     },
     "fbjs-scripts": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "from": "fbjs-scripts@^1.0.0",
-      "resolved": "https://registry.npmjs.org/fbjs-scripts/-/fbjs-scripts-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fbjs-scripts/-/fbjs-scripts-1.2.0.tgz",
       "dependencies": {
         "core-js": {
           "version": "2.6.5",
@@ -1523,9 +1523,9 @@
       }
     },
     "find-cache-dir": {
-      "version": "1.0.0",
-      "from": "find-cache-dir@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz"
+      "version": "2.1.0",
+      "from": "find-cache-dir@^2.0.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz"
     },
     "find-up": {
       "version": "1.1.2",
@@ -1707,7 +1707,7 @@
       "dependencies": {
         "glob": {
           "version": "7.1.3",
-          "from": "glob@>=7.1.3 <8.0.0",
+          "from": "glob@^7.1.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz"
         },
         "rimraf": {
@@ -1768,7 +1768,7 @@
       "dependencies": {
         "glob": {
           "version": "7.1.3",
-          "from": "glob@>=7.1.3 <8.0.0",
+          "from": "glob@^7.1.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz"
         },
         "rimraf": {
@@ -1851,11 +1851,6 @@
       "version": "2.2.0",
       "from": "hasha@>=2.2.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz"
-    },
-    "home-or-tmp": {
-      "version": "3.0.0",
-      "from": "home-or-tmp@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz"
     },
     "hooker": {
       "version": "0.2.3",
@@ -2058,9 +2053,9 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
     },
     "is-glob": {
-      "version": "4.0.0",
-      "from": "is-glob@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz"
+      "version": "4.0.1",
+      "from": "is-glob@^4.0.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz"
     },
     "is-module": {
       "version": "1.0.0",
@@ -2239,14 +2234,14 @@
       }
     },
     "jest-serializer": {
-      "version": "24.3.0",
+      "version": "24.4.0",
       "from": "jest-serializer@^24.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.4.0.tgz"
     },
     "jest-worker": {
-      "version": "24.3.1",
+      "version": "24.4.0",
       "from": "jest-worker@^24.0.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.4.0.tgz",
       "dependencies": {
         "supports-color": {
           "version": "6.1.0",
@@ -2379,11 +2374,6 @@
       "from": "lodash@~4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz"
     },
-    "lodash.get": {
-      "version": "4.4.2",
-      "from": "lodash.get@>=4.4.2 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz"
-    },
     "lodash.pad": {
       "version": "4.5.1",
       "from": "lodash.pad@>=4.1.0 <5.0.0",
@@ -2421,18 +2411,18 @@
     },
     "magic-string": {
       "version": "0.25.2",
-      "from": "magic-string@^0.25.1",
+      "from": "magic-string@^0.25.2",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz"
     },
     "make-dir": {
-      "version": "1.3.0",
-      "from": "make-dir@^1.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "version": "2.1.0",
+      "from": "make-dir@^2.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
       "dependencies": {
         "pify": {
-          "version": "3.0.0",
-          "from": "pify@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
+          "version": "4.0.1",
+          "from": "pify@^4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz"
         }
       }
     },
@@ -2498,7 +2488,7 @@
         },
         "glob": {
           "version": "7.1.3",
-          "from": "glob@>=7.1.3 <8.0.0",
+          "from": "glob@^7.1.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz"
         },
         "jest-worker": {
@@ -2547,7 +2537,7 @@
       "dependencies": {
         "glob": {
           "version": "7.1.3",
-          "from": "glob@>=7.1.3 <8.0.0",
+          "from": "glob@^7.1.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz"
         },
         "jest-serializer": {
@@ -2824,7 +2814,7 @@
     },
     "on-headers": {
       "version": "1.0.2",
-      "from": "on-headers@~1.0.1",
+      "from": "on-headers@~1.0.2",
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz"
     },
     "once": {
@@ -3029,14 +3019,39 @@
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz"
     },
     "pkg-dir": {
-      "version": "2.0.0",
-      "from": "pkg-dir@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "version": "3.0.0",
+      "from": "pkg-dir@^3.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
       "dependencies": {
         "find-up": {
+          "version": "3.0.0",
+          "from": "find-up@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz"
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "from": "locate-path@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz"
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "from": "p-limit@^2.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz"
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "from": "p-locate@^3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz"
+        },
+        "p-try": {
           "version": "2.1.0",
-          "from": "find-up@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz"
+          "from": "p-try@^2.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz"
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "from": "path-exists@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz"
         }
       }
     },
@@ -3209,9 +3224,9 @@
       }
     },
     "react-is": {
-      "version": "16.8.4",
+      "version": "16.8.6",
       "from": "react-is@^16.8.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.4.tgz"
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz"
     },
     "react-native": {
       "version": "0.58.5",
@@ -3220,7 +3235,7 @@
       "dependencies": {
         "glob": {
           "version": "7.1.3",
-          "from": "glob@>=7.1.1 <8.0.0",
+          "from": "glob@^7.1.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz"
         },
         "rimraf": {
@@ -3231,9 +3246,9 @@
       }
     },
     "react-native-device-info": {
-      "version": "0.26.4",
+      "version": "0.26.5",
       "from": "react-native-device-info@^0.26.4",
-      "resolved": "https://registry.npmjs.org/react-native-device-info/-/react-native-device-info-0.26.4.tgz"
+      "resolved": "https://registry.npmjs.org/react-native-device-info/-/react-native-device-info-0.26.5.tgz"
     },
     "react-proxy": {
       "version": "1.1.8",
@@ -3276,9 +3291,9 @@
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz"
     },
     "regenerate-unicode-properties": {
-      "version": "8.0.1",
-      "from": "regenerate-unicode-properties@^8.0.1",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.0.1.tgz"
+      "version": "8.0.2",
+      "from": "regenerate-unicode-properties@^8.0.2",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.0.2.tgz"
     },
     "regenerator-runtime": {
       "version": "0.11.1",
@@ -3301,9 +3316,9 @@
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz"
     },
     "regexpu-core": {
-      "version": "4.5.3",
+      "version": "4.5.4",
       "from": "regexpu-core@^4.1.3",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.3.tgz"
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz"
     },
     "regjsgen": {
       "version": "0.5.0",
@@ -3403,9 +3418,9 @@
       "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.4.0.tgz"
     },
     "rollup-plugin-replace": {
-      "version": "2.1.0",
+      "version": "2.1.1",
       "from": "rollup-plugin-replace@^2.1.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-2.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-2.1.1.tgz"
     },
     "rollup-plugin-uglify": {
       "version": "6.0.2",
@@ -3413,9 +3428,9 @@
       "resolved": "https://registry.npmjs.org/rollup-plugin-uglify/-/rollup-plugin-uglify-6.0.2.tgz",
       "dependencies": {
         "commander": {
-          "version": "2.17.1",
-          "from": "commander@~2.17.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz"
+          "version": "2.19.0",
+          "from": "commander@~2.19.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz"
         },
         "source-map": {
           "version": "0.6.1",
@@ -3423,16 +3438,16 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
         },
         "uglify-js": {
-          "version": "3.4.9",
+          "version": "3.5.2",
           "from": "uglify-js@^3.4.9",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz"
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.2.tgz"
         }
       }
     },
     "rollup-pluginutils": {
-      "version": "2.4.1",
-      "from": "rollup-pluginutils@^2.0.1",
-      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.4.1.tgz"
+      "version": "2.5.0",
+      "from": "rollup-pluginutils@^2.4.1",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.5.0.tgz"
     },
     "rsvp": {
       "version": "3.6.2",
@@ -3490,9 +3505,9 @@
       "resolved": "https://registry.npmjs.org/selenium-server-standalone-jar/-/selenium-server-standalone-jar-3.141.5.tgz"
     },
     "semver": {
-      "version": "5.6.0",
+      "version": "5.7.0",
       "from": "semver@2 || 3 || 4 || 5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz"
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz"
     },
     "send": {
       "version": "0.16.2",
@@ -3684,9 +3699,9 @@
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz"
     },
     "source-map-support": {
-      "version": "0.5.10",
+      "version": "0.5.11",
       "from": "source-map-support@^0.5.9",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
@@ -3931,9 +3946,9 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz"
     },
     "tslint": {
-      "version": "5.13.1",
+      "version": "5.14.0",
       "from": "tslint@^5.11.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.14.0.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
@@ -3962,13 +3977,13 @@
         },
         "glob": {
           "version": "7.1.3",
-          "from": "glob@>=7.1.1 <8.0.0",
+          "from": "glob@^7.1.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz"
         },
         "js-yaml": {
-          "version": "3.12.2",
+          "version": "3.13.0",
           "from": "js-yaml@^3.7.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz"
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz"
         },
         "supports-color": {
           "version": "5.5.0",
@@ -3991,7 +4006,7 @@
     },
     "tsutils": {
       "version": "2.29.0",
-      "from": "tsutils@^2.27.2",
+      "from": "tsutils@^2.29.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz"
     },
     "tunnel-agent": {
@@ -4101,9 +4116,9 @@
       }
     },
     "upath": {
-      "version": "1.1.1",
-      "from": "upath@^1.1.0",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.1.tgz"
+      "version": "1.1.2",
+      "from": "upath@^1.1.1",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz"
     },
     "uri-js": {
       "version": "4.2.2",

--- a/vNext/extensions/applicationinsights-analytics-js/package.json
+++ b/vNext/extensions/applicationinsights-analytics-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-analytics-js",
-    "version": "2.0.0-beta.3",
+    "version": "2.0.0-beta.4",
     "description": "Microsoft Application Insights Javascript SDK apis",
     "main": "dist/applicationinsights-analytics-js.js",
     "module": "dist-esm/applicationinsights-analytics-js.js",
@@ -8,7 +8,7 @@
     "sideEffects": false,
     "repository": {
         "type": "git",
-        "url": "https://github.com/Microsoft/ApplicationInsights-JS/tree/master/ApplicationInsights"
+        "url": "https://github.com/Microsoft/ApplicationInsights-JS/tree/master/vNext/extensions/applicationinsights-analytics-js"
     },
     "scripts": {
         "build": "npm run build:esm && npm run build:browser",
@@ -28,8 +28,8 @@
         "rollup": "^0.66.0"
     },
     "dependencies": {
-        "@microsoft/applicationinsights-core-js": "^2.0.0-beta.3",
-        "@microsoft/applicationinsights-common": "^2.0.0-beta.3",
+        "@microsoft/applicationinsights-core-js": "^2.0.0-beta.4",
+        "@microsoft/applicationinsights-common": "^2.0.0-beta.4",
         "tslib": "^1.9.3"
     },
     "license": "MIT"

--- a/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
+++ b/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
@@ -244,6 +244,10 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
      * @param systemProperties System level properties (Part A) that a user can add to the telemetry item
      */
     public sendPageViewInternal(pageView: IPageViewTelemetryInternal, properties?: { [key: string]: any }, systemProperties?: { [key: string]: any }) {
+        if (typeof document !== "undefined") {
+            pageView.refUri = pageView.refUri || document.referrer;
+        }
+
         let telemetryItem = TelemetryItemCreator.create<IPageViewTelemetryInternal>(
             pageView,
             PageView.dataType,

--- a/vNext/extensions/applicationinsights-dependencies-js/package.json
+++ b/vNext/extensions/applicationinsights-dependencies-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-dependencies-js",
-    "version": "2.0.0-beta.3",
+    "version": "2.0.0-beta.4",
     "description": "Microsoft Application Insights XHR dependencies plugin",
     "main": "dist/applicationinsights-dependencies-js.js",
     "module": "dist-esm/applicationinsights-dependencies-js.js",
@@ -8,7 +8,7 @@
     "sideEffects": false,
     "repository": {
         "type": "git",
-        "url": "https://github.com/Microsoft/ApplicationInsights-JS/tree/master/extensions/applicationinsights-dependencies-js"
+        "url": "https://github.com/Microsoft/ApplicationInsights-JS/tree/master/vNext/extensions/applicationinsights-dependencies-js"
     },
     "scripts": {
         "build": "npm run build:esm && npm run build:browser",
@@ -28,8 +28,8 @@
         "rollup": "^0.66.0"
     },
     "dependencies": {
-        "@microsoft/applicationinsights-core-js": "^2.0.0-beta.3",
-        "@microsoft/applicationinsights-common": "^2.0.0-beta.3",
+        "@microsoft/applicationinsights-core-js": "^2.0.0-beta.4",
+        "@microsoft/applicationinsights-common": "^2.0.0-beta.4",
         "tslib": "^1.9.3"
     },
     "license": "MIT"

--- a/vNext/extensions/applicationinsights-properties-js/package.json
+++ b/vNext/extensions/applicationinsights-properties-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-properties-js",
-    "version": "2.0.0-beta.3",
+    "version": "2.0.0-beta.4",
     "description": "Microsoft Application Insights properties (Part A) plugin",
     "main": "dist/applicationinsights-properties-js.js",
     "module": "dist-esm/applicationinsights-properties-js.js",
@@ -8,7 +8,7 @@
     "sideEffects": false,
     "repository": {
         "type": "git",
-        "url": "https://github.com/Microsoft/ApplicationInsights-JS/tree/master/extensions/applicationinsights-properties-js"
+        "url": "https://github.com/Microsoft/ApplicationInsights-JS/tree/master/vNext/extensions/applicationinsights-properties-js"
     },
     "scripts": {
         "build": "npm run build:esm && npm run build:browser",
@@ -28,8 +28,8 @@
         "rollup": "^0.66.0"
     },
     "dependencies": {
-        "@microsoft/applicationinsights-core-js": "^2.0.0-beta.3",
-        "@microsoft/applicationinsights-common": "^2.0.0-beta.3",
+        "@microsoft/applicationinsights-core-js": "^2.0.0-beta.4",
+        "@microsoft/applicationinsights-common": "^2.0.0-beta.4",
         "tslib": "^1.9.3"
     },
     "license": "MIT"

--- a/vNext/extensions/applicationinsights-react-native/package.json
+++ b/vNext/extensions/applicationinsights-react-native/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-react-native",
-    "version": "1.0.0-beta.4",
+    "version": "1.0.0-beta.5",
     "description": "Microsoft Application Insights React Native Plugin",
     "main": "dist-esm/index.js",
     "types": "dist-esm/index.d.ts",
@@ -30,8 +30,8 @@
     },
     "dependencies": {
         "react-native-device-info": "^0.26.4",
-        "@microsoft/applicationinsights-core-js": "^2.0.0-beta.3",
-        "@microsoft/applicationinsights-common": "^2.0.0-beta.3",
+        "@microsoft/applicationinsights-core-js": "^2.0.0-beta.4",
+        "@microsoft/applicationinsights-common": "^2.0.0-beta.4",
         "tslib": "^1.9.3"
     },
     "peerDependencies": {

--- a/vNext/shared/AppInsightsCommon/package.json
+++ b/vNext/shared/AppInsightsCommon/package.json
@@ -8,7 +8,7 @@
     "sideEffects": false,
     "repository": {
         "type": "git",
-        "url": "https://github.com/Microsoft/ApplicationInsights-JS/tree/master/AppInsightsCommon"
+        "url": "https://github.com/Microsoft/ApplicationInsights-JS/tree/master/vNext/shared/AppInsightsCommon"
     },
     "scripts": {
         "build": "npm run build:esm && npm run build:browser",
@@ -30,7 +30,7 @@
         "rollup": "^0.66.0"
     },
     "dependencies": {
-        "@microsoft/applicationinsights-core-js": "^2.0.0-beta.3",
+        "@microsoft/applicationinsights-core-js": "^2.0.0-beta.4",
         "tslib": "^1.9.3"
     },
     "license": "MIT"

--- a/vNext/shared/AppInsightsCommon/package.json
+++ b/vNext/shared/AppInsightsCommon/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-common",
-    "version": "2.0.0-beta.3",
+    "version": "2.0.0-beta.4",
     "description": "Microsoft Application Insights Common JavaScript Library",
     "main": "./dist/applicationinsights-common.js",
     "module": "./dist-esm/applicationinsights-common.js",

--- a/vNext/shared/AppInsightsCommon/src/Interfaces/IDependencyTelemetry.ts
+++ b/vNext/shared/AppInsightsCommon/src/Interfaces/IDependencyTelemetry.ts
@@ -15,6 +15,6 @@ export interface IDependencyTelemetry {
     type?: string;
     data?: string;
     target?: string;
-    properties?: {[key: string]: string};
-    measurements?: {[key: string]: string};
+    properties?: {[key: string]: any};
+    measurements?: {[key: string]: number};
 }

--- a/vNext/shared/AppInsightsCommon/src/Interfaces/IEventTelemetry.ts
+++ b/vNext/shared/AppInsightsCommon/src/Interfaces/IEventTelemetry.ts
@@ -12,7 +12,7 @@ export interface IEventTelemetry {
     /**
      * Property bag to contain additional custom properties (Part C)
      */
-    properties?: { [key: string]: string };
+    properties?: { [key: string]: any };
 
     /**
      * Property bag to contain additional custom measurements (Part C)

--- a/vNext/shared/AppInsightsCommon/src/Interfaces/IExceptionTelemetry.ts
+++ b/vNext/shared/AppInsightsCommon/src/Interfaces/IExceptionTelemetry.ts
@@ -26,10 +26,10 @@ export interface IExceptionTelemetry {
 
     /**
      * Collection of custom properties
-     * @type {{ [key: string]: string}}
+     * @type {{ [key: any]: string}}
      * @memberof IExceptionTelemetry
      */
-    properties?: { [key: string]: string};
+    properties?: { [key: string]: any};
 
     /**
      * Collection of custom measurements

--- a/vNext/shared/AppInsightsCommon/src/Interfaces/IMetricTelemetry.ts
+++ b/vNext/shared/AppInsightsCommon/src/Interfaces/IMetricTelemetry.ts
@@ -31,7 +31,7 @@ export interface IMetricTelemetry {
      * @default min=average
      */
     min?: number;
-    
+
     /**
      * @description (optional) The largest measurement in the sample. Defaults to the average.
      * @type {number}

--- a/vNext/shared/AppInsightsCommon/src/Interfaces/IPageViewPerformanceTelemetry.ts
+++ b/vNext/shared/AppInsightsCommon/src/Interfaces/IPageViewPerformanceTelemetry.ts
@@ -39,7 +39,7 @@ export interface IPageViewPerformanceTelemetry {
     /**
      * Property bag to contain additional custom properties (Part C)
      */
-    properties?: { [key: string]: string };
+    properties?: { [key: string]: any };
 
     /**
      * Property bag to contain additional custom measurements (Part C)

--- a/vNext/shared/AppInsightsCommon/src/Interfaces/IPageViewTelemetry.ts
+++ b/vNext/shared/AppInsightsCommon/src/Interfaces/IPageViewTelemetry.ts
@@ -33,7 +33,7 @@ export interface IPageViewTelemetry {
     /**
      * property bag to contain an extension to domain properties - extension to Part B
      */
-    properties?: { [key: string]: string };
+    properties?: { [key: string]: any };
 
     /**
      * Property bag to contain additional custom measurements (Part C)

--- a/vNext/shared/AppInsightsCommon/src/Interfaces/ITraceTelemetry.ts
+++ b/vNext/shared/AppInsightsCommon/src/Interfaces/ITraceTelemetry.ts
@@ -21,5 +21,5 @@ export interface ITraceTelemetry {
     /**
      * property bag to contain an extension to domain properties - extension to Part B
      */
-    properties?: { [key: string]: string };
+    properties?: { [key: string]: any };
 }

--- a/vNext/shared/AppInsightsCommon/src/Telemetry/Common/DataSanitizer.ts
+++ b/vNext/shared/AppInsightsCommon/src/Telemetry/Common/DataSanitizer.ts
@@ -129,7 +129,16 @@ export class DataSanitizer {
         if (properties) {
             var tempProps = {};
             for (var prop in properties) {
-                var value = DataSanitizer.sanitizeString(logger, properties[prop], DataSanitizer.MAX_PROPERTY_LENGTH);
+                var value = properties[prop];
+                if (typeof value === "object" && typeof JSON !== "undefined") {
+                    // Stringify any part C properties
+                    try {
+                        value = JSON.stringify(value);
+                    } catch (e) {
+                        logger.throwInternal(LoggingSeverity.WARNING, _InternalMessageId.CannotSerializeObjectNonSerializable, "custom property is not valid", { exception: e}, true);
+                    }
+                }
+                value = DataSanitizer.sanitizeString(logger, value, DataSanitizer.MAX_PROPERTY_LENGTH);
                 prop = DataSanitizer.sanitizeKeyAndAddUniqueness(logger, prop, tempProps);
                 tempProps[prop] = value;
             }

--- a/vNext/shared/AppInsightsCore/package.json
+++ b/vNext/shared/AppInsightsCore/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/applicationinsights-core-js",
     "author": "Microsoft Corporation",
-    "version": "2.0.0-beta.3",
+    "version": "2.0.0-beta.4",
     "description": "Microsoft Application Insights Core Javascript SDK",
     "keywords": [
         "azure",
@@ -23,7 +23,10 @@
         "build:browser": "rollup -c rollup.config.js",
         "test": "grunt coretest"
     },
-    "repository": "github:Microsoft/applicationinsights-core-js",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Microsoft/ApplicationInsights-JS/tree/master/vNext/shared/AppInsightsCore"
+    },
     "license": "MIT",
     "sideEffects": false,
     "devDependencies": {


### PR DESCRIPTION
- #816 - Rename measurement fields to accept a number
- #818 - Adds `refUri` from `document.referral` on pageview
- **Stringifies** part C objects so user provided custom `properties` objects will now show up properly in Azure
- **Travis CI:** Also fixes Travis CI tests sometimes failing by letting tests poll for longer.

![image](https://user-images.githubusercontent.com/5515583/55028681-8d57bd80-4fc5-11e9-9f39-bcc4be7270ea.png)
