### PR TITLE
save appId response from breeze channel in context

### DIFF
--- a/vNext/AISKU/Tests/applicationinsights.e2e.tests.ts
+++ b/vNext/AISKU/Tests/applicationinsights.e2e.tests.ts
@@ -48,9 +48,10 @@ export class ApplicationInsightsTests extends TestClass {
                 instrumentationKey: ApplicationInsightsTests._instrumentationKey,
                 disableAjaxTracking: false,
                 disableFetchTracking: false,
-                maxBatchInterval: 5000,
+                maxBatchInterval: 2500,
                 disableExceptionTracking: false,
-                namePrefix: this.sessionPrefix
+                namePrefix: this.sessionPrefix,
+                enableCorsCorrelation: true
             };
 
             var init = new ApplicationInsights({
@@ -332,13 +333,17 @@ export class ApplicationInsightsTests extends TestClass {
         if (window && window.fetch) {
             this.testCaseAsync({
                 name: "DependenciesPlugin: auto collection of outgoing fetch requests",
-                stepDelay: 1,
+                stepDelay: 5000,
                 steps: [
                     () => {
                         fetch('https://httpbin.org/status/200', { method: 'GET' });
                         Assert.ok(true, "fetch monitoring is instrumented");
+                    },
+                    () => {
+                        fetch('https://httpbin.org/status/200', { method: 'GET' });
+                        Assert.ok(true, "fetch monitoring is instrumented");
                     }
-                ].concat(this.asserts(1))
+                ].concat(this.asserts(2))
             });
         } else {
             this.testCase({
@@ -521,8 +526,8 @@ export class ApplicationInsightsTests extends TestClass {
             this.successSpy.args.forEach(call => {
                 currentCount += call[1];
             });
-            console.log('curr: ' + currentCount + ' exp: ' + expectedCount);
-            return currentCount === expectedCount;
+            console.log('curr: ' + currentCount + ' exp: ' + expectedCount, ' appId: ' + this._ai.context.appId());
+            return currentCount === expectedCount && !!this._ai.context.appId();
         } else {
             return false;
         }

--- a/vNext/AISKU/package-lock.json
+++ b/vNext/AISKU/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-web",
-    "version": "2.0.0-rc4",
+    "version": "2.0.0-rc5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -56,59 +56,59 @@
             }
         },
         "@microsoft/applicationinsights-analytics-js": {
-            "version": "2.0.0-rc4",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.0.0-rc4.tgz",
+            "version": "2.0.0-rc5",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.0.0-rc5.tgz",
             "integrity": "sha512-sRXAIxISn+aA/wbUoNKQI0HFL0OmRiTTQq9e8XQglGhG2cZ4q2i/HAe+XPzuu4QeTgR7cDWhdi9KNR9ebRlP6w==",
             "requires": {
-                "@microsoft/applicationinsights-common": "2.0.0-rc4",
-                "@microsoft/applicationinsights-core-js": "2.0.0-rc4",
+                "@microsoft/applicationinsights-common": "2.0.0-rc5",
+                "@microsoft/applicationinsights-core-js": "2.0.0-rc5",
                 "tslib": "1.9.3"
             }
         },
         "@microsoft/applicationinsights-channel-js": {
-            "version": "2.0.0-rc4",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.0.0-rc4.tgz",
+            "version": "2.0.0-rc5",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.0.0-rc5.tgz",
             "integrity": "sha512-ggpSf/RgPTQ1AqFl7DjF4YgQiGhCdp+K6zaR9NNsxcZRBM25/Jl1wLh1OLz2Lx5IxDFSkZWvSMsmYzfEAuOkRw==",
             "requires": {
-                "@microsoft/applicationinsights-common": "2.0.0-rc4",
-                "@microsoft/applicationinsights-core-js": "2.0.0-rc4",
+                "@microsoft/applicationinsights-common": "2.0.0-rc5",
+                "@microsoft/applicationinsights-core-js": "2.0.0-rc5",
                 "tslib": "1.9.3"
             }
         },
         "@microsoft/applicationinsights-common": {
-            "version": "2.0.0-rc4",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.0.0-rc4.tgz",
+            "version": "2.0.0-rc5",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.0.0-rc5.tgz",
             "integrity": "sha512-sOV1flyZb5MOSHCiwLtsAwwY2h8/+wT9AbU9IYrlNk5Fm5BzBVkXmH07iSHMMS1vHvZhcvvKosr+boWcehQrPg==",
             "requires": {
-                "@microsoft/applicationinsights-core-js": "2.0.0-rc4",
+                "@microsoft/applicationinsights-core-js": "2.0.0-rc5",
                 "tslib": "1.9.3"
             }
         },
         "@microsoft/applicationinsights-core-js": {
-            "version": "2.0.0-rc4",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.0.0-rc4.tgz",
+            "version": "2.0.0-rc5",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.0.0-rc5.tgz",
             "integrity": "sha512-H2bqUElFSsqFOqbTibCWV2ngtjwjwfLGyPx3TEoON65P8No15oiHfwEEWrgQdn//ZvOrAiQxFQslLSDEJkG+lA==",
             "requires": {
                 "tslib": "1.9.3"
             }
         },
         "@microsoft/applicationinsights-dependencies-js": {
-            "version": "2.0.0-rc4",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.0.0-rc4.tgz",
+            "version": "2.0.0-rc5",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.0.0-rc5.tgz",
             "integrity": "sha512-/606iOTa1YMxBK3dAH4yUy9g3L6ZZCj0nMaIEjkJ6bXtA3zR+VDIZkf+Cy96hdh52Hv821uNDAgP7FuLSiE1VA==",
             "requires": {
-                "@microsoft/applicationinsights-common": "2.0.0-rc4",
-                "@microsoft/applicationinsights-core-js": "2.0.0-rc4",
+                "@microsoft/applicationinsights-common": "2.0.0-rc5",
+                "@microsoft/applicationinsights-core-js": "2.0.0-rc5",
                 "tslib": "1.9.3"
             }
         },
         "@microsoft/applicationinsights-properties-js": {
-            "version": "2.0.0-rc4",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.0.0-rc4.tgz",
+            "version": "2.0.0-rc5",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.0.0-rc5.tgz",
             "integrity": "sha512-BXsrkEkvJuSxkM0xv/MZQhaBd/kJ4XT8jjFc2LxihEvvFLczMKgSc7C6hJu/TWnO7Lo39qLhSq0j/22O5NKdFQ==",
             "requires": {
-                "@microsoft/applicationinsights-common": "2.0.0-rc4",
-                "@microsoft/applicationinsights-core-js": "2.0.0-rc4",
+                "@microsoft/applicationinsights-common": "2.0.0-rc5",
+                "@microsoft/applicationinsights-core-js": "2.0.0-rc5",
                 "tslib": "1.9.3"
             }
         },

--- a/vNext/AISKU/package.json
+++ b/vNext/AISKU/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-web",
-    "version": "2.0.0-rc4",
+    "version": "2.0.0-rc5",
     "description": "Microsoft Application Insights Javascript SDK API 1.0 beta",
     "main": "dist/applicationinsights-web.js",
     "module": "dist-esm/applicationinsights-web.js",
@@ -44,12 +44,12 @@
         "grunt-tslint": "^5.0.2"
     },
     "dependencies": {
-        "@microsoft/applicationinsights-analytics-js": "2.0.0-rc4",
-        "@microsoft/applicationinsights-channel-js": "2.0.0-rc4",
-        "@microsoft/applicationinsights-common": "2.0.0-rc4",
-        "@microsoft/applicationinsights-core-js": "2.0.0-rc4",
-        "@microsoft/applicationinsights-dependencies-js": "2.0.0-rc4",
-        "@microsoft/applicationinsights-properties-js": "2.0.0-rc4"
+        "@microsoft/applicationinsights-analytics-js": "2.0.0-rc5",
+        "@microsoft/applicationinsights-channel-js": "2.0.0-rc5",
+        "@microsoft/applicationinsights-common": "2.0.0-rc5",
+        "@microsoft/applicationinsights-core-js": "2.0.0-rc5",
+        "@microsoft/applicationinsights-dependencies-js": "2.0.0-rc5",
+        "@microsoft/applicationinsights-properties-js": "2.0.0-rc5"
     },
     "peerDependencies": {
         "tslib": "^1.9.3"

--- a/vNext/AISKU/src/Initialization.ts
+++ b/vNext/AISKU/src/Initialization.ts
@@ -52,7 +52,7 @@ export class Initialization implements IApplicationInsights {
         // ensure instrumentationKey is specified
         if (config && !config.instrumentationKey) {
             config = <any>snippet;
-            ApplicationInsights.Version = "2.0.0-rc4"; // Not currently used anywhere
+            ApplicationInsights.Version = "2.0.0-rc5"; // Not currently used anywhere
         }
 
         this.appInsights = new ApplicationInsights();

--- a/vNext/AISKULight/package.json
+++ b/vNext/AISKULight/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-web-basic",
-    "version": "2.0.0-rc4",
+    "version": "2.0.0-rc5",
     "description": "Microsoft Application Insights Javascript SDK core and channel",
     "main": "dist/applicationinsights-web-basic.js",
     "module": "dist-esm/index.js",
@@ -22,9 +22,9 @@
         "rollup": "^0.66.0"
     },
     "dependencies": {
-        "@microsoft/applicationinsights-common": "2.0.0-rc4",
-        "@microsoft/applicationinsights-channel-js": "2.0.0-rc4",
-        "@microsoft/applicationinsights-core-js": "2.0.0-rc4"
+        "@microsoft/applicationinsights-common": "2.0.0-rc5",
+        "@microsoft/applicationinsights-channel-js": "2.0.0-rc5",
+        "@microsoft/applicationinsights-core-js": "2.0.0-rc5"
     },
     "peerDependencies": {
       "tslib": "^1.9.3"

--- a/vNext/channels/applicationinsights-channel-js/Tests/Sender.tests.ts
+++ b/vNext/channels/applicationinsights-channel-js/Tests/Sender.tests.ts
@@ -240,7 +240,7 @@ export class SenderTests extends TestClass {
                 Assert.ok(baseData.ver);
                 Assert.equal(2, baseData.ver);
 
-                Assert.equal("javascript:2.0.0-rc4", appInsightsEnvelope.tags["ai.internal.sdkVersion"]);
+                Assert.equal("javascript:2.0.0-rc5", appInsightsEnvelope.tags["ai.internal.sdkVersion"]);
 
             }
         })

--- a/vNext/channels/applicationinsights-channel-js/package.json
+++ b/vNext/channels/applicationinsights-channel-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-channel-js",
-    "version": "2.0.0-rc4",
+    "version": "2.0.0-rc5",
     "description": "Microsoft Application Insights JavaScript SDK Channel",
     "main": "dist/applicationinsights-channel-js.js",
     "module": "dist-esm/applicationinsights-channel-js.js",
@@ -28,8 +28,8 @@
         "rollup": "^0.66.0"
     },
     "dependencies": {
-        "@microsoft/applicationinsights-core-js": "2.0.0-rc4",
-        "@microsoft/applicationinsights-common": "2.0.0-rc4",
+        "@microsoft/applicationinsights-core-js": "2.0.0-rc5",
+        "@microsoft/applicationinsights-common": "2.0.0-rc5",
         "tslib": "^1.9.3"
     },
     "license": "MIT"

--- a/vNext/channels/applicationinsights-channel-js/src/EnvelopeCreator.ts
+++ b/vNext/channels/applicationinsights-channel-js/src/EnvelopeCreator.ts
@@ -18,7 +18,7 @@ const baseType: string = "baseType";
 const baseData: string = "baseData";
 
 export abstract class EnvelopeCreator {
-    public static Version = "2.0.0-rc4";
+    public static Version = "2.0.0-rc5";
     protected _logger: IDiagnosticLogger;
 
     abstract Create(logger: IDiagnosticLogger, telemetryItem: ITelemetryItem): IEnvelope;

--- a/vNext/channels/applicationinsights-channel-js/src/Sender.ts
+++ b/vNext/channels/applicationinsights-channel-js/src/Sender.ts
@@ -20,7 +20,8 @@ import {
     PageViewPerformance, RemoteDependencyData,
     IChannelControlsAI,
     ConfigurationManager, IConfig,
-    ProcessLegacy
+    ProcessLegacy,
+    BreezeChannelIdentifier
 } from '@microsoft/applicationinsights-common';
 import {
     ITelemetryPlugin, ITelemetryItem, IConfiguration,
@@ -37,7 +38,7 @@ declare var XDomainRequest: {
 export class Sender implements IChannelControlsAI {
     public priority: number = 1001;
 
-    public identifier: string;
+    public identifier: string = BreezeChannelIdentifier;
 
     public pause(): void {
         throw new Error("Method not implemented.");
@@ -111,10 +112,6 @@ export class Sender implements IChannelControlsAI {
 
     private _logger: IDiagnosticLogger;
     private _serializer: Serializer;
-
-    constructor() {
-        this.identifier = "AppInsightsChannelPlugin"
-    }
 
     public initialize(config: IConfiguration & IConfig, core: IAppInsightsCore, extensions: IPlugin[]) :void {
         this._logger = core.logger;

--- a/vNext/common/config/rush/npm-shrinkwrap.json
+++ b/vNext/common/config/rush/npm-shrinkwrap.json
@@ -8,9 +8,9 @@
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz"
     },
     "@babel/core": {
-      "version": "7.4.3",
+      "version": "7.4.4",
       "from": "@babel/core@^7.1.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.4.tgz",
       "dependencies": {
         "debug": {
           "version": "4.1.1",
@@ -25,9 +25,9 @@
       }
     },
     "@babel/generator": {
-      "version": "7.4.0",
-      "from": "@babel/generator@^7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz"
+      "version": "7.4.4",
+      "from": "@babel/generator@^7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz"
     },
     "@babel/helper-function-name": {
       "version": "7.1.0",
@@ -45,14 +45,14 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz"
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.4.0",
-      "from": "@babel/helper-split-export-declaration@^7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz"
+      "version": "7.4.4",
+      "from": "@babel/helper-split-export-declaration@^7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz"
     },
     "@babel/helpers": {
-      "version": "7.4.3",
-      "from": "@babel/helpers@^7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.3.tgz"
+      "version": "7.4.4",
+      "from": "@babel/helpers@^7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz"
     },
     "@babel/highlight": {
       "version": "7.0.0",
@@ -77,9 +77,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.4.3",
-      "from": "@babel/parser@^7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz"
+      "version": "7.4.4",
+      "from": "@babel/parser@^7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.4.tgz"
     },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.2.0",
@@ -87,19 +87,19 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz"
     },
     "@babel/runtime": {
-      "version": "7.4.3",
+      "version": "7.4.4",
       "from": "@babel/runtime@^7.1.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz"
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz"
     },
     "@babel/template": {
-      "version": "7.4.0",
-      "from": "@babel/template@^7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz"
+      "version": "7.4.4",
+      "from": "@babel/template@^7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz"
     },
     "@babel/traverse": {
-      "version": "7.4.3",
-      "from": "@babel/traverse@^7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
+      "version": "7.4.4",
+      "from": "@babel/traverse@^7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.4.tgz",
       "dependencies": {
         "debug": {
           "version": "4.1.1",
@@ -114,9 +114,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.4.0",
-      "from": "@babel/types@^7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz"
+      "version": "7.4.4",
+      "from": "@babel/types@^7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz"
     },
     "@cnakazawa/watch": {
       "version": "1.0.3",
@@ -146,9 +146,9 @@
       }
     },
     "@jest/core": {
-      "version": "24.7.1",
-      "from": "@jest/core@^24.7.1",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-24.7.1.tgz",
+      "version": "24.8.0",
+      "from": "@jest/core@^24.8.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-24.8.0.tgz",
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
@@ -166,9 +166,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.4",
           "from": "glob@^7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz"
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz"
         },
         "rimraf": {
           "version": "2.6.3",
@@ -188,19 +188,19 @@
       }
     },
     "@jest/environment": {
-      "version": "24.7.1",
-      "from": "@jest/environment@^24.7.1",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.7.1.tgz"
+      "version": "24.8.0",
+      "from": "@jest/environment@^24.8.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.8.0.tgz"
     },
     "@jest/fake-timers": {
-      "version": "24.7.1",
-      "from": "@jest/fake-timers@^24.7.1",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.7.1.tgz"
+      "version": "24.8.0",
+      "from": "@jest/fake-timers@^24.8.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.8.0.tgz"
     },
     "@jest/reporters": {
-      "version": "24.7.1",
-      "from": "@jest/reporters@^24.7.1",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.7.1.tgz",
+      "version": "24.8.0",
+      "from": "@jest/reporters@^24.8.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.8.0.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
@@ -213,9 +213,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.4",
           "from": "glob@^7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz"
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz"
         },
         "source-map": {
           "version": "0.6.1",
@@ -242,19 +242,19 @@
       }
     },
     "@jest/test-result": {
-      "version": "24.7.1",
-      "from": "@jest/test-result@^24.7.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.7.1.tgz"
+      "version": "24.8.0",
+      "from": "@jest/test-result@^24.8.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.8.0.tgz"
     },
     "@jest/test-sequencer": {
-      "version": "24.7.1",
-      "from": "@jest/test-sequencer@^24.7.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.7.1.tgz"
+      "version": "24.8.0",
+      "from": "@jest/test-sequencer@^24.8.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.8.0.tgz"
     },
     "@jest/transform": {
-      "version": "24.7.1",
-      "from": "@jest/transform@^24.7.1",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.7.1.tgz",
+      "version": "24.8.0",
+      "from": "@jest/transform@^24.8.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.8.0.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
@@ -279,9 +279,9 @@
       }
     },
     "@jest/types": {
-      "version": "24.7.0",
-      "from": "@jest/types@^24.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz"
+      "version": "24.8.0",
+      "from": "@jest/types@^24.8.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.8.0.tgz"
     },
     "@rush-temp/applicationinsights-analytics-js": {
       "version": "0.0.0",
@@ -369,14 +369,24 @@
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.2.tgz"
     },
     "@types/istanbul-lib-coverage": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "from": "@types/istanbul-lib-coverage@^2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz"
+    },
+    "@types/istanbul-lib-report": {
+      "version": "1.1.1",
+      "from": "@types/istanbul-lib-report@*",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz"
+    },
+    "@types/istanbul-reports": {
+      "version": "1.1.1",
+      "from": "@types/istanbul-reports@^1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz"
     },
     "@types/jest": {
-      "version": "24.0.11",
+      "version": "24.0.12",
       "from": "@types/jest@^24.0.11",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.11.tgz"
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.12.tgz"
     },
     "@types/jest-diff": {
       "version": "20.0.1",
@@ -442,7 +452,7 @@
     },
     "airbnb-prop-types": {
       "version": "2.13.2",
-      "from": "airbnb-prop-types@^2.12.0",
+      "from": "airbnb-prop-types@^2.13.2",
       "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.13.2.tgz"
     },
     "ajv": {
@@ -476,11 +486,6 @@
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz"
         }
       }
-    },
-    "append-transform": {
-      "version": "1.0.0",
-      "from": "append-transform@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz"
     },
     "argparse": {
       "version": "1.0.10",
@@ -598,9 +603,9 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz"
     },
     "babel-jest": {
-      "version": "24.7.1",
-      "from": "babel-jest@^24.7.1",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.7.1.tgz",
+      "version": "24.8.0",
+      "from": "babel-jest@^24.8.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.8.0.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
@@ -620,9 +625,9 @@
       }
     },
     "babel-plugin-istanbul": {
-      "version": "5.1.3",
+      "version": "5.1.4",
       "from": "babel-plugin-istanbul@^5.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.4.tgz",
       "dependencies": {
         "find-up": {
           "version": "3.0.0",
@@ -881,11 +886,6 @@
       "from": "commander@>=2.11.0 <2.12.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
     },
-    "compare-versions": {
-      "version": "3.4.0",
-      "from": "compare-versions@^3.2.1",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.4.0.tgz"
-    },
     "component-emitter": {
       "version": "1.3.0",
       "from": "component-emitter@^1.2.1",
@@ -992,18 +992,6 @@
       "version": "0.1.3",
       "from": "deep-is@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
-    },
-    "default-require-extensions": {
-      "version": "2.0.0",
-      "from": "default-require-extensions@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
-      "dependencies": {
-        "strip-bom": {
-          "version": "3.0.0",
-          "from": "strip-bom@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
-        }
-      }
     },
     "define-properties": {
       "version": "1.1.3",
@@ -1150,9 +1138,9 @@
       "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.12.1.tgz"
     },
     "enzyme-adapter-utils": {
-      "version": "1.11.0",
+      "version": "1.12.0",
       "from": "enzyme-adapter-utils@^1.11.0",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.11.0.tgz"
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.12.0.tgz"
     },
     "error-ex": {
       "version": "1.3.2",
@@ -1259,9 +1247,9 @@
       }
     },
     "expect": {
-      "version": "24.7.1",
-      "from": "expect@^24.7.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-24.7.1.tgz",
+      "version": "24.8.0",
+      "from": "expect@^24.8.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-24.8.0.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
@@ -1358,11 +1346,6 @@
       "version": "1.7.0",
       "from": "figures@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz"
-    },
-    "fileset": {
-      "version": "2.0.3",
-      "from": "fileset@>=2.0.3 <3.0.0",
-      "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz"
     },
     "fill-range": {
       "version": "4.0.0",
@@ -1491,9 +1474,9 @@
       }
     },
     "globals": {
-      "version": "11.11.0",
+      "version": "11.12.0",
       "from": "globals@^11.1.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz"
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz"
     },
     "globby": {
       "version": "6.1.0",
@@ -1533,9 +1516,9 @@
       "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-1.1.0.tgz",
       "dependencies": {
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.4",
           "from": "glob@^7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz"
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz"
         },
         "rimraf": {
           "version": "2.6.3",
@@ -1594,9 +1577,9 @@
       "resolved": "https://registry.npmjs.org/grunt-lib-phantomjs/-/grunt-lib-phantomjs-1.1.0.tgz",
       "dependencies": {
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.4",
           "from": "glob@^7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz"
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz"
         },
         "rimraf": {
           "version": "2.6.3",
@@ -1634,7 +1617,7 @@
     },
     "handlebars": {
       "version": "4.1.2",
-      "from": "handlebars@^4.1.0",
+      "from": "handlebars@^4.1.2",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
       "dependencies": {
         "source-map": {
@@ -1734,9 +1717,16 @@
       }
     },
     "http-errors": {
-      "version": "1.6.3",
-      "from": "http-errors@~1.6.2",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz"
+      "version": "1.7.2",
+      "from": "http-errors@~1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "dependencies": {
+        "statuses": {
+          "version": "1.5.0",
+          "from": "statuses@>= 1.5.0 < 2",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz"
+        }
+      }
     },
     "http-signature": {
       "version": "1.2.0",
@@ -2006,42 +1996,15 @@
       "from": "isstream@>=0.1.2 <0.2.0",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
     },
-    "istanbul-api": {
-      "version": "2.1.5",
-      "from": "istanbul-api@^2.1.1",
-      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.5.tgz",
-      "dependencies": {
-        "async": {
-          "version": "2.6.2",
-          "from": "async@^2.6.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz"
-        },
-        "esprima": {
-          "version": "4.0.1",
-          "from": "esprima@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz"
-        },
-        "js-yaml": {
-          "version": "3.13.1",
-          "from": "js-yaml@^3.13.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz"
-        }
-      }
-    },
     "istanbul-lib-coverage": {
-      "version": "2.0.4",
+      "version": "2.0.5",
       "from": "istanbul-lib-coverage@^2.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz"
-    },
-    "istanbul-lib-hook": {
-      "version": "2.0.6",
-      "from": "istanbul-lib-hook@^2.0.6",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.6.tgz"
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz"
     },
     "istanbul-lib-instrument": {
-      "version": "3.2.0",
+      "version": "3.3.0",
       "from": "istanbul-lib-instrument@^3.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
       "dependencies": {
         "semver": {
           "version": "6.0.0",
@@ -2051,21 +2014,21 @@
       }
     },
     "istanbul-lib-report": {
-      "version": "2.0.7",
-      "from": "istanbul-lib-report@^2.0.7",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.7.tgz",
+      "version": "2.0.8",
+      "from": "istanbul-lib-report@^2.0.4",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
       "dependencies": {
         "supports-color": {
           "version": "6.1.0",
-          "from": "supports-color@^6.0.0",
+          "from": "supports-color@^6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz"
         }
       }
     },
     "istanbul-lib-source-maps": {
-      "version": "3.0.5",
+      "version": "3.0.6",
       "from": "istanbul-lib-source-maps@^3.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
       "dependencies": {
         "debug": {
           "version": "4.1.1",
@@ -2073,9 +2036,9 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz"
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.4",
           "from": "glob@^7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz"
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz"
         },
         "ms": {
           "version": "2.1.1",
@@ -2084,7 +2047,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "from": "rimraf@^2.6.2",
+          "from": "rimraf@^2.6.3",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz"
         },
         "source-map": {
@@ -2095,14 +2058,14 @@
       }
     },
     "istanbul-reports": {
-      "version": "2.2.3",
-      "from": "istanbul-reports@^2.2.3",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.3.tgz"
+      "version": "2.2.4",
+      "from": "istanbul-reports@^2.1.1",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.4.tgz"
     },
     "jest": {
-      "version": "24.7.1",
+      "version": "24.8.0",
       "from": "jest@^24.7.1",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-24.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-24.8.0.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
@@ -2115,9 +2078,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
         },
         "jest-cli": {
-          "version": "24.7.1",
-          "from": "jest-cli@^24.7.1",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.7.1.tgz"
+          "version": "24.8.0",
+          "from": "jest-cli@^24.8.0",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.8.0.tgz"
         },
         "supports-color": {
           "version": "5.5.0",
@@ -2127,14 +2090,14 @@
       }
     },
     "jest-changed-files": {
-      "version": "24.7.0",
-      "from": "jest-changed-files@^24.7.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.7.0.tgz"
+      "version": "24.8.0",
+      "from": "jest-changed-files@^24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.8.0.tgz"
     },
     "jest-config": {
-      "version": "24.7.1",
-      "from": "jest-config@^24.7.1",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.7.1.tgz",
+      "version": "24.8.0",
+      "from": "jest-config@^24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.8.0.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
@@ -2147,9 +2110,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.4",
           "from": "glob@^7.1.1",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz"
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz"
         },
         "supports-color": {
           "version": "5.5.0",
@@ -2159,9 +2122,9 @@
       }
     },
     "jest-diff": {
-      "version": "24.7.0",
-      "from": "jest-diff@^24.7.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.7.0.tgz",
+      "version": "24.8.0",
+      "from": "jest-diff@^24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.8.0.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
@@ -2186,9 +2149,9 @@
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.3.0.tgz"
     },
     "jest-each": {
-      "version": "24.7.1",
-      "from": "jest-each@^24.7.1",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.7.1.tgz",
+      "version": "24.8.0",
+      "from": "jest-each@^24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.8.0.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
@@ -2208,29 +2171,29 @@
       }
     },
     "jest-environment-jsdom": {
-      "version": "24.7.1",
-      "from": "jest-environment-jsdom@^24.7.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.7.1.tgz"
+      "version": "24.8.0",
+      "from": "jest-environment-jsdom@^24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.8.0.tgz"
     },
     "jest-environment-node": {
-      "version": "24.7.1",
-      "from": "jest-environment-node@^24.7.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.7.1.tgz"
+      "version": "24.8.0",
+      "from": "jest-environment-node@^24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.8.0.tgz"
     },
     "jest-get-type": {
-      "version": "24.3.0",
-      "from": "jest-get-type@^24.3.0",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.3.0.tgz"
+      "version": "24.8.0",
+      "from": "jest-get-type@^24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.8.0.tgz"
     },
     "jest-haste-map": {
-      "version": "24.7.1",
-      "from": "jest-haste-map@^24.7.1",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.7.1.tgz"
+      "version": "24.8.0",
+      "from": "jest-haste-map@^24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.0.tgz"
     },
     "jest-jasmine2": {
-      "version": "24.7.1",
-      "from": "jest-jasmine2@^24.7.1",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.7.1.tgz",
+      "version": "24.8.0",
+      "from": "jest-jasmine2@^24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.8.0.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
@@ -2250,14 +2213,14 @@
       }
     },
     "jest-leak-detector": {
-      "version": "24.7.0",
-      "from": "jest-leak-detector@^24.7.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.7.0.tgz"
+      "version": "24.8.0",
+      "from": "jest-leak-detector@^24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.8.0.tgz"
     },
     "jest-matcher-utils": {
-      "version": "24.7.0",
-      "from": "jest-matcher-utils@^24.7.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.7.0.tgz",
+      "version": "24.8.0",
+      "from": "jest-matcher-utils@^24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
@@ -2277,9 +2240,9 @@
       }
     },
     "jest-message-util": {
-      "version": "24.7.1",
-      "from": "jest-message-util@^24.7.1",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.7.1.tgz",
+      "version": "24.8.0",
+      "from": "jest-message-util@^24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.8.0.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
@@ -2299,9 +2262,9 @@
       }
     },
     "jest-mock": {
-      "version": "24.7.0",
-      "from": "jest-mock@^24.7.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.7.0.tgz"
+      "version": "24.8.0",
+      "from": "jest-mock@^24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.8.0.tgz"
     },
     "jest-pnp-resolver": {
       "version": "1.2.1",
@@ -2314,9 +2277,9 @@
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.3.0.tgz"
     },
     "jest-resolve": {
-      "version": "24.7.1",
-      "from": "jest-resolve@^24.7.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.7.1.tgz",
+      "version": "24.8.0",
+      "from": "jest-resolve@^24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.8.0.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
@@ -2336,14 +2299,14 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "24.7.1",
-      "from": "jest-resolve-dependencies@^24.7.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.7.1.tgz"
+      "version": "24.8.0",
+      "from": "jest-resolve-dependencies@^24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.8.0.tgz"
     },
     "jest-runner": {
-      "version": "24.7.1",
-      "from": "jest-runner@^24.7.1",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.7.1.tgz",
+      "version": "24.8.0",
+      "from": "jest-runner@^24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.8.0.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
@@ -2363,9 +2326,9 @@
       }
     },
     "jest-runtime": {
-      "version": "24.7.1",
-      "from": "jest-runtime@^24.7.1",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.7.1.tgz",
+      "version": "24.8.0",
+      "from": "jest-runtime@^24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.8.0.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
@@ -2378,9 +2341,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.4",
           "from": "glob@^7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz"
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz"
         },
         "strip-bom": {
           "version": "3.0.0",
@@ -2400,9 +2363,9 @@
       "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.4.0.tgz"
     },
     "jest-snapshot": {
-      "version": "24.7.1",
-      "from": "jest-snapshot@^24.7.1",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.7.1.tgz",
+      "version": "24.8.0",
+      "from": "jest-snapshot@^24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.8.0.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
@@ -2422,9 +2385,9 @@
       }
     },
     "jest-util": {
-      "version": "24.7.1",
-      "from": "jest-util@^24.7.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.7.1.tgz",
+      "version": "24.8.0",
+      "from": "jest-util@^24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.8.0.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
@@ -2449,9 +2412,9 @@
       }
     },
     "jest-validate": {
-      "version": "24.7.0",
-      "from": "jest-validate@^24.7.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.7.0.tgz",
+      "version": "24.8.0",
+      "from": "jest-validate@^24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.8.0.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
@@ -2476,9 +2439,9 @@
       }
     },
     "jest-watcher": {
-      "version": "24.7.1",
-      "from": "jest-watcher@^24.7.1",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.7.1.tgz",
+      "version": "24.8.0",
+      "from": "jest-watcher@^24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.8.0.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
@@ -2603,7 +2566,7 @@
     },
     "lcid": {
       "version": "2.0.0",
-      "from": "lcid@>=2.0.0 <3.0.0",
+      "from": "lcid@^2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz"
     },
     "left-pad": {
@@ -2758,9 +2721,9 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz"
     },
     "mime": {
-      "version": "1.4.1",
-      "from": "mime@1.4.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz"
+      "version": "1.6.0",
+      "from": "mime@1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz"
     },
     "mime-db": {
       "version": "1.40.0",
@@ -2911,9 +2874,9 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
     },
     "nwsapi": {
-      "version": "2.1.3",
+      "version": "2.1.4",
       "from": "nwsapi@^2.0.7",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.3.tgz"
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz"
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -3209,9 +3172,9 @@
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz"
     },
     "pretty-format": {
-      "version": "24.7.0",
-      "from": "pretty-format@^24.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.7.0.tgz",
+      "version": "24.8.0",
+      "from": "pretty-format@^24.8.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
@@ -3471,9 +3434,9 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
         },
         "uglify-js": {
-          "version": "3.5.8",
+          "version": "3.5.11",
           "from": "uglify-js@^3.4.9",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.8.tgz"
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.11.tgz"
         }
       }
     },
