### PR TITLE
Feature: add SPA auto route change tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Most configuration fields are named such that they can be defaulted to falsey. A
 | appId | null | AppId is used for the correlation between AJAX dependencies happening on the client-side with the server-side requests. When Beacon API is enabled, it cannot be used automatically, but can be set manually in the configuration. Default is null |
 | enableCorsCorrelation | false | If true, the SDK will add two headers ('Request-Id' and 'Request-Context') to all CORS requests tocorrelate outgoing AJAX dependencies with corresponding requests on the server side. Default is false |
 | namePrefix | undefined | An optional value that will be used as name postfix for localStorage and cookie name.
+<!-- | enableAutoRouteTracking | false | Automatically track route changes in Single Page Applications (SPA). If true, each route change will send a new Pageview to Application Insights. Hash route changes changes (`example.com/foo#bar`) are also recorded as new page views. -->
 
 ## Single Page Applications
 

--- a/README.md
+++ b/README.md
@@ -158,13 +158,9 @@ Most configuration fields are named such that they can be defaulted to falsey. A
 
 ## Single Page Applications
 
-By default, this SDK will **not** handle state based route changing that occurs in single page applications unless you use a plugin designed for your frontend framework (Angular, React, Vue, etc). Currently, we support a separate [React plugin](#available-extensions-for-the-sdk) which you can initialize with this SDK and it will accomplish this for you in your React application. Otherwise, you must manually trigger pageviews on each route change. An example of accomplishing this for a React application is located [here](https://github.com/Azure-Samples/appinsights-guestbook/blob/6555933e19d737b2ff4f9f339cc1b928f0c08cdb/client/src/AppContainer.js#L17-L20). Note that you must refresh the current operation's id **as well as** trigger an additional pageview:
-**React Router history listener example**
-```js
-this.unlisten = this.props.history.listen((location, action) => {
-  ai.properties.context.telemetryTrace.traceID = Util.newId();
-  ai.trackPageView({name: window.location.pathname});
-});
+By default, this SDK will **not** handle state based route changing that occurs in single page applications unless you use a plugin designed for your frontend framework (Angular, React, Vue, etc). <!-- To enable enable automatic route change tracking for your single page application, you can add `enableAutoRouteTracking: true` to the setup configuration. -->
+
+Currently, we support a separate [React plugin](#available-extensions-for-the-sdk) which you can initialize with this SDK. It will also accomplish route change tracking for you, as well as collect [other React specific telemetry](./vNext/extensions/applicationinsights-react-js).
 ```
 
 ## Examples

--- a/vNext/extensions/applicationinsights-analytics-js/Tests/ApplicationInsights.tests.ts
+++ b/vNext/extensions/applicationinsights-analytics-js/Tests/ApplicationInsights.tests.ts
@@ -55,7 +55,7 @@ export class ApplicationInsightsTests extends TestClass {
                 var appInsights = new ApplicationInsights();
                 var core = new AppInsightsCore();
                 var channel = new ChannelPlugin();
-                appInsights['_properties'] = {
+                appInsights['_properties'] = <any>{
                     context: { telemetryTrace: { traceID: 'not set'}}
                 }
                 const trackPageViewStub = this.sandbox.stub(appInsights, 'trackPageView');
@@ -85,7 +85,7 @@ export class ApplicationInsightsTests extends TestClass {
                 var appInsights = new ApplicationInsights();
                 var core = new AppInsightsCore();
                 var channel = new ChannelPlugin();
-                appInsights['_properties'] = {
+                appInsights['_properties'] = <any>{
                     context: { telemetryTrace: { traceID: 'not set'}}
                 }
                 const trackPageViewStub = this.sandbox.stub(appInsights, 'trackPageView');

--- a/vNext/extensions/applicationinsights-analytics-js/Tests/ApplicationInsights.tests.ts
+++ b/vNext/extensions/applicationinsights-analytics-js/Tests/ApplicationInsights.tests.ts
@@ -56,7 +56,7 @@ export class ApplicationInsightsTests extends TestClass {
                 var core = new AppInsightsCore();
                 var channel = new ChannelPlugin();
                 appInsights['_properties'] = <any>{
-                    context: { telemetryTrace: { traceID: 'not set'}}
+                    context: { telemetryTrace: { traceID: 'not set', name: 'name not set' } }
                 }
                 const trackPageViewStub = this.sandbox.stub(appInsights, 'trackPageView');
 
@@ -70,7 +70,9 @@ export class ApplicationInsightsTests extends TestClass {
                 // Assert
                 Assert.ok(trackPageViewStub.calledOnce);
                 Assert.ok(appInsights['_properties'].context.telemetryTrace.traceID);
+                Assert.ok(appInsights['_properties'].context.telemetryTrace.name);
                 Assert.notEqual(appInsights['_properties'].context.telemetryTrace.traceID, 'not set', 'current operation id is updated after route change');
+                Assert.notEqual(appInsights['_properties'].context.telemetryTrace.name, 'name not set', 'current operation name is updated after route change');
             }
         });
 
@@ -88,7 +90,7 @@ export class ApplicationInsightsTests extends TestClass {
                 appInsights['_properties'] = <any>{
                     context: { telemetryTrace: { traceID: 'not set'}}
                 }
-                const trackPageViewStub = this.sandbox.stub(appInsights, 'trackPageView');
+                this.sandbox.stub(appInsights, 'trackPageView');
 
                 // Act
                 core.initialize(<IConfig & IConfiguration>{

--- a/vNext/extensions/applicationinsights-analytics-js/package.json
+++ b/vNext/extensions/applicationinsights-analytics-js/package.json
@@ -17,6 +17,7 @@
         "test": "grunt aitests"
     },
     "devDependencies": {
+        "@microsoft/applicationinsights-properties-js": "2.0.1",
         "typescript": "2.5.3",
         "rollup-plugin-node-resolve": "^3.4.0",
         "rollup-plugin-replace": "^2.1.0",

--- a/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
+++ b/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
@@ -570,7 +570,9 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
         /**
          * Create a custom "locationchange" event which is triggered each time the history object is changed
          */
-        if (this.config.enableAutoRouteTracking === true && typeof history === "object" && typeof window === "object") {
+        if (this.config.enableAutoRouteTracking === true
+            && typeof history === "object" && typeof history.pushState === "function" && typeof history.replaceState === "function"
+            && typeof window === "object") {
             // Find the properties plugin
             extensions.forEach(extension => {
                 if (extension.identifier === PropertiesPluginIdentifier) {

--- a/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
+++ b/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
@@ -580,23 +580,23 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
 
             history.pushState = ( f => function pushState() {
                 var ret = f.apply(this, arguments);
-                window.dispatchEvent(new Event(config.namePrefix + "pushState"));
-                window.dispatchEvent(new Event(config.namePrefix + "locationchange"));
+                window.dispatchEvent(new Event(this.config.namePrefix + "pushState"));
+                window.dispatchEvent(new Event(this.config.namePrefix + "locationchange"));
                 return ret;
             })(history.pushState);
 
             history.replaceState = ( f => function replaceState(){
                 var ret = f.apply(this, arguments);
-                window.dispatchEvent(new Event(config.namePrefix + "replaceState"));
-                window.dispatchEvent(new Event(config.namePrefix + "locationchange"));
+                window.dispatchEvent(new Event(this.config.namePrefix + "replaceState"));
+                window.dispatchEvent(new Event(this.config.namePrefix + "locationchange"));
                 return ret;
             })(history.replaceState);
 
-            window.addEventListener(config.namePrefix + "popstate",()=>{
-                window.dispatchEvent(new Event(config.namePrefix + "locationchange"));
+            window.addEventListener(this.config.namePrefix + "popstate",()=>{
+                window.dispatchEvent(new Event(this.config.namePrefix + "locationchange"));
             });
 
-            window.addEventListener(config.namePrefix + "locationchange", () => {
+            window.addEventListener(this.config.namePrefix + "locationchange", () => {
                 if (this._properties) this._properties.context.telemetryTrace.traceID = Util.newId();
                 this.trackPageView({ name: window.location.pathname });
             });

--- a/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
+++ b/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
@@ -604,8 +604,9 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
             window.addEventListener(this.config.namePrefix + "locationchange", () => {
                 if (this._properties && this._properties.context && this._properties.context.telemetryTrace) {
                     this._properties.context.telemetryTrace.traceID = Util.newId();
+                    this._properties.context.telemetryTrace.name = window.location.pathname;
                 }
-                this.trackPageView({ name: window.location.pathname });
+                this.trackPageView({ measurements: { duration: 0 } }); // SPA route change loading durations are undefined, so send 0
             });
         }
 

--- a/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
+++ b/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
@@ -23,6 +23,9 @@ import { PageVisitTimeManager } from "./Telemetry/PageVisitTimeManager";
 import { PageViewPerformanceManager } from './Telemetry/PageViewPerformanceManager';
 import { ITelemetryConfig } from "../JavaScriptSDK.Interfaces/ITelemetryConfig";
 
+// For types only
+import * as properties from "@microsoft/applicationinsights-properties-js";
+
 "use strict";
 
 const durationProperty: string = "duration";
@@ -40,7 +43,7 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
     private _globalconfig: IConfiguration;
     private _eventTracking: Timing;
     private _pageTracking: Timing;
-    private _properties;
+    private _properties: properties.PropertiesPlugin;
     protected _nextPlugin: ITelemetryPlugin;
     protected _logger: IDiagnosticLogger; // Initialized by Core
     protected _telemetryInitializers: { (envelope: ITelemetryItem): boolean | void; }[]; // Internal telemetry initializers.
@@ -576,7 +579,7 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
             // Find the properties plugin
             extensions.forEach(extension => {
                 if (extension.identifier === PropertiesPluginIdentifier) {
-                    this._properties = extension;
+                    this._properties = extension as properties.PropertiesPlugin;
                 }
             });
 
@@ -599,7 +602,9 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
             });
 
             window.addEventListener(this.config.namePrefix + "locationchange", () => {
-                if (this._properties) this._properties.context.telemetryTrace.traceID = Util.newId();
+                if (this._properties && this._properties.context && this._properties.context.telemetryTrace) {
+                    this._properties.context.telemetryTrace.traceID = Util.newId();
+                }
                 this.trackPageView({ name: window.location.pathname });
             });
         }

--- a/vNext/shared/AppInsightsCommon/src/Interfaces/IConfig.ts
+++ b/vNext/shared/AppInsightsCommon/src/Interfaces/IConfig.ts
@@ -95,6 +95,13 @@ export interface IConfig {
     autoTrackPageVisitTime?: boolean;
 
     /**
+     * @description Automatically track route changes in Single Page Applications (SPA). If true, each route change will send a new Pageview to Application Insights.
+     * @type {boolean}
+     * @memberof IConfig
+     */
+    enableAutoRouteTracking?: boolean;
+
+    /**
      * @description If true, Ajax calls are not autocollected. Default is false
      * @type {boolean}
      * @memberof IConfig


### PR DESCRIPTION
Adds new off-by-default configuration `enableAutoRouteTracking`, which listens for changes in the `window.history` stack to trigger a new pageview/operation. Each listener forwards events to the catch-all `locationchange` event to actually track the new pageview.

All events are prefixed with `config.namePrefix`, so that multiple instances of the SDK do not duplicate pageview telemetry to each instance.

README changes can be uncommented when the feature is shipped