### PR TITLE
common: add parseHost for fallback url parsing

### DIFF
--- a/vNext/shared/AppInsightsCommon/Tests/Selenium/appinsights-common.tests.ts
+++ b/vNext/shared/AppInsightsCommon/Tests/Selenium/appinsights-common.tests.ts
@@ -1,7 +1,9 @@
 import { ApplicationInsightsTests } from '../AppInsightsCommon.tests';
 import { ExceptionTests } from '../Exception.tests';
+import { UtilTests } from '../Util.tests';
 
 export function runTests() {
     new ApplicationInsightsTests().registerTests();
     new ExceptionTests().registerTests();
+    new UtilTests().registerTests();
 }

--- a/vNext/shared/AppInsightsCommon/Tests/Util.tests.ts
+++ b/vNext/shared/AppInsightsCommon/Tests/Util.tests.ts
@@ -1,0 +1,46 @@
+/// <reference path="./TestFramework/Common.ts" />
+
+import { UrlHelper } from "../src/Util";
+
+export class UtilTests extends TestClass {
+
+    public testInitialize() {
+    }
+
+    public testCleanup() {}
+
+    public registerTests() {
+        this.testCase({
+            name: "UrlHelper: parseUrl should contain host field even if document.createElement is not defined",
+            test: () => {
+                var origCreateElement = document.createElement;
+                document.createElement = null;
+
+                let passed;
+                let match;
+                try {
+                    const host = UrlHelper.parseUrl("https://portal.azure.com/some/endpoint").host.toLowerCase();
+                    passed = true;
+                    match = host === "portal.azure.com";
+                } catch (e) {
+                    passed = false;
+                }
+
+                // Need to reset createElement before doing any assertions, else qunit crashes
+                document.createElement = origCreateElement;
+                Assert.ok(passed);
+                Assert.ok(match, "host should be portal.azure.com");
+            }
+        });
+
+        this.testCase({
+            name: "UrlHelper: parseHost should return correct host name",
+            test: () => {
+                Assert.equal("portal.azure.com", UrlHelper.parseHost("https://portal.azure.com/some/endpoint"));
+                Assert.equal("bing.com", UrlHelper.parseHost("http://www.bing.com"));
+                Assert.equal("bing.com", UrlHelper.parseHost("https://www2.bing.com/"));
+                Assert.equal("p.r.e.f.i.x.bing.com", UrlHelper.parseHost("http://wwW2.p.r.e.f.i.x.bing.com/"));
+            }
+        });
+    }
+}

--- a/vNext/shared/AppInsightsCommon/src/Util.ts
+++ b/vNext/shared/AppInsightsCommon/src/Util.ts
@@ -556,7 +556,7 @@ export class UrlHelper {
 
     public static parseUrl(url): HTMLAnchorElement {
         if (!UrlHelper.htmlAnchorElement) {
-            UrlHelper.htmlAnchorElement = !!UrlHelper.document.createElement ? UrlHelper.document.createElement('a') : {};
+            UrlHelper.htmlAnchorElement = !!UrlHelper.document.createElement ? UrlHelper.document.createElement('a') : { host: UrlHelper.parseHost(url) }; // fill host field in the fallback case as that is the only externally required field from this fn
         }
 
         UrlHelper.htmlAnchorElement.href = url;
@@ -589,6 +589,16 @@ export class UrlHelper {
             return method.toUpperCase() + " " + absoluteUrl;
         } else {
             return absoluteUrl;
+        }
+    }
+
+    // Fallback method to grab host from url if document.createElement method is not available
+    public static parseHost(url: string) {
+        var match = url.match(/:\/\/(www[0-9]?\.)?(.[^/:]+)/i);
+        if (match != null && match.length > 2 && typeof match[2] === 'string' && match[2].length > 0) {
+            return match[2];
+        } else {
+            return null;
         }
     }
 }


### PR DESCRIPTION
Add fallback for parseUrl to fill the `host` field when `document.createElement` does not exist