### PR TITLE
docs: rename resultCode to responseCode

### DIFF
--- a/API.md
+++ b/API.md
@@ -119,7 +119,7 @@ The `IDependencyTelemetry` interface is described below
 Parameter | Type | Description
 ---|---|---
 `id` | string | **Required**<br>Unique id, this is used by the backend to correlate server requests.
-`resultCode` | number | **Required**<br>Response code returned by the dependency request (e.g., `200` for a success)
+`responseCode` | number | **Required**<br>Response code returned by the dependency request (e.g., `200` for a success)
 `absoluteUrl?` | string | **Optional**<br>Absolute url used to make the dependency request
 `success?` | boolean | **Optional**<br>Whether or not the request was successful or not (e.g., `responseCode` in the range 200-299)
 `commandName?` | string| **Optional**<br>Command used to make the dependency request

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ appInsights.trackPageViewPerformance({name : 'some page', url: 'some url'});
 appInsights.trackException({exception: new Error('some error')});
 appInsights.trackTrace({message: 'some trace'});
 appInsights.trackMetric({name: 'some metric', average: 42});
-appInsights.trackDependencyData({absoluteUrl: 'some url', resultCode: 200, method: 'GET', id: 'some id'});
+appInsights.trackDependencyData({absoluteUrl: 'some url', responseCode: 200, method: 'GET', id: 'some id'});
 appInsights.startTrackPage("pageName");
 appInsights.stopTrackPage("pageName", {customProp1: "some value"});
 appInsights.startTrackEvent("event");


### PR DESCRIPTION
Docs incorrectly reference `resultCode`. Should be `responseCode`