### PR TITLE
route tracking: track pageview after delay

### DIFF
--- a/vNext/extensions/applicationinsights-analytics-js/Tests/ApplicationInsights.tests.ts
+++ b/vNext/extensions/applicationinsights-analytics-js/Tests/ApplicationInsights.tests.ts
@@ -53,6 +53,7 @@ export class ApplicationInsightsTests extends TestClass {
             test: () => {
                 // Setup
                 var appInsights = new ApplicationInsights();
+                appInsights.autoRoutePVDelay = 500;
                 var core = new AppInsightsCore();
                 var channel = new ChannelPlugin();
                 appInsights['_properties'] = <any>{
@@ -66,6 +67,7 @@ export class ApplicationInsightsTests extends TestClass {
                     enableAutoRouteTracking: true
                 }, [appInsights, channel]);
                 window.dispatchEvent(new Event('locationchange'));
+                this.clock.tick(500);
 
                 // Assert
                 Assert.ok(trackPageViewStub.calledOnce);

--- a/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
+++ b/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
@@ -38,6 +38,7 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
     public config: IConfig;
     public core: IAppInsightsCore;
     public queue: (() => void)[];
+    public autoRoutePVDelay = 500; // ms; Time to wait after a route change before triggering a pageview to allow DOM changes to take place
 
     private _isInitialized: boolean = false;
     private _globalconfig: IConfiguration;
@@ -252,7 +253,7 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
      */
     public sendPageViewInternal(pageView: IPageViewTelemetryInternal, properties?: { [key: string]: any }, systemProperties?: { [key: string]: any }) {
         if (typeof document !== "undefined") {
-            pageView.refUri = pageView.refUri || document.referrer;
+            pageView.refUri = pageView.refUri === undefined ? document.referrer : pageView.refUri;
         }
 
         let telemetryItem = TelemetryItemCreator.create<IPageViewTelemetryInternal>(
@@ -607,7 +608,10 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
                     _self._properties.context.telemetryTrace.traceID = Util.newId();
                     _self._properties.context.telemetryTrace.name = window.location.pathname;
                 }
-                _self.trackPageView({ properties: { duration: 0 } }); // SPA route change loading durations are undefined, so send 0
+                setTimeout(() => {
+                    // todo: override start time so that it is not affected by autoRoutePVDelay
+                    _self.trackPageView({ refUri: null, properties: { duration: 0 } }); // SPA route change loading durations are undefined, so send 0
+                }, _self.autoRoutePVDelay);
             });
         }
 


### PR DESCRIPTION
- Nulls out the referrer uri on route changes instead of using `document.referrer`, which never changes SPAs (#969)
- Adds a configurable offset, default 500ms, to wait until calling trackPageView to give time for `window.title` and other DOM elements to update (#967)

#### New todos
https://github.com/microsoft/ApplicationInsights-JS/compare/markwolff/spa-route-changes?expand=1#diff-3a1cf06b58810f39d62ba7f728e6e3c7R612 (Related to #804)