### PR TITLE
channel: add missing deviceClass lookup to env

### DIFF
--- a/vNext/channels/applicationinsights-channel-js/Tests/Sender.tests.ts
+++ b/vNext/channels/applicationinsights-channel-js/Tests/Sender.tests.ts
@@ -115,12 +115,16 @@ export class SenderTests extends TestClass {
                     time: new Date("2018-06-12").toISOString(),
                     iKey: "iKey",
                     ext: {
-                        "ai.session.id": "d041d2e5fa834b4f9eee41ac163bf402",
-                        "ai.device.id": "browser",
-                        "ai.device.type": "Browser",
-                        "ai.internal.sdkVersion": "javascript:1.0.18",
+                        app: {
+                            sesId: "d041d2e5fa834b4f9eee41ac163bf402"
+                        },
+                        device: {
+                            deviceClass: "Browser",
+                            localId: "browser"
+                        }
+
                     },
-                    tags: [{}],
+                    tags: [{"ai.internal.sdkVersion": "javascript:2.0.0"}],
                     data: {
                         "property1": "val1",
                         "measurement1": 50.0,
@@ -163,10 +167,10 @@ export class SenderTests extends TestClass {
 
                 // Assert tags
                 Assert.ok(appInsightsEnvelope.tags);
-                // Assert.equal("d041d2e5fa834b4f9eee41ac163bf402", appInsightsEnvelope.tags["ai.session.id"]);
-                // Assert.equal("browser", appInsightsEnvelope.tags["ai.device.id"]);
-                // Assert.equal("Browser", appInsightsEnvelope.tags["ai.device.type"]);
-                // Assert.equal("javascript:1.0.18", appInsightsEnvelope.tags["ai.internal.sdkVersion"]);
+                Assert.equal("d041d2e5fa834b4f9eee41ac163bf402", appInsightsEnvelope.tags["ai.session.id"]);
+                Assert.equal("browser", appInsightsEnvelope.tags["ai.device.id"]);
+                Assert.equal("Browser", appInsightsEnvelope.tags["ai.device.type"]);
+                Assert.equal("javascript:2.0.0", appInsightsEnvelope.tags["ai.internal.sdkVersion"]);
 
                 // Assert name
                 Assert.ok(appInsightsEnvelope.name);
@@ -192,7 +196,6 @@ export class SenderTests extends TestClass {
                         "ai.session.id": "d041d2e5fa834b4f9eee41ac163bf402",
                         "ai.device.id": "browser",
                         "ai.device.type": "Browser",
-                        "ai.internal.sdkVersion": "javascript:1.0.18",
                     },
                     tags: [{}],
                     data: {
@@ -236,6 +239,9 @@ export class SenderTests extends TestClass {
                 // Assert ver
                 Assert.ok(baseData.ver);
                 Assert.equal(2, baseData.ver);
+
+                Assert.equal("javascript:2.0.0-rc3", appInsightsEnvelope.tags["ai.internal.sdkVersion"]);
+
             }
         })
 

--- a/vNext/channels/applicationinsights-channel-js/src/EnvelopeCreator.ts
+++ b/vNext/channels/applicationinsights-channel-js/src/EnvelopeCreator.ts
@@ -113,6 +113,10 @@ export abstract class EnvelopeCreator {
                 env.tags[CtxTagKeys.deviceId] = item.ext.device.id || item.ext.device.localId;
             }
 
+            if (item.ext.device.deviceClass) {
+                env.tags[CtxTagKeys.deviceType] = item.ext.device.deviceClass;
+            }
+
             if (item.ext.device.ip) {
                 env.tags[CtxTagKeys.deviceIp] = item.ext.device.ip;
             }

--- a/vNext/extensions/applicationinsights-properties-js/Tests/Selenium/properties.tests.ts
+++ b/vNext/extensions/applicationinsights-properties-js/Tests/Selenium/properties.tests.ts
@@ -25,6 +25,7 @@ export class PropertiesTests extends TestClass {
     public registerTests() {
         this.addConfigTests();
         this.addUserTests();
+        this.addDeviceTests();
     }
 
     private addConfigTests() {
@@ -52,6 +53,26 @@ export class PropertiesTests extends TestClass {
         });
     }
 
+    private addDeviceTests() {
+        this.testCase({
+            name: 'Device: device context adds Browser field to ITelemetryItem',
+            test: () => {
+                this.properties.initialize({
+                    instrumentationKey: 'key',
+                    extensionConfig: {}
+                }, this.core, []);
+
+                // Act
+                const item: ITelemetryItem = {name: 'item'};
+                this.properties.processTelemetry(item);
+
+                // Assert
+                Assert.equal("Browser", item.ext.device.deviceClass);
+                Assert.equal("browser", item.ext.device.localId);
+            }
+        });
+    }
+
     private addUserTests() {
         this.testCase({
             name: 'User: user context initializes from cookie when possible',
@@ -70,7 +91,7 @@ export class PropertiesTests extends TestClass {
             }
         });
 
-        
+
         this.testCase({
             name: "ai_user cookie is set with acq date and year expiration",
             test: () => {


### PR DESCRIPTION
- Add missing `ext.device.deviceClass` lookup in channel: `EnvelopeCreator.ts` to add the item to `tags[CtxTagKeys.deviceType]`
- Re-enables disabled tests for this functionality in channel
- Add tests for adding this to `ITelemetryItem` in properties plugin

Addresses #843 and #835 