@@ -3533,9 +3496,21 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz"
     },
     "send": {
-      "version": "0.16.2",
-      "from": "send@0.16.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz"
+      "version": "0.17.0",
+      "from": "send@0.17.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.0.tgz",
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "from": "ms@2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz"
+        },
+        "statuses": {
+          "version": "1.5.0",
+          "from": "statuses@~1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz"
+        }
+      }
     },
     "serialize-javascript": {
       "version": "1.7.0",
@@ -3543,9 +3518,9 @@
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz"
     },
     "serve-static": {
-      "version": "1.13.2",
+      "version": "1.14.0",
       "from": "serve-static@^1.13.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz"
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.0.tgz"
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -3565,9 +3540,9 @@
       }
     },
     "setprototypeof": {
-      "version": "1.1.0",
-      "from": "setprototypeof@1.1.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz"
+      "version": "1.1.1",
+      "from": "setprototypeof@1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz"
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -3596,7 +3571,7 @@
     },
     "slash": {
       "version": "2.0.0",
-      "from": "slash@>=2.0.0 <3.0.0",
+      "from": "slash@^2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz"
     },
     "snapdragon": {
@@ -3858,9 +3833,9 @@
       "resolved": "https://registry.npmjs.org/temporary/-/temporary-0.0.8.tgz"
     },
     "test-exclude": {
-      "version": "5.2.2",
-      "from": "test-exclude@^5.2.2",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.2.tgz",
+      "version": "5.2.3",
+      "from": "test-exclude@^5.2.3",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
       "dependencies": {
         "find-up": {
           "version": "3.0.0",
@@ -3868,9 +3843,9 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz"
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.4",
           "from": "glob@^7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz"
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz"
         },
         "load-json-file": {
           "version": "4.0.0",
@@ -3961,6 +3936,11 @@
       "from": "to-regex-range@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz"
     },
+    "toidentifier": {
+      "version": "1.0.0",
+      "from": "toidentifier@1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz"
+    },
     "tough-cookie": {
       "version": "2.4.3",
       "from": "tough-cookie@~2.4.3",
@@ -4041,9 +4021,9 @@
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz"
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.4",
           "from": "glob@^7.1.1",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz"
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz"
         },
         "js-yaml": {
           "version": "3.13.1",

--- a/vNext/extensions/applicationinsights-analytics-js/package.json
+++ b/vNext/extensions/applicationinsights-analytics-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-analytics-js",
-    "version": "2.0.0-rc4",
+    "version": "2.0.0-rc5",
     "description": "Microsoft Application Insights Javascript SDK apis",
     "main": "dist/applicationinsights-analytics-js.js",
     "module": "dist-esm/applicationinsights-analytics-js.js",
@@ -28,8 +28,8 @@
         "rollup": "^0.66.0"
     },
     "dependencies": {
-        "@microsoft/applicationinsights-core-js": "2.0.0-rc4",
-        "@microsoft/applicationinsights-common": "2.0.0-rc4",
+        "@microsoft/applicationinsights-core-js": "2.0.0-rc5",
+        "@microsoft/applicationinsights-common": "2.0.0-rc5",
         "tslib": "^1.9.3"
     },
     "license": "MIT"

--- a/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
+++ b/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
@@ -27,7 +27,7 @@ import { ITelemetryConfig } from "../JavaScriptSDK.Interfaces/ITelemetryConfig";
 const durationProperty: string = "duration";
 
 export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IAppInsightsInternal {
-    public static Version = "2.0.0-rc4"; // Not currently used anywhere
+    public static Version = "2.0.0-rc5"; // Not currently used anywhere
     public initialize: (config: IConfiguration, core: IAppInsightsCore, extensions: IPlugin[]) => void;
     public identifier: string = "ApplicationInsightsAnalytics"; // do not change name or priority
     public priority: number = 160;// take from reserved priority range 100- 200

--- a/vNext/extensions/applicationinsights-dependencies-js/package.json
+++ b/vNext/extensions/applicationinsights-dependencies-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-dependencies-js",
-    "version": "2.0.0-rc4",
+    "version": "2.0.0-rc5",
     "description": "Microsoft Application Insights XHR dependencies plugin",
     "main": "dist/applicationinsights-dependencies-js.js",
     "module": "dist-esm/applicationinsights-dependencies-js.js",
@@ -28,8 +28,8 @@
         "rollup": "^0.66.0"
     },
     "dependencies": {
-        "@microsoft/applicationinsights-core-js": "2.0.0-rc4",
-        "@microsoft/applicationinsights-common": "2.0.0-rc4",
+        "@microsoft/applicationinsights-core-js": "2.0.0-rc5",
+        "@microsoft/applicationinsights-common": "2.0.0-rc5",
         "tslib": "^1.9.3"
     },
     "license": "MIT"

--- a/vNext/extensions/applicationinsights-dependencies-js/src/ajax.ts
+++ b/vNext/extensions/applicationinsights-dependencies-js/src/ajax.ts
@@ -430,7 +430,7 @@ export class AjaxMonitor implements ITelemetryPlugin, IDependenciesPlugin, IInst
                 // not using original request headers will result in them being lost
                 init.headers = new Headers(init.headers || (input instanceof Request ? (input.headers || {}) : {}));
                 init.headers.set(RequestHeaders.requestIdHeader, ajaxData.id);
-                let appId: string = this._config.appId;
+                let appId: string = this._config.appId || this._context.appId();
                 if (appId) {
                     init.headers.set(RequestHeaders.requestContextHeader, RequestHeaders.requestContextAppIdFormat + appId);
                 }
@@ -442,7 +442,7 @@ export class AjaxMonitor implements ITelemetryPlugin, IDependenciesPlugin, IInst
             if (this.currentWindowHost && CorrelationIdHelper.canIncludeCorrelationHeader(this._config, xhr.ajaxData.getAbsoluteUrl(),
                 this.currentWindowHost)) {
                 xhr.setRequestHeader(RequestHeaders.requestIdHeader, xhr.ajaxData.id);
-                var appId = this._config.appId; // Todo: also, get appId from channel as breeze returns it
+                var appId = this._config.appId || this._context.appId();
                 if (appId) {
                     xhr.setRequestHeader(RequestHeaders.requestContextHeader, RequestHeaders.requestContextAppIdFormat + appId);
                 }

--- a/vNext/extensions/applicationinsights-properties-js/package.json
+++ b/vNext/extensions/applicationinsights-properties-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-properties-js",
-    "version": "2.0.0-rc4",
+    "version": "2.0.0-rc5",
     "description": "Microsoft Application Insights properties (Part A) plugin",
     "main": "dist/applicationinsights-properties-js.js",
     "module": "dist-esm/applicationinsights-properties-js.js",
@@ -28,8 +28,8 @@
         "rollup": "^0.66.0"
     },
     "dependencies": {
-        "@microsoft/applicationinsights-core-js": "2.0.0-rc4",
-        "@microsoft/applicationinsights-common": "2.0.0-rc4",
+        "@microsoft/applicationinsights-core-js": "2.0.0-rc5",
+        "@microsoft/applicationinsights-common": "2.0.0-rc5",
         "tslib": "^1.9.3"
     },
     "license": "MIT"

--- a/vNext/extensions/applicationinsights-properties-js/src/Context/Internal.ts
+++ b/vNext/extensions/applicationinsights-properties-js/src/Context/Internal.ts
@@ -4,7 +4,7 @@
 import { IInternal } from '@microsoft/applicationinsights-common';
 import { ITelemetryConfig } from '../Interfaces/ITelemetryConfig';
 
-const Version = "2.0.0-rc4";
+const Version = "2.0.0-rc5";
 
 export class Internal implements IInternal {
 

--- a/vNext/extensions/applicationinsights-properties-js/src/PropertiesPlugin.ts
+++ b/vNext/extensions/applicationinsights-properties-js/src/PropertiesPlugin.ts
@@ -9,12 +9,13 @@ import {
 } from '@microsoft/applicationinsights-core-js';
 import { TelemetryContext } from './TelemetryContext';
 import { PageView, ConfigurationManager,
-    IConfig, PropertiesPluginIdentifier, IPropertiesPlugin, Extensions } from '@microsoft/applicationinsights-common';
+    IConfig, BreezeChannelIdentifier, PropertiesPluginIdentifier, IPropertiesPlugin, Extensions, Util } from '@microsoft/applicationinsights-common';
 import { ITelemetryConfig } from './Interfaces/ITelemetryConfig';
 
 export default class PropertiesPlugin implements ITelemetryPlugin, IPropertiesPlugin {
     public context: TelemetryContext;
     private _logger: IDiagnosticLogger;
+    private _breezeChannel: IPlugin; // optional. If exists, grab appId from it
 
     public priority = 170;
     public identifier = PropertiesPluginIdentifier;
@@ -47,6 +48,8 @@ export default class PropertiesPlugin implements ITelemetryPlugin, IPropertiesPl
 
         this._logger = core.logger;
         this.context = new TelemetryContext(core.logger, this._extensionConfig);
+        this._breezeChannel = Util.getExtension(extensions, BreezeChannelIdentifier);
+        this.context.appId = () => this._breezeChannel ? this._breezeChannel["_appId"] : null;
     }
 
     /**

--- a/vNext/extensions/applicationinsights-properties-js/src/TelemetryContext.ts
+++ b/vNext/extensions/applicationinsights-properties-js/src/TelemetryContext.ts
@@ -14,7 +14,7 @@ import { User } from './Context/User';
 import { Location } from './Context/Location';
 import { ITelemetryConfig } from './Interfaces/ITelemetryConfig';
 import { TelemetryTrace } from './Context/TelemetryTrace';
- 
+
 export class TelemetryContext implements ITelemetryContext {
 
     public application: Application; // The object describing a component tracked by this object - legacy
@@ -28,6 +28,7 @@ export class TelemetryContext implements ITelemetryContext {
     public sample: Sample;
     public os: IOperatingSystem;
     public web: IWeb;
+    public appId: () => string;
 
     constructor(logger: IDiagnosticLogger, defaultConfig: ITelemetryConfig) {
         if (typeof window !== 'undefined') {
@@ -41,8 +42,9 @@ export class TelemetryContext implements ITelemetryContext {
             this.session = new Session();
             this.sample = new Sample(defaultConfig.samplingPercentage(), logger);
         }
+        this.appId = () => null;
     }
-    
+
     public applySessionContext(event: ITelemetryItem) {
         let sessionContext = this.session || this.sessionManager.automaticSession;
         if (sessionContext) {
@@ -52,7 +54,7 @@ export class TelemetryContext implements ITelemetryContext {
         }
 
         if (this.session) {
-            // If customer set session info, apply his context; otherwise apply context automatically generated 
+            // If customer set session info, apply his context; otherwise apply context automatically generated
             if (typeof this.session.id === "string") {
                 event.ext.app.sesId = this.session.id;
             } else {
@@ -82,7 +84,6 @@ export class TelemetryContext implements ITelemetryContext {
     public applyDeviceContext(event: ITelemetryItem) {
 
         if (this.device) {
-
             if (typeof this.device.id === "string") {
                 event.ext.device.localId = this.device.id;
             }
@@ -111,7 +112,7 @@ export class TelemetryContext implements ITelemetryContext {
             } else {
                 // store the version provided by core
                 if (event[Extensions.SDKExt] && event[Extensions.SDKExt][SDKExtensionKeys.libVer]) { // not exposing context object as this ext is not finalized
-                    event.tags.push({[CtxTagKeys.internalSdkVersion]: event[Extensions.SDKExt][SDKExtensionKeys.libVer] }); // map sdk.libVer 
+                    event.tags.push({[CtxTagKeys.internalSdkVersion]: event[Extensions.SDKExt][SDKExtensionKeys.libVer] }); // map sdk.libVer
                 }
             }
         }
@@ -119,7 +120,7 @@ export class TelemetryContext implements ITelemetryContext {
 
     public applyLocationContext(event: ITelemetryItem) {
         if (this.location) {
-            if (typeof this.location.ip === "string") {                
+            if (typeof this.location.ip === "string") {
                 event.tags.push({[CtxTagKeys.locationIp]: this.location.ip});
             }
         }
@@ -141,7 +142,7 @@ export class TelemetryContext implements ITelemetryContext {
             if (typeof this.telemetryTrace.name === "string") {
                 trace.name = this.telemetryTrace.name;
             }
-            
+
             if (typeof this.telemetryTrace.parentID === "string") {
                 trace.parentID = this.telemetryTrace.parentID;
             }
@@ -162,21 +163,21 @@ export class TelemetryContext implements ITelemetryContext {
             if (!event.tags) {
                 event.tags = [];
             }
-            
+
             // stays in tags
             if (typeof this.user.accountId === "string") {
                 let item = {};
                 event.tags.push({[CtxTagKeys.userAccountId]: this.user.accountId});
             }
-            
-            // CS 4.0            
+
+            // CS 4.0
             if (typeof this.user.id === "string") {
                 event.ext.user.id = this.user.id;
             }
-            
+
             if (typeof this.user.authenticatedId === "string") {
                 event.ext.user.authId = this.user.authenticatedId;
-            }            
+            }
         }
     }
 

--- a/vNext/extensions/applicationinsights-react-js/package.json
+++ b/vNext/extensions/applicationinsights-react-js/package.json
@@ -37,9 +37,9 @@
         "typescript": "2.5.3"
     },
     "dependencies": {
-        "@microsoft/applicationinsights-core-js": "2.0.0-rc4",
-        "@microsoft/applicationinsights-common": "2.0.0-rc4",
-        "@microsoft/applicationinsights-analytics-js": "2.0.0-rc4",
+        "@microsoft/applicationinsights-core-js": "2.0.0-rc5",
+        "@microsoft/applicationinsights-common": "2.0.0-rc5",
+        "@microsoft/applicationinsights-analytics-js": "2.0.0-rc5",
         "tslib": "^1.9.3",
         "react": "^16.8.6",
         "history": "^4.9.0"

--- a/vNext/extensions/applicationinsights-react-native/package.json
+++ b/vNext/extensions/applicationinsights-react-native/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-react-native",
-    "version": "1.0.0-rc4",
+    "version": "1.0.0-rc5",
     "description": "Microsoft Application Insights React Native Plugin",
     "main": "dist-esm/index.js",
     "types": "dist-esm/index.d.ts",
@@ -30,8 +30,8 @@
     },
     "dependencies": {
         "react-native-device-info": "^1.4.1",
-        "@microsoft/applicationinsights-core-js": "2.0.0-rc4",
-        "@microsoft/applicationinsights-common": "2.0.0-rc4",
+        "@microsoft/applicationinsights-core-js": "2.0.0-rc5",
+        "@microsoft/applicationinsights-common": "2.0.0-rc5",
         "tslib": "^1.9.3"
     },
     "peerDependencies": {

--- a/vNext/shared/AppInsightsCommon/package.json
+++ b/vNext/shared/AppInsightsCommon/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-common",
-    "version": "2.0.0-rc4",
+    "version": "2.0.0-rc5",
     "description": "Microsoft Application Insights Common JavaScript Library",
     "main": "./dist/applicationinsights-common.js",
     "module": "./dist-esm/applicationinsights-common.js",
@@ -30,7 +30,7 @@
         "rollup": "^0.66.0"
     },
     "dependencies": {
-        "@microsoft/applicationinsights-core-js": "2.0.0-rc4",
+        "@microsoft/applicationinsights-core-js": "2.0.0-rc5",
         "tslib": "^1.9.3"
     },
     "license": "MIT"

--- a/vNext/shared/AppInsightsCommon/src/Interfaces/ITelemetryContext.ts
+++ b/vNext/shared/AppInsightsCommon/src/Interfaces/ITelemetryContext.ts
@@ -44,4 +44,9 @@ export interface ITelemetryContext {
      * The object describing a session tracked by this object.
      */
     session: ISession;
+
+    /**
+     * application id obtained from breeze responses. Is used if appId is not specified by root config
+     */
+    appId: () => string;
 }

--- a/vNext/shared/AppInsightsCommon/src/Util.ts
+++ b/vNext/shared/AppInsightsCommon/src/Util.ts
@@ -10,7 +10,6 @@ import { ICorrelationConfig } from "./Interfaces/ICorrelationConfig";
 
 export class Util {
     private static document: any = typeof document !== "undefined" ? document : {};
-    private static _canUseCookies: boolean = undefined;
     private static _canUseLocalStorage: boolean = undefined;
     private static _canUseSessionStorage: boolean = undefined;
     // listing only non-geo specific locations
@@ -309,7 +308,7 @@ export class Util {
             };
         }
 
-        return Util._canUseCookies;
+        return CoreUtils._canUseCookies;
     }
 
     /**

--- a/vNext/shared/AppInsightsCommon/src/Util.ts
+++ b/vNext/shared/AppInsightsCommon/src/Util.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { StorageType } from "./Enums";
-import { CoreUtils, _InternalMessageId, LoggingSeverity, IDiagnosticLogger } from "@microsoft/applicationinsights-core-js";
+import { CoreUtils, _InternalMessageId, LoggingSeverity, IDiagnosticLogger, IPlugin } from "@microsoft/applicationinsights-core-js";
 import { IConfig } from "./Interfaces/IConfig";
 import { RequestHeaders } from "./RequestResponseHeaders";
 import { DataSanitizer } from "./Telemetry/Common/DataSanitizer";
@@ -547,6 +547,20 @@ export class Util {
      */
     public static IsBeaconApiSupported(): boolean {
         return ('sendBeacon' in navigator && (<any>navigator).sendBeacon);
+    }
+
+    public static getExtension(extensions: IPlugin[], identifier: string) {
+        let extension = null;
+        let extIx = 0;
+
+        while (!extension && extIx < extensions.length) {
+            if (extensions[extIx] && extensions[extIx].identifier === identifier) {
+                extension = extensions[extIx];
+            }
+            extIx++;
+        }
+
+        return extension;
     }
 }
 

--- a/vNext/shared/AppInsightsCommon/src/applicationinsights-common.ts
+++ b/vNext/shared/AppInsightsCommon/src/applicationinsights-common.ts
@@ -48,3 +48,4 @@ export { IPropertiesPlugin } from './Interfaces/IPropertiesPlugin';
 export { IUser, IUserContext } from './Interfaces/Context/IUser';
 export { ITelemetryTrace, ITraceState } from './Interfaces/Context/ITelemetryTrace';
 export const PropertiesPluginIdentifier = "AppInsightsPropertiesPlugin";
+export const BreezeChannelIdentifier = "AppInsightsChannelPlugin";

--- a/vNext/shared/AppInsightsCore/package.json
+++ b/vNext/shared/AppInsightsCore/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/applicationinsights-core-js",
     "author": "Microsoft Corporation",
-    "version": "2.0.0-rc4",
+    "version": "2.0.0-rc5",
     "description": "Microsoft Application Insights Core Javascript SDK",
     "keywords": [
         "azure",


### PR DESCRIPTION
Addresses #857 
- Saves appId response from Breeze Channel in TelemetryContext instance. This is then used in the dependencies plugin when it grabs its context ref from properties plugin