### PR TITLE
add isCookieUseDisabled to CoreUtils

### DIFF
--- a/vNext/extensions/applicationinsights-properties-js/src/Interfaces/ITelemetryConfig.ts
+++ b/vNext/extensions/applicationinsights-properties-js/src/Interfaces/ITelemetryConfig.ts
@@ -7,7 +7,6 @@ export interface ITelemetryConfig {
     sessionRenewalMs: () => number;
     samplingPercentage: () => number;
     sessionExpirationMs: () => number;
-    isCookieUseDisabled: () => boolean;
     cookieDomain: () => string;
     sdkExtension: () => string;
     isBrowserLinkTrackingEnabled: () => boolean;

--- a/vNext/extensions/applicationinsights-properties-js/src/Interfaces/ITelemetryConfig.ts
+++ b/vNext/extensions/applicationinsights-properties-js/src/Interfaces/ITelemetryConfig.ts
@@ -7,6 +7,7 @@ export interface ITelemetryConfig {
     sessionRenewalMs: () => number;
     samplingPercentage: () => number;
     sessionExpirationMs: () => number;
+    isCookieUseDisabled: () => boolean;
     cookieDomain: () => string;
     sdkExtension: () => string;
     isBrowserLinkTrackingEnabled: () => boolean;

--- a/vNext/extensions/applicationinsights-properties-js/src/PropertiesPlugin.ts
+++ b/vNext/extensions/applicationinsights-properties-js/src/PropertiesPlugin.ts
@@ -9,7 +9,7 @@ import {
 } from '@microsoft/applicationinsights-core-js';
 import { TelemetryContext } from './TelemetryContext';
 import { PageView, ConfigurationManager,
-    IConfig, PropertiesPluginIdentifier, IPropertiesPlugin, Extensions, IDevice, Util } from '@microsoft/applicationinsights-common';
+    IConfig, PropertiesPluginIdentifier, IPropertiesPlugin, Extensions } from '@microsoft/applicationinsights-common';
 import { ITelemetryConfig } from './Interfaces/ITelemetryConfig';
 
 export default class PropertiesPlugin implements ITelemetryPlugin, IPropertiesPlugin {
@@ -29,7 +29,6 @@ export default class PropertiesPlugin implements ITelemetryPlugin, IPropertiesPl
             sessionRenewalMs: () => 30 * 60 * 1000,
             samplingPercentage: () => 100,
             sessionExpirationMs: () => 24 * 60 * 60 * 1000,
-            isCookieUseDisabled: () => false,
             cookieDomain: () => null,
             sdkExtension: () => null,
             isBrowserLinkTrackingEnabled: () => false,
@@ -47,11 +46,6 @@ export default class PropertiesPlugin implements ITelemetryPlugin, IPropertiesPl
         }
 
         this._logger = core.logger;
-
-        if (this._extensionConfig.isCookieUseDisabled()) {
-            Util.disableCookies();
-        }
-
         this.context = new TelemetryContext(core.logger, this._extensionConfig);
     }
 

--- a/vNext/shared/AppInsightsCommon/src/Util.ts
+++ b/vNext/shared/AppInsightsCommon/src/Util.ts
@@ -10,6 +10,7 @@ import { ICorrelationConfig } from "./Interfaces/ICorrelationConfig";
 
 export class Util {
     private static document: any = typeof document !== "undefined" ? document : {};
+    private static _canUseCookies: boolean = undefined;
     private static _canUseLocalStorage: boolean = undefined;
     private static _canUseSessionStorage: boolean = undefined;
     // listing only non-geo specific locations
@@ -294,17 +295,21 @@ export class Util {
      * helper method to tell if document.cookie object is available
      */
     public static canUseCookies(logger: IDiagnosticLogger): any {
-        let res = null;
-        try {
-            res = CoreUtils.canUseCookies();
-        } catch (e) {
-            logger.throwInternal(
-                LoggingSeverity.WARNING,
-                _InternalMessageId.CannotAccessCookie,
-                "Cannot access document.cookie - " + Util.getExceptionName(e),
-                { exception: Util.dump(e) });
+        if (CoreUtils._canUseCookies === undefined) {
+            CoreUtils._canUseCookies = false;
+
+            try {
+                CoreUtils._canUseCookies = Util.document.cookie !== undefined;
+            } catch (e) {
+                logger.throwInternal(
+                    LoggingSeverity.WARNING,
+                    _InternalMessageId.CannotAccessCookie,
+                    "Cannot access document.cookie - " + Util.getExceptionName(e),
+                    { exception: Util.dump(e) });
+            };
         }
-        return res;
+
+        return Util._canUseCookies;
     }
 
     /**

--- a/vNext/shared/AppInsightsCommon/src/Util.ts
+++ b/vNext/shared/AppInsightsCommon/src/Util.ts
@@ -10,10 +10,9 @@ import { ICorrelationConfig } from "./Interfaces/ICorrelationConfig";
 
 export class Util {
     private static document: any = typeof document !== "undefined" ? document : {};
-    private static _canUseCookies: boolean = undefined;
     private static _canUseLocalStorage: boolean = undefined;
     private static _canUseSessionStorage: boolean = undefined;
-    // listing only non-geo specific locations 
+    // listing only non-geo specific locations
     private static _internalEndpoints: string[] = [
         "https://dc.services.visualstudio.com/v2/track",
         "https://breeze.aimon.applicationinsights.io/v2/track",
@@ -70,11 +69,11 @@ export class Util {
         return storage;
     }
 
-    /** 
-     *  Checks if endpoint URL is application insights internal injestion service URL. 
-     * 
-     *  @param endpointUrl Endpoint URL to check. 
-     *  @returns {boolean} True if if endpoint URL is application insights internal injestion service URL. 
+    /**
+     *  Checks if endpoint URL is application insights internal injestion service URL.
+     *
+     *  @param endpointUrl Endpoint URL to check.
+     *  @returns {boolean} True if if endpoint URL is application insights internal injestion service URL.
      */
     public static isInternalApplicationInsightsEndpoint(endpointUrl: string): boolean {
         return Util._internalEndpoints.indexOf(endpointUrl.toLowerCase()) !== -1;
@@ -288,28 +287,24 @@ export class Util {
      * Force the SDK not to store and read any data from cookies
      */
     public static disableCookies() {
-        Util._canUseCookies = false;
+        CoreUtils.disableCookies();
     }
 
     /*
      * helper method to tell if document.cookie object is available
      */
     public static canUseCookies(logger: IDiagnosticLogger): any {
-        if (Util._canUseCookies === undefined) {
-            Util._canUseCookies = false;
-
-            try {
-                Util._canUseCookies = Util.document.cookie !== undefined;
-            } catch (e) {
-                logger.throwInternal(
-                    LoggingSeverity.WARNING,
-                    _InternalMessageId.CannotAccessCookie,
-                    "Cannot access document.cookie - " + Util.getExceptionName(e),
-                    { exception: Util.dump(e) });
-            };
+        let res = null;
+        try {
+            res = CoreUtils.canUseCookies();
+        } catch (e) {
+            logger.throwInternal(
+                LoggingSeverity.WARNING,
+                _InternalMessageId.CannotAccessCookie,
+                "Cannot access document.cookie - " + Util.getExceptionName(e),
+                { exception: Util.dump(e) });
         }
-
-        return Util._canUseCookies;
+        return res;
     }
 
     /**
@@ -484,9 +479,9 @@ export class Util {
         return (days > 0 ? days + "." : "") + hour + ":" + min + ":" + sec + "." + ms;
     }
 
-    /**		
-    * Checks if error has no meaningful data inside. Ususally such errors are received by window.onerror when error		
-    * happens in a script from other domain (cross origin, CORS).		
+    /**
+    * Checks if error has no meaningful data inside. Ususally such errors are received by window.onerror when error
+    * happens in a script from other domain (cross origin, CORS).
     */
     public static isCrossOriginError(message: string, url: string, lineNumber: number, columnNumber: number, error: Error): boolean {
         return (message === "Script error." || message === "Script error") && !error;
@@ -519,7 +514,7 @@ export class Util {
     /**
      * Adds an event handler for the specified event
      * @param eventName {string} - The name of the event
-     * @param callback {any} - The callback function that needs to be executed for the given event 
+     * @param callback {any} - The callback function that needs to be executed for the given event
      * @return {boolean} - true if the handler was successfully added
      */
     public static addEventHandler(eventName: string, callback: any): boolean {

--- a/vNext/shared/AppInsightsCore/src/JavaScriptSDK/AppInsightsCore.ts
+++ b/vNext/shared/AppInsightsCore/src/JavaScriptSDK/AppInsightsCore.ts
@@ -43,7 +43,7 @@ export class AppInsightsCore implements IAppInsightsCore {
 
         this.config = config;
 
-        this._notificationManager = new NotificationManager();        
+        this._notificationManager = new NotificationManager();
         this.config.extensions = CoreUtils.isNullOrUndefined(this.config.extensions) ? [] : this.config.extensions;
 
         // add notification to the extensions in the config so other plugins can access it
@@ -324,6 +324,10 @@ class ChannelController implements ITelemetryPlugin {
     priority: number = ChannelControllerPriority; // in reserved range 100 to 200
 
     initialize(config: IConfiguration, core: IAppInsightsCore, extensions: IPlugin[]) {
+        if ((<any>config).isCookieUseDisabled) {
+            CoreUtils.disableCookies();
+        }
+
         this.channelQueue = new Array<IChannelControls[]>();
         if (config.channels) {
             let invalidChannelIdentifier = undefined;
@@ -354,7 +358,7 @@ class ChannelController implements ITelemetryPlugin {
                 }
             });
         }
-        
+
         let arr = new Array<IChannelControls>();
 
         for (let i = 0; i < extensions.length; i++) {
@@ -379,7 +383,7 @@ class ChannelController implements ITelemetryPlugin {
             }
 
             this.channelQueue.push(arr);
-        }        
+        }
     }
 }
 

--- a/vNext/shared/AppInsightsCore/src/JavaScriptSDK/CoreUtils.ts
+++ b/vNext/shared/AppInsightsCore/src/JavaScriptSDK/CoreUtils.ts
@@ -3,8 +3,7 @@
 "use strict";
 
 export class CoreUtils {
-    private static _canUseCookies: boolean;
-    private static document: any = typeof document !== "undefined" ? document : {};
+    public static _canUseCookies: boolean;
 
     public static isNullOrUndefined(input: any): boolean {
         return input === null || input === undefined;
@@ -18,19 +17,6 @@ export class CoreUtils {
 
     public static disableCookies() {
         CoreUtils._canUseCookies = false;
-    }
-
-    /**
-     * helper method to check for validity of document.cookie object. Wrap with try/catch
-     * @param logger
-     */
-    public static canUseCookies(): any {
-        if (CoreUtils._canUseCookies === undefined) {
-            CoreUtils._canUseCookies = false;
-            CoreUtils._canUseCookies = CoreUtils.document.cookie !== undefined;
-        }
-
-        return CoreUtils._canUseCookies;
     }
 
     public static newGuid():  string  {

--- a/vNext/shared/AppInsightsCore/src/JavaScriptSDK/CoreUtils.ts
+++ b/vNext/shared/AppInsightsCore/src/JavaScriptSDK/CoreUtils.ts
@@ -3,6 +3,9 @@
 "use strict";
 
 export class CoreUtils {
+    private static _canUseCookies: boolean;
+    private static document: any = typeof document !== "undefined" ? document : {};
+
     public static isNullOrUndefined(input: any): boolean {
         return input === null || input === undefined;
     }
@@ -12,6 +15,23 @@ export class CoreUtils {
 * Creates a new GUID.
 * @return {string} A GUID.
 */
+
+    public static disableCookies() {
+        CoreUtils._canUseCookies = false;
+    }
+
+    /**
+     * helper method to check for validity of document.cookie object. Wrap with try/catch
+     * @param logger
+     */
+    public static canUseCookies(): any {
+        if (CoreUtils._canUseCookies === undefined) {
+            CoreUtils._canUseCookies = false;
+            CoreUtils._canUseCookies = CoreUtils.document.cookie !== undefined;
+        }
+
+        return CoreUtils._canUseCookies;
+    }
 
     public static newGuid():  string  {
         return  'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(GuidRegex,  function  (c) {


### PR DESCRIPTION
- Add `isCookieUseDisabled` to properties plugin for cases where analytics plugin is not available.