### PR TITLE
move exception creation to channel

### DIFF
--- a/vNext/channels/applicationinsights-channel-js/src/EnvelopeCreator.ts
+++ b/vNext/channels/applicationinsights-channel-js/src/EnvelopeCreator.ts
@@ -3,7 +3,9 @@ import {
     RemoteDependencyData, Event, Exception,
     Metric, PageView, Trace, PageViewPerformance, IDependencyTelemetry,
     IPageViewPerformanceTelemetry, CtxTagKeys,
-    HttpMethod, IPageViewTelemetryInternal, IWeb
+    HttpMethod, IPageViewTelemetryInternal, IWeb,
+    Util,
+    IExceptionTelemetry
 } from '@microsoft/applicationinsights-common';
 import {
     ITelemetryItem, CoreUtils,
@@ -290,8 +292,12 @@ export class ExceptionEnvelopeCreator extends EnvelopeCreator {
                 LoggingSeverity.CRITICAL,
                 _InternalMessageId.TelemetryEnvelopeInvalid, "telemetryItem.baseData cannot be null.");
         }
-
-        let baseData = telemetryItem.baseData as Exception;
+        let bd = telemetryItem.baseData as IExceptionTelemetry;
+        let customProperties = bd.properties;
+        let customMeasurements = bd.measurements;
+        let error = bd.error;
+        let severityLevel = bd.severityLevel
+        let baseData = new Exception(logger, error, customProperties, customMeasurements, severityLevel);
         let data = new Data<Exception>(Exception.dataType, baseData);
         return EnvelopeCreator.createEnvelope<Exception>(logger, Exception.envelopeType, telemetryItem, data);
     }

--- a/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
+++ b/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
@@ -364,9 +364,8 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
     * @param systemProperties
     */
     public sendExceptionInternal(exception: IExceptionTelemetry, customProperties?: { [key: string]: any }, systemProperties?: { [key: string]: any }) {
-        let baseData = new Exception(this._logger, exception.error, exception.properties, exception.measurements, exception.severityLevel)
-        let telemetryItem: ITelemetryItem = TelemetryItemCreator.create<Exception>(
-            baseData,
+        let telemetryItem: ITelemetryItem = TelemetryItemCreator.create<IExceptionTelemetry>(
+            exception,
             Exception.dataType,
             Exception.envelopeType,
             this._logger,


### PR DESCRIPTION
Move `new Exception` to channel so that `aiDataContract` does not show up in `ITelemetryItem`