### PR TITLE
rename IExceptionTelemetry.error to exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If initialized using the snippet, your Application Insights instance is located 
 appInsights.trackEvent({name: 'some event'});
 appInsights.trackPageView({name: 'some page'});
 appInsights.trackPageViewPerformance({name : 'some page', url: 'some url'});
-appInsights.trackException({error: new Error('some error')});
+appInsights.trackException({exception: new Error('some error')});
 appInsights.trackTrace({message: 'some trace'});
 appInsights.trackMetric({name: 'some metric', average: 42});
 appInsights.trackDependencyData({absoluteUrl: 'some url', resultCode: 200, method: 'GET', id: 'some id'});

--- a/vNext/AISKU/Tests/applicationinsights.e2e.tests.ts
+++ b/vNext/AISKU/Tests/applicationinsights.e2e.tests.ts
@@ -159,7 +159,23 @@ export class ApplicationInsightsTests extends TestClass {
                     Assert.ok(false, 'trackException test not run');
                 } catch (e) {
                     exception = e;
-                    this._ai.trackException({ error: exception });
+                    this._ai.trackException({ exception: exception });
+                }
+                Assert.ok(exception);
+            }].concat(this.asserts(1))
+        });
+
+        this.testCaseAsync({
+            name: 'E2E.GenericTests: legacy trackException sends to backend',
+            stepDelay: 1,
+            steps: [() => {
+                let exception: Error = null;
+                try {
+                    window['a']['b']();
+                    Assert.ok(false, 'trackException test not run');
+                } catch (e) {
+                    exception = e;
+                    this._ai.trackException(<any>{ error: exception });
                 }
                 Assert.ok(exception);
             }].concat(this.asserts(1))
@@ -213,7 +229,7 @@ export class ApplicationInsightsTests extends TestClass {
 
                     Assert.ok(exception);
 
-                    this._ai.trackException({ error: exception });
+                    this._ai.trackException({ exception: exception });
                     this._ai.trackMetric({ name: "test", average: Math.round(100 * Math.random()) });
                     this._ai.trackTrace({ message: "test" });
                     this._ai.trackPageView({}); // sends 2
@@ -237,7 +253,7 @@ export class ApplicationInsightsTests extends TestClass {
                     Assert.ok(exception);
 
                     for (var i = 0; i < 100; i++) {
-                        this._ai.trackException({ error: exception });
+                        this._ai.trackException({ exception: exception });
                         this._ai.trackMetric({ name: "test", average: Math.round(100 * Math.random()) });
                         this._ai.trackTrace({ message: "test" });
                         this._ai.trackPageView({ name: `${i}` }); // sends 2 1st time

--- a/vNext/AISKU/src/ApplicationInsightsDeprecated.ts
+++ b/vNext/AISKU/src/ApplicationInsightsDeprecated.ts
@@ -87,7 +87,7 @@ export class AppInsightsDeprecated implements IAppInsightsDeprecated {
 
     trackException(exception: Error, handledAt?: string, properties?: { [name: string]: string; }, measurements?: { [name: string]: number; }, severityLevel?: any) {
         this.appInsightsNew.trackException(<IExceptionTelemetry>{
-            error: exception
+            exception: exception
         });
     }
 

--- a/vNext/AISKU/src/Initialization.ts
+++ b/vNext/AISKU/src/Initialization.ts
@@ -103,6 +103,9 @@ export class Initialization implements IApplicationInsights {
      * @memberof Initialization
      */
     public trackException(exception: IExceptionTelemetry): void {
+        if (!exception.exception && (<any>exception).error) {
+            exception.exception = (<any>exception).error;
+        }
         this.appInsights.trackException(exception);
     }
 

--- a/vNext/extensions/applicationinsights-analytics-js/Tests/ApplicationInsights.tests.ts
+++ b/vNext/extensions/applicationinsights-analytics-js/Tests/ApplicationInsights.tests.ts
@@ -177,6 +177,7 @@ export class ApplicationInsightsTests extends TestClass {
                 };
 
                 // Test
+                test(() => appInsights.trackException({exception: new Error(), severityLevel: SeverityLevel.Critical}), Exception.envelopeType, Exception.dataType)
                 test(() => appInsights.trackException({error: new Error(), severityLevel: SeverityLevel.Critical}), Exception.envelopeType, Exception.dataType)
                 test(() => appInsights.trackTrace({message: "some string"}), Trace.envelopeType, Trace.dataType);
                 test(() => appInsights.trackPageViewPerformance({name: undefined, uri: undefined, measurements: {somefield: 123}}, {vpHeight: 123}), PageViewPerformance.envelopeType, PageViewPerformance.dataType, () => {
@@ -200,11 +201,12 @@ export class ApplicationInsightsTests extends TestClass {
                 const senderStub = this.sandbox.stub(appInsights.core, "track");
 
                 // Act
+                appInsights.trackException({exception: new Error(), severityLevel: SeverityLevel.Critical});
                 appInsights.trackException({error: new Error(), severityLevel: SeverityLevel.Critical});
                 this.clock.tick(1);
 
                 // Test
-                Assert.ok(senderStub.calledOnce, "Telemetry is sent when master switch is on");
+                Assert.ok(senderStub.calledTwice, "Telemetry is sent when master switch is on");
             }
         });
     }

--- a/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
+++ b/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
@@ -369,7 +369,7 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
     public sendExceptionInternal(exception: IExceptionTelemetry, customProperties?: { [key: string]: any }, systemProperties?: { [key: string]: any }) {
         const exceptionPartB = new Exception(
             this._logger,
-            exception.error,
+            exception.exception || new Error(Util.NotSpecified),
             exception.properties,
             exception.measurements,
             exception.severityLevel,
@@ -431,7 +431,7 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
                     exception.error = new Error(exception.message);
                     exception.error.stack = stack;
                 }
-                this.trackException({ error: exception.error, severityLevel: SeverityLevel.Error }, properties);
+                this.trackException({ exception: exception.error, severityLevel: SeverityLevel.Error }, properties);
             }
         } catch (e) {
             const errorString = exception.error ?

--- a/vNext/shared/AppInsightsCommon/src/Interfaces/IExceptionTelemetry.ts
+++ b/vNext/shared/AppInsightsCommon/src/Interfaces/IExceptionTelemetry.ts
@@ -18,7 +18,7 @@ export interface IExceptionTelemetry {
      * @deprecated
      * @type {Error}
      * @memberof IExceptionTelemetry
-     * @description Error Object(s)
+     * @description DEPRECATED: Please use exception instead. Behavior/usage for exception remains the same as this field.
      */
     error?: Error;
 

--- a/vNext/shared/AppInsightsCommon/src/Interfaces/IExceptionTelemetry.ts
+++ b/vNext/shared/AppInsightsCommon/src/Interfaces/IExceptionTelemetry.ts
@@ -15,11 +15,19 @@ export interface IExceptionTelemetry {
     id?: string;
 
     /**
+     * @deprecated
      * @type {Error}
      * @memberof IExceptionTelemetry
      * @description Error Object(s)
      */
-    error: Error;
+    error?: Error;
+
+    /**
+     * @type {Error}
+     * @memberof IExceptionTelemetry
+     * @description Error Object(s)
+     */
+    exception?: Error;
 
     /**
      * @description Specified severity of exception for use with


### PR DESCRIPTION
Fixes https://github.com/microsoft/ApplicationInsights-node.js/issues/522
This PR aligns `trackException` API of this SDK with other App Insights SDKs. 

e.g [Node.js SDK](https://github.com/microsoft/ApplicationInsights-node.js/blob/develop/Declarations/Contracts/TelemetryTypes/ExceptionTelemetry.ts)
`appInsights.trackException({ exception: new Error() });`
