### PR TITLE
common: add exception convert to/from interface

### DIFF
--- a/vNext/channels/applicationinsights-channel-js/Tests/Sender.tests.ts
+++ b/vNext/channels/applicationinsights-channel-js/Tests/Sender.tests.ts
@@ -542,22 +542,18 @@ export class SenderTests extends TestClass {
         this.testCase({
             name: 'Envelope: custom properties are put into envelope for Exception data type',
             test: () => {
+                const bd = new Exception(
+                    null,
+                    new Error(),
+                    {"property1": "val1", "property2": "val2" },
+                    {"measurement1": 50.0, "measurement2": 1.3 }
+                );
                 const inputEnvelope: ITelemetryItem = {
                     name: "test",
                     time: new Date("2018-06-12").toISOString(),
                     iKey: "iKey",
                     baseType: Exception.dataType,
-                    baseData: {
-                        error: new Error(),
-                        properties: {
-                            "property1": "val1",
-                            "property2": "val2"
-                        },
-                        measurements: {
-                            "measurement1": 50.0,
-                            "measurement2": 1.3
-                        }
-                    },
+                    baseData: bd,
                     data: {
                         "property3": "val3",
                         "measurement3": 3.0

--- a/vNext/channels/applicationinsights-channel-js/src/EnvelopeCreator.ts
+++ b/vNext/channels/applicationinsights-channel-js/src/EnvelopeCreator.ts
@@ -5,7 +5,8 @@ import {
     IPageViewPerformanceTelemetry, CtxTagKeys,
     HttpMethod, IPageViewTelemetryInternal, IWeb,
     Util,
-    IExceptionTelemetry
+    IExceptionTelemetry,
+    IExceptionInternal
 } from '@microsoft/applicationinsights-common';
 import {
     ITelemetryItem, CoreUtils,
@@ -292,12 +293,8 @@ export class ExceptionEnvelopeCreator extends EnvelopeCreator {
                 LoggingSeverity.CRITICAL,
                 _InternalMessageId.TelemetryEnvelopeInvalid, "telemetryItem.baseData cannot be null.");
         }
-        let bd = telemetryItem.baseData as IExceptionTelemetry;
-        let customProperties = bd.properties;
-        let customMeasurements = bd.measurements;
-        let error = bd.error;
-        let severityLevel = bd.severityLevel
-        let baseData = new Exception(logger, error, customProperties, customMeasurements, severityLevel);
+        let bd = telemetryItem.baseData as IExceptionInternal;
+        let baseData = Exception.CreateFromInterface(logger, bd);
         let data = new Data<Exception>(Exception.dataType, baseData);
         return EnvelopeCreator.createEnvelope<Exception>(logger, Exception.envelopeType, telemetryItem, data);
     }

--- a/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
+++ b/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
@@ -8,7 +8,8 @@ import {
     TelemetryItemCreator, Metric, Exception, SeverityLevel, Trace, IDependencyTelemetry,
     IExceptionTelemetry, ITraceTelemetry, IMetricTelemetry, IAutoExceptionTelemetry,
     IPageViewTelemetryInternal, IPageViewTelemetry, IPageViewPerformanceTelemetry, IPageViewPerformanceTelemetryInternal,
-    ConfigurationManager, DateTimeUtils
+    ConfigurationManager, DateTimeUtils,
+    IExceptionInternal
 } from "@microsoft/applicationinsights-common";
 
 import {
@@ -366,17 +367,23 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
     * @param systemProperties
     */
     public sendExceptionInternal(exception: IExceptionTelemetry, customProperties?: { [key: string]: any }, systemProperties?: { [key: string]: any }) {
-        let telemetryItem: ITelemetryItem = TelemetryItemCreator.create<IExceptionTelemetry>(
-            exception,
+        const exceptionPartB = new Exception(
+            this._logger,
+            exception.error,
+            exception.properties,
+            exception.measurements,
+            exception.severityLevel
+        ).toInterface();
+
+        let telemetryItem: ITelemetryItem = TelemetryItemCreator.create<IExceptionInternal>(
+            exceptionPartB,
             Exception.dataType,
             Exception.envelopeType,
             this._logger,
             customProperties,
             systemProperties
         );
-
         this._setTelemetryNameAndIKey(telemetryItem);
-
         this.core.track(telemetryItem);
     }
 

--- a/vNext/shared/AppInsightsCommon/Tests/Exception.tests.ts
+++ b/vNext/shared/AppInsightsCommon/Tests/Exception.tests.ts
@@ -1,0 +1,80 @@
+/// <reference path="./TestFramework/Common.ts" />
+
+import { Exception } from "../src/applicationinsights-common"
+import { DiagnosticLogger } from "@microsoft/applicationinsights-core-js";
+import { IExceptionInternal, IExceptionDetailsInternal, IExceptionStackFrameInternal } from "../src/Interfaces/IExceptionTelemetry";
+import { _ExceptionDetails, _StackFrame } from "../src/Telemetry/Exception";
+
+export class ExceptionTests extends TestClass {
+    logger = new DiagnosticLogger();
+
+    public testInitialize() {
+        this.clock.reset();
+    }
+
+    public testCleanup() {}
+
+    public registerTests() {
+        this.testCase({
+            name: "Exception: Exception can be exported to interface format",
+            test: () => {
+                var exception = new Exception(this.logger, new Error("test error"));
+                Assert.ok(exception, "Exception is created");
+
+                var exceptionInterface: IExceptionInternal = exception.toInterface();
+                Assert.deepEqual(exception.ver, exceptionInterface.ver);
+                Assert.deepEqual(exception.exceptions.map((exception: any) => exception.toInterface()), exceptionInterface.exceptions);
+                Assert.deepEqual(exception.severityLevel, exceptionInterface.severityLevel);
+                Assert.deepEqual(exception.properties, exceptionInterface.properties);
+                Assert.deepEqual(exception.measurements, exceptionInterface.measurements);
+
+                var exceptionConverted = Exception.CreateFromInterface(this.logger, exceptionInterface);
+                Assert.deepEqual(exception, exceptionConverted);
+            }
+        });
+
+        this.testCase({
+            name: "ExceptionDetails: ExceptionDetails can be exported to interface format",
+            test: () => {
+                var exceptionDetails = new _ExceptionDetails(this.logger, new Error("test error"));
+                Assert.ok(exceptionDetails, "ExceptionDetails instance is created");
+
+                var exceptionDetailsInterface: IExceptionDetailsInternal = exceptionDetails.toInterface();
+                Assert.deepEqual(exceptionDetails.id, exceptionDetailsInterface.id);
+                Assert.deepEqual(exceptionDetails.outerId, exceptionDetailsInterface.outerId);
+                Assert.deepEqual(exceptionDetails.typeName, exceptionDetailsInterface.typeName);
+                Assert.deepEqual(exceptionDetails.message, exceptionDetailsInterface.message);
+                Assert.deepEqual(exceptionDetails.hasFullStack, exceptionDetailsInterface.hasFullStack);
+                Assert.deepEqual(exceptionDetails.stack, exceptionDetailsInterface.stack);
+                Assert.deepEqual(exceptionDetails.parsedStack && exceptionDetails.parsedStack.map((frame: _StackFrame) => frame.toInterface()), exceptionDetailsInterface.parsedStack);
+
+                var exceptionDetailsConverted = _ExceptionDetails.CreateFromInterface(this.logger, exceptionDetailsInterface);
+                Assert.deepEqual(exceptionDetails, exceptionDetailsConverted);
+            }
+        });
+
+        this.testCase({
+            name: "StackFrame: StackFrame can be exported to interface format",
+            test: () => {
+                const error = new Error("hello");
+                const stack = error.stack;
+                if (!stack) {
+                    Assert.ok(true);
+                    return;
+                }
+                var stackFrame = new _StackFrame(stack.split("\n")[0], 0);
+                Assert.ok(stackFrame, "StackFrame instance is created");
+
+                var stackFrameInterface: IExceptionStackFrameInternal = stackFrame.toInterface();
+                Assert.deepEqual(stackFrame.level, stackFrameInterface.level);
+                Assert.deepEqual(stackFrame.method, stackFrameInterface.method);
+                Assert.deepEqual(stackFrame.assembly, stackFrameInterface.assembly);
+                Assert.deepEqual(stackFrame.fileName, stackFrameInterface.fileName);
+                Assert.deepEqual(stackFrame.line, stackFrameInterface.line);
+
+                // var stackFrameConverted = _StackFrame.CreateFromInterface(stackFrameInterface);
+                // Assert.deepEqual(stackFrame, stackFrameConverted);
+            }
+        });
+    }
+}

--- a/vNext/shared/AppInsightsCommon/Tests/Selenium/appinsights-common.tests.ts
+++ b/vNext/shared/AppInsightsCommon/Tests/Selenium/appinsights-common.tests.ts
@@ -1,5 +1,7 @@
 import { ApplicationInsightsTests } from '../AppInsightsCommon.tests';
+import { ExceptionTests } from '../Exception.tests';
 
 export function runTests() {
     new ApplicationInsightsTests().registerTests();
+    new ExceptionTests().registerTests();
 }

--- a/vNext/shared/AppInsightsCommon/src/Interfaces/IExceptionTelemetry.ts
+++ b/vNext/shared/AppInsightsCommon/src/Interfaces/IExceptionTelemetry.ts
@@ -80,3 +80,33 @@ export interface IAutoExceptionTelemetry {
      */
     error: Error;
 }
+
+export interface IExceptionInternal {
+    ver: number;
+    id: string;
+    exceptions: IExceptionDetailsInternal[];
+    severityLevel?: SeverityLevel | number;
+    problemGroup: string;
+    isManual: boolean;
+    properties: { [key: string]: any};
+    measurements: { [key: string]: number};
+}
+
+export interface IExceptionDetailsInternal {
+    id: number;
+    outerId: number;
+    typeName: string;
+    message: string;
+    hasFullStack: boolean;
+    stack: string;
+    parsedStack: IExceptionStackFrameInternal[];
+}
+
+export interface IExceptionStackFrameInternal {
+    level: number;
+    method: string;
+    assembly: string;
+    fileName: string;
+    line: number;
+    pos?: number;
+}

--- a/vNext/shared/AppInsightsCommon/src/applicationinsights-common.ts
+++ b/vNext/shared/AppInsightsCommon/src/applicationinsights-common.ts
@@ -20,7 +20,7 @@ export { IEventTelemetry } from './Interfaces/IEventTelemetry';
 export { ITraceTelemetry } from './Interfaces/ITraceTelemetry';
 export { IMetricTelemetry } from './Interfaces/IMetricTelemetry';
 export { IDependencyTelemetry } from './Interfaces/IDependencyTelemetry';
-export { IExceptionTelemetry, IAutoExceptionTelemetry } from './Interfaces/IExceptionTelemetry';
+export { IExceptionTelemetry, IAutoExceptionTelemetry, IExceptionInternal } from './Interfaces/IExceptionTelemetry';
 export { IPageViewTelemetry, IPageViewTelemetryInternal } from './Interfaces/IPageViewTelemetry';
 export { IPageViewPerformanceTelemetry, IPageViewPerformanceTelemetryInternal } from './Interfaces/IPageViewPerformanceTelemetry';
 export { Trace } from './Telemetry/Trace';


### PR DESCRIPTION
Adds `CreateFromInterface` static method and `toInterface` instance method. When converting back and fourth with these, result is equivalent. Interface mode only contains valid Part B.