### PR TITLE
common: sanitize rdd name and target

### DIFF
--- a/vNext/shared/AppInsightsCommon/src/Telemetry/RemoteDependencyData.ts
+++ b/vNext/shared/AppInsightsCommon/src/Telemetry/RemoteDependencyData.ts
@@ -52,11 +52,11 @@ export class RemoteDependencyData extends GeneratedRemoteDependencyData implemen
         this.resultCode = resultCode + "";
 
         this.type = DataSanitizer.sanitizeString(logger, requestAPI);
-        
+
         var dependencyFields = AjaxHelper.ParseDependencyPath(logger, absoluteUrl, method, commandName);
         this.data = DataSanitizer.sanitizeUrl(logger, commandName) || dependencyFields.data; // get a value from hosturl if commandName not available
-        this.target = dependencyFields.target;
-        this.name = dependencyFields.name;
+        this.target = DataSanitizer.sanitizeString(logger, dependencyFields.target);
+        this.name = DataSanitizer.sanitizeString(logger, dependencyFields.name);
 
         this.properties = DataSanitizer.sanitizeProperties(logger, properties);
         this.measurements = DataSanitizer.sanitizeMeasurements(logger, measurements);


### PR DESCRIPTION
Adds missing string sanitization to `RDD.ts` that already exists in other Telemetry Classes.