### PR TITLE
analytics: remove ikey setter

### DIFF
--- a/vNext/extensions/applicationinsights-analytics-js/Tests/ApplicationInsights.tests.ts
+++ b/vNext/extensions/applicationinsights-analytics-js/Tests/ApplicationInsights.tests.ts
@@ -169,8 +169,8 @@ export class ApplicationInsightsTests extends TestClass {
                 var test = (action, expectedEnvelopeType, expectedDataType, test?: () => void) => {
                     action();
                     envelope = this.getFirstResult(action, trackStub);
-                    Assert.equal(iKey, envelope.iKey, "envelope iKey");
-                    Assert.equal(expectedEnvelopeType.replace("{0}", iKeyNoDash), envelope.name, "envelope name");
+                    Assert.equal("", envelope.iKey, "envelope iKey");
+                    Assert.equal(expectedEnvelopeType, envelope.name, "envelope name");
                     Assert.equal(expectedDataType, envelope.baseType, "data type name");
                     if (typeof test === 'function') {test();}
                     trackStub.reset();

--- a/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
+++ b/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
@@ -119,7 +119,6 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
                 customProperties
             );
 
-            this._setTelemetryNameAndIKey(telemetryItem);
             this.core.track(telemetryItem);
         } catch (e) {
             this._logger.throwInternal(LoggingSeverity.WARNING,
@@ -176,7 +175,6 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
                 this._logger,
                 customProperties);
 
-            this._setTelemetryNameAndIKey(telemetryItem);
             this.core.track(telemetryItem);
         } catch (e) {
             this._logger.throwInternal(LoggingSeverity.WARNING,
@@ -207,7 +205,6 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
                 customProperties
             );
 
-            this._setTelemetryNameAndIKey(telemetryItem);
             this.core.track(telemetryItem);
         } catch (e) {
             this._logger.throwInternal(LoggingSeverity.CRITICAL,
@@ -259,8 +256,6 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
             properties,
             systemProperties);
 
-        // set instrumentation key
-        this._setTelemetryNameAndIKey(telemetryItem);
         this.core.track(telemetryItem);
 
         // reset ajaxes counter
@@ -280,9 +275,6 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
             this._logger,
             properties,
             systemProperties);
-
-        // set instrumentation key
-        this._setTelemetryNameAndIKey(telemetryItem);
 
         this.core.track(telemetryItem);
     }
@@ -384,7 +376,6 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
             customProperties,
             systemProperties
         );
-        this._setTelemetryNameAndIKey(telemetryItem);
         this.core.track(telemetryItem);
     }
 
@@ -634,14 +625,6 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
         );
 
         this.core.track(telemetryItem);
-    }
-
-    // Mutate telemetryItem inplace to add boilerplate iKey & name info
-    private _setTelemetryNameAndIKey(telemetryItem: ITelemetryItem): void {
-        telemetryItem.iKey = this._globalconfig.instrumentationKey;
-
-        var iKeyNoDashes = this._globalconfig.instrumentationKey.replace(/-/g, "");
-        telemetryItem.name = telemetryItem.name.replace("{0}", iKeyNoDashes);
     }
 }
 


### PR DESCRIPTION
Remove redundant code. This functionality is currently performed by the breeze-channel and core. This change enables changing ikey in a telemetry initializer to also change `iKeyNoDashes` in `ITelemetryItem.name`.

#### Core
https://github.com/microsoft/ApplicationInsights-JS/blob/96a5125a40229fb5c496a9a799d7deb26aa88b56/vNext/shared/AppInsightsCore/src/JavaScriptSDK/AppInsightsCore.ts#L164-L184

#### Channel
https://github.com/microsoft/ApplicationInsights-JS/blob/96a5125a40229fb5c496a9a799d7deb26aa88b56/vNext/channels/applicationinsights-channel-js/src/EnvelopeCreator.ts#L61-L65