### PR TITLE
rename rollup output name

### DIFF
--- a/vNext/AISKU/rollup.config.js
+++ b/vNext/AISKU/rollup.config.js
@@ -17,7 +17,7 @@ const browserRollupConfigFactory = (isProduction, libVersion = '2') => {
       file: `browser/ai.${libVersion}.js`,
       banner: banner,
       format: "umd",
-      name: "Microsoft.ApplicationInsights",
+      name: "Microsoft.ApplicationInsightsWeb",
       sourcemap: true
     },
     plugins: [
@@ -56,7 +56,7 @@ const nodeUmdRollupConfigFactory = (isProduction) => {
       file: `dist/applicationinsights-web.js`,
       banner: banner,
       format: "umd",
-      name: "Microsoft.ApplicationInsights",
+      name: "Microsoft.ApplicationInsightsWeb",
       sourcemap: true
     },
     plugins: [

--- a/vNext/AISKULight/rollup.config.js
+++ b/vNext/AISKULight/rollup.config.js
@@ -17,7 +17,7 @@ const browserRollupConfigFactory = (isProduction, libV = '2') => {
       file: `browser/aib.${libV}.js`,
       banner: banner,
       format: "umd",
-      name: "Microsoft.ApplicationInsights",
+      name: "Microsoft.ApplicationInsightsWeb",
       sourcemap: true
     },
     plugins: [
@@ -56,7 +56,7 @@ const nodeUmdRollupConfigFactory = (isProduction) => {
       file: `dist/applicationinsights-web-basic.js`,
       banner: banner,
       format: "umd",
-      name: "Microsoft.ApplicationInsights",
+      name: "Microsoft.ApplicationInsightsWeb",
       sourcemap: true
     },
     plugins: [

--- a/vNext/channels/applicationinsights-channel-js/rollup.config.js
+++ b/vNext/channels/applicationinsights-channel-js/rollup.config.js
@@ -18,7 +18,7 @@ const browserRollupConfigFactory = isProduction => {
       file: "browser/applicationinsights-channel-js.js",
       banner: banner,
       format: "umd",
-      name: "Microsoft.ApplicationInsights",
+      name: "Microsoft.ApplicationInsightsWeb",
       sourcemap: true
     },
     plugins: [
@@ -57,7 +57,7 @@ const nodeUmdRollupConfigFactory = (isProduction) => {
       file: `dist/${outputName}.js`,
       banner: banner,
       format: "umd",
-      name: "Microsoft.ApplicationInsights",
+      name: "Microsoft.ApplicationInsightsWeb",
       sourcemap: true
     },
     plugins: [

--- a/vNext/extensions/applicationinsights-analytics-js/rollup.config.js
+++ b/vNext/extensions/applicationinsights-analytics-js/rollup.config.js
@@ -18,7 +18,7 @@ const browserRollupConfigFactory = isProduction => {
       file: `browser/${outputName}.js`,
       banner: banner,
       format: "umd",
-      name: "Microsoft.ApplicationInsights",
+      name: "Microsoft.ApplicationInsightsWeb",
       sourcemap: true
     },
     plugins: [
@@ -57,7 +57,7 @@ const nodeUmdRollupConfigFactory = (isProduction) => {
       file: `dist/${outputName}.js`,
       banner: banner,
       format: "umd",
-      name: "Microsoft.ApplicationInsights",
+      name: "Microsoft.ApplicationInsightsWeb",
       sourcemap: true
     },
     plugins: [

--- a/vNext/extensions/applicationinsights-dependencies-js/rollup.config.js
+++ b/vNext/extensions/applicationinsights-dependencies-js/rollup.config.js
@@ -18,7 +18,7 @@ const browserRollupConfigFactory = isProduction => {
       file: `browser/${outputName}.js`,
       banner: banner,
       format: "umd",
-      name: "Microsoft.ApplicationInsights",
+      name: "Microsoft.ApplicationInsightsWeb",
       sourcemap: true
     },
     plugins: [
@@ -57,7 +57,7 @@ const nodeUmdRollupConfigFactory = (isProduction) => {
       file: `dist/${outputName}.js`,
       banner: banner,
       format: "umd",
-      name: "Microsoft.ApplicationInsights",
+      name: "Microsoft.ApplicationInsightsWeb",
       sourcemap: true
     },
     plugins: [

--- a/vNext/extensions/applicationinsights-properties-js/rollup.config.js
+++ b/vNext/extensions/applicationinsights-properties-js/rollup.config.js
@@ -18,7 +18,7 @@ const browserRollupConfigFactory = isProduction => {
       file: `browser/${outputName}.js`,
       banner: banner,
       format: "umd",
-      name: "Microsoft.ApplicationInsights",
+      name: "Microsoft.ApplicationInsightsWeb",
       sourcemap: true
     },
     plugins: [
@@ -57,7 +57,7 @@ const nodeUmdRollupConfigFactory = (isProduction) => {
       file: `dist/${outputName}.js`,
       banner: banner,
       format: "umd",
-      name: "Microsoft.ApplicationInsights",
+      name: "Microsoft.ApplicationInsightsWeb",
       sourcemap: true
     },
     plugins: [

--- a/vNext/extensions/applicationinsights-react-js/rollup.config.js
+++ b/vNext/extensions/applicationinsights-react-js/rollup.config.js
@@ -18,7 +18,7 @@ const browserRollupConfigFactory = isProduction => {
       file: `browser/${outputName}.js`,
       banner: banner,
       format: "umd",
-      name: "Microsoft.ApplicationInsights",
+      name: "Microsoft.ApplicationInsightsWeb",
       sourcemap: true
     },
     plugins: [
@@ -57,7 +57,7 @@ const nodeUmdRollupConfigFactory = (isProduction) => {
       file: `dist/${outputName}.js`,
       banner: banner,
       format: "umd",
-      name: "Microsoft.ApplicationInsights",
+      name: "Microsoft.ApplicationInsightsWeb",
       sourcemap: true
     },
     plugins: [

--- a/vNext/shared/AppInsightsCommon/rollup.config.js
+++ b/vNext/shared/AppInsightsCommon/rollup.config.js
@@ -18,7 +18,7 @@ const browserRollupConfigFactory = isProduction => {
       file: `browser/${outputName}.js`,
       banner: banner,
       format: "umd",
-      name: "Microsoft.ApplicationInsights",
+      name: "Microsoft.ApplicationInsightsWeb",
       sourcemap: true
     },
     plugins: [
@@ -57,7 +57,7 @@ const nodeUmdRollupConfigFactory = (isProduction) => {
       file: `dist/${outputName}.js`,
       banner: banner,
       format: "umd",
-      name: "Microsoft.ApplicationInsights",
+      name: "Microsoft.ApplicationInsightsWeb",
       sourcemap: true
     },
     plugins: [

--- a/vNext/shared/AppInsightsCore/rollup.config.js
+++ b/vNext/shared/AppInsightsCore/rollup.config.js
@@ -18,7 +18,7 @@ const browserRollupConfigFactory = isProduction => {
       file: `browser/${outputName}.js`,
       banner: banner,
       format: "umd",
-      name: "Microsoft.ApplicationInsights",
+      name: "Microsoft.ApplicationInsightsWeb",
       sourcemap: true
     },
     plugins: [
@@ -58,7 +58,7 @@ const nodeUmdRollupConfigFactory = (isProduction) => {
       file: `dist/${outputName}.js`,
       banner: banner,
       format: "umd",
-      name: "Microsoft.ApplicationInsights",
+      name: "Microsoft.ApplicationInsightsWeb",
       sourcemap: true
     },
     plugins: [


### PR DESCRIPTION
Fixes #855 
Rollup output name for V2 SDK conflicts with name used by browser version of V1 SDK. This name is not used at all by any V2 code and it was not documented at all for external usage, so it is (probably?) safe to change.

`Microsoft.ApplicationInsights` --> `Microsoft.ApplicationInsightsWeb`