### PR TITLE
analytics: move to last priority of default plugins

### DIFF
--- a/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
+++ b/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
@@ -30,7 +30,7 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
     public static Version = "2.0.1"; // Not currently used anywhere
     public initialize: (config: IConfiguration, core: IAppInsightsCore, extensions: IPlugin[]) => void;
     public identifier: string = "ApplicationInsightsAnalytics"; // do not change name or priority
-    public priority: number = 200;// take from reserved priority range 100- 200
+    public priority: number = 180; // take from reserved priority range 100- 200
     public config: IConfig;
     public core: IAppInsightsCore;
     public queue: (() => void)[];

--- a/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
+++ b/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
@@ -30,7 +30,7 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
     public static Version = "2.0.1"; // Not currently used anywhere
     public initialize: (config: IConfiguration, core: IAppInsightsCore, extensions: IPlugin[]) => void;
     public identifier: string = "ApplicationInsightsAnalytics"; // do not change name or priority
-    public priority: number = 199;// take from reserved priority range 100- 200
+    public priority: number = 200;// take from reserved priority range 100- 200
     public config: IConfig;
     public core: IAppInsightsCore;
     public queue: (() => void)[];

--- a/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
+++ b/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
@@ -30,7 +30,7 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
     public static Version = "2.0.1"; // Not currently used anywhere
     public initialize: (config: IConfiguration, core: IAppInsightsCore, extensions: IPlugin[]) => void;
     public identifier: string = "ApplicationInsightsAnalytics"; // do not change name or priority
-    public priority: number = 160;// take from reserved priority range 100- 200
+    public priority: number = 199;// take from reserved priority range 100- 200
     public config: IConfig;
     public core: IAppInsightsCore;
     public queue: (() => void)[];

--- a/vNext/extensions/applicationinsights-dependencies-js/src/ajax.ts
+++ b/vNext/extensions/applicationinsights-dependencies-js/src/ajax.ts
@@ -338,7 +338,7 @@ export class AjaxMonitor implements ITelemetryPlugin, IDependenciesPlugin, IInst
         }
     }
 
-    priority: number = 171;
+    priority: number = 120;
 
     // Fetch Stuff
     protected instrumentFetch(): void {

--- a/vNext/extensions/applicationinsights-properties-js/src/PropertiesPlugin.ts
+++ b/vNext/extensions/applicationinsights-properties-js/src/PropertiesPlugin.ts
@@ -17,7 +17,7 @@ export default class PropertiesPlugin implements ITelemetryPlugin, IPropertiesPl
     private _logger: IDiagnosticLogger;
     private _breezeChannel: IPlugin; // optional. If exists, grab appId from it
 
-    public priority = 170;
+    public priority = 110;
     public identifier = PropertiesPluginIdentifier;
 
     private _nextPlugin: ITelemetryPlugin;

--- a/vNext/extensions/applicationinsights-react-js/src/ReactPlugin.ts
+++ b/vNext/extensions/applicationinsights-react-js/src/ReactPlugin.ts
@@ -16,7 +16,7 @@ import { History, LocationListener, Location, Action } from "history";
 
 export default class ReactPlugin implements ITelemetryPlugin {
     private _logger: IDiagnosticLogger;
-    public priority = 180;
+    public priority = 130;
     public identifier = 'ReactPlugin';
 
     private _analyticsPlugin: IAppInsights;

--- a/vNext/extensions/applicationinsights-react-native/src/ReactNativePlugin.ts
+++ b/vNext/extensions/applicationinsights-react-native/src/ReactNativePlugin.ts
@@ -21,7 +21,7 @@ export class ReactNativePlugin implements ITelemetryPlugin {
     private _config: IReactNativePluginConfig;
 
     identifier: string = 'AppInsightsReactNativePlugin';
-    priority: number = 199;
+    priority: number = 140;
     _nextPlugin?: ITelemetryPlugin;
 
     constructor(config?: IReactNativePluginConfig) {

--- a/vNext/shared/AppInsightsCore/package.json
+++ b/vNext/shared/AppInsightsCore/package.json
@@ -15,7 +15,6 @@
     "main": "dist/applicationinsights-core-js.js",
     "module": "dist-esm/applicationinsights-core-js.js",
     "types": "types/applicationinsights-core-js.d.ts",
-    "browser": "browser/applicationinsights-core-js.min.js",
     "scripts": {
         "clean": "grunt clean",
         "build": "npm run build:esm && npm run build:browser",


### PR DESCRIPTION
Custom telemetry intializers are run in `processTelemetry` in the analytics plugin. It needs to be made as the last priority among the default plugins so that all other telemetry information from other plugins is available to custom telemetry initializers.

Also removes minified entry point from `core`