### PR TITLE
Fixed a typo. `enable enable` -> `enable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Most configuration fields are named such that they can be defaulted to falsey. A
 
 ## Single Page Applications
 
-By default, this SDK will **not** handle state based route changing that occurs in single page applications. To enable enable automatic route change tracking for your single page application, you can add `enableAutoRouteTracking: true` to your setup configuration.
+By default, this SDK will **not** handle state based route changing that occurs in single page applications. To enable automatic route change tracking for your single page application, you can add `enableAutoRouteTracking: true` to your setup configuration.
 
 Currently, we support a separate [React plugin](#available-extensions-for-the-sdk) which you can initialize with this SDK. It will also accomplish route change tracking for you, as well as collect [other React specific telemetry](./vNext/extensions/applicationinsights-react-js).
 


### PR DESCRIPTION
## Changes
- Removed typo from documentation. `enable enable` -> `enable`