### PR TITLE
add operation.name, pageview.id

### DIFF
--- a/vNext/AISKU/Tests/applicationinsights.e2e.tests.ts
+++ b/vNext/AISKU/Tests/applicationinsights.e2e.tests.ts
@@ -197,12 +197,24 @@ export class ApplicationInsightsTests extends TestClass {
 
         this.testCaseAsync({
             name: "TelemetryContext: track page view",
-            stepDelay: 1,
+            stepDelay: 500,
             steps: [
                 () => {
-                    this._ai.trackPageView({}); // sends 2
+                    this._ai.trackPageView(); // sends 2
                 }
-            ].concat(this.asserts(2))
+            ].concat(this.asserts(2)).concat(() => {
+
+                if (this.successSpy.called) {
+                    const payloadStr: string[] = this.successSpy.args[0][0];
+                    const payload = JSON.parse(payloadStr[0]);
+                    let data = payload.data;
+                    Assert.ok(data.baseData.id, "pageView id is defined");
+                    Assert.ok(data.baseData.id.length > 0, "pageView id has content");
+                    Assert.deepEqual(data.baseData.id, data.tags["ai.operation.id"], "pageView id matches current operation id");
+                } else {
+                    Assert.ok(false, "successSpy not called");
+                }
+            })
         });
 
         this.testCaseAsync({

--- a/vNext/AISKU/Tests/applicationinsights.e2e.tests.ts
+++ b/vNext/AISKU/Tests/applicationinsights.e2e.tests.ts
@@ -196,14 +196,11 @@ export class ApplicationInsightsTests extends TestClass {
         });
 
         this.testCaseAsync({
-            name: "TelemetryContext: track page view",
+            name: `TelemetryContext: track page view ${window.location.pathname}`,
             stepDelay: 500,
             steps: [
                 () => {
-                    const originalPathName = window.location.pathname.slice();
-                    window.location.pathname = "/test"
                     this._ai.trackPageView(); // sends 2
-                    window.location.pathname = originalPathName;
                 }
             ].concat(this.asserts(2)).concat(() => {
 
@@ -212,8 +209,9 @@ export class ApplicationInsightsTests extends TestClass {
                     const payload = JSON.parse(payloadStr[0]);
                     let data = payload.data;
                     Assert.ok(data.baseData.id, "pageView id is defined");
-                    Assert.deepEqual(data.baseData.id.length > 0, "/test");
-                    Assert.deepEqual(data.baseData.id, data.tags["ai.operation.id"], "pageView id matches current operation id");
+                    Assert.ok(data.baseData.id.length > 0);
+                    Assert.ok(payload.tags["ai.operation.id"]);
+                    Assert.equal(data.baseData.id, payload.tags["ai.operation.id"], "pageView id matches current operation id");
                 } else {
                     Assert.ok(false, "successSpy not called");
                 }

--- a/vNext/AISKU/Tests/applicationinsights.e2e.tests.ts
+++ b/vNext/AISKU/Tests/applicationinsights.e2e.tests.ts
@@ -200,7 +200,10 @@ export class ApplicationInsightsTests extends TestClass {
             stepDelay: 500,
             steps: [
                 () => {
+                    const originalPathName = window.location.pathname.slice();
+                    window.location.pathname = "/test"
                     this._ai.trackPageView(); // sends 2
+                    window.location.pathname = originalPathName;
                 }
             ].concat(this.asserts(2)).concat(() => {
 
@@ -209,7 +212,7 @@ export class ApplicationInsightsTests extends TestClass {
                     const payload = JSON.parse(payloadStr[0]);
                     let data = payload.data;
                     Assert.ok(data.baseData.id, "pageView id is defined");
-                    Assert.ok(data.baseData.id.length > 0, "pageView id has content");
+                    Assert.deepEqual(data.baseData.id.length > 0, "/test");
                     Assert.deepEqual(data.baseData.id, data.tags["ai.operation.id"], "pageView id matches current operation id");
                 } else {
                     Assert.ok(false, "successSpy not called");

--- a/vNext/channels/applicationinsights-channel-js/src/EnvelopeCreator.ts
+++ b/vNext/channels/applicationinsights-channel-js/src/EnvelopeCreator.ts
@@ -365,9 +365,15 @@ export class PageViewEnvelopeCreator extends EnvelopeCreator {
         }
 
         let bd = telemetryItem.baseData as IPageViewTelemetryInternal;
+
+         // special case: pageview.id is grabbed from current operation id. Analytics plugin is decoupled from properties plugin, so this is done here instead. This can be made a default telemetry intializer instead if needed to be decoupled from channel
+        let currentContextId;
+        if (telemetryItem.ext && telemetryItem.ext.trace && telemetryItem.ext.trace.traceID) {
+            currentContextId = telemetryItem.ext.trace.traceID;
+        }
+        let id = bd.id || currentContextId
         let name = bd.name;
         let url = bd.uri;
-        let id = bd.id;
         let properties = bd.properties || {};
         let measurements = bd.measurements || {};
 

--- a/vNext/extensions/applicationinsights-properties-js/Tests/Selenium/properties.tests.ts
+++ b/vNext/extensions/applicationinsights-properties-js/Tests/Selenium/properties.tests.ts
@@ -6,6 +6,7 @@ import { ITelemetryConfig } from "../../src/Interfaces/ITelemetryConfig";
 import { Util, TelemetryItemCreator, IWeb } from "@microsoft/applicationinsights-common";
 import { TelemetryContext } from "../../src/TelemetryContext";
 import { Session, _SessionManager } from "../../src/Context/Session";
+import { TelemetryTrace } from "../../src/Context/TelemetryTrace";
 
 export class PropertiesTests extends TestClass {
     private properties: PropertiesPlugin;
@@ -26,6 +27,17 @@ export class PropertiesTests extends TestClass {
         this.addConfigTests();
         this.addUserTests();
         this.addDeviceTests();
+        this.addTelemetryTraceTests();
+    }
+
+    private addTelemetryTraceTests() {
+        this.testCase({
+            name: 'Trace: default operation.name is grabbed from window pathname, if available',
+            test: () => {
+                const operation = new TelemetryTrace();
+                Assert.ok(operation.name);
+            }
+        });
     }
 
     private addConfigTests() {

--- a/vNext/extensions/applicationinsights-properties-js/src/Context/TelemetryTrace.ts
+++ b/vNext/extensions/applicationinsights-properties-js/src/Context/TelemetryTrace.ts
@@ -14,5 +14,8 @@ export class TelemetryTrace implements ITelemetryTrace {
         this.traceID = id || Util.newId();
         this.parentID = parentId;
         this.name = name;
+        if (window && window.location && window.location.pathname) {
+            this.name = window.location.pathname;
+        }
     }
 }


### PR DESCRIPTION
Adds previously existing behavior to automatically name a newly started operation.
V1 SDK:
https://github.com/microsoft/ApplicationInsights-JS/blob/a96b1a0e77a43e6ba64369cae635c678e009f4f8/JavaScript/JavaScriptSDK/Context/Operation.ts#L19-L23

Also saves the current operation id to each PageView.id as was done in V1 SDK.
https://github.com/microsoft/ApplicationInsights-JS/blob/a96b1a0e77a43e6ba64369cae635c678e009f4f8/JavaScript/JavaScriptSDK/AppInsights.ts#L140-L141