### PR TITLE
routes: add ie polyfill for Event constructor

### DIFF
--- a/vNext/extensions/applicationinsights-analytics-js/Tests/ApplicationInsights.tests.ts
+++ b/vNext/extensions/applicationinsights-analytics-js/Tests/ApplicationInsights.tests.ts
@@ -27,6 +27,17 @@ export class ApplicationInsightsTests extends TestClass {
 
     public registerTests() {
         this.testCase({
+            name: '_createDomEvent: creates new event if constructor is undefined',
+            test: () => {
+                const origEvent = (window as any).Event;
+                (window as any).Event = {};
+                const event = ApplicationInsights['_createDomEvent']('something');
+                Assert.equal('something', event.type);
+                (window as any).Event = origEvent;
+            }
+        });
+
+        this.testCase({
             name: 'enableAutoRouteTracking: event listener is added to the popstate event',
             test: () => {
                 // Setup
@@ -68,7 +79,7 @@ export class ApplicationInsightsTests extends TestClass {
                     instrumentationKey: '',
                     enableAutoRouteTracking: true
                 }, [appInsights, channel]);
-                window.dispatchEvent(new Event('locationchange'));
+                window.dispatchEvent(ApplicationInsights['_createDomEvent']('locationchange'));
                 this.clock.tick(500);
 
                 // Assert
@@ -102,11 +113,11 @@ export class ApplicationInsightsTests extends TestClass {
                     instrumentationKey: '',
                     enableAutoRouteTracking: true
                 }, [appInsights, channel]);
-                window.dispatchEvent(new Event('locationchange'));
+                window.dispatchEvent(ApplicationInsights['_createDomEvent']('locationchange'));
                 this.clock.tick(200);
 
                 // set up second dispatch
-                window.dispatchEvent(new Event('locationchange'));
+                window.dispatchEvent(ApplicationInsights['_createDomEvent']('locationchange'));
                 this.clock.tick(500);
 
 
@@ -145,7 +156,7 @@ export class ApplicationInsightsTests extends TestClass {
                     instrumentationKey: '',
                     enableAutoRouteTracking: true
                 }, [appInsights, channel]);
-                window.dispatchEvent(new Event('locationchange'));
+                window.dispatchEvent(ApplicationInsights['_createDomEvent']('locationchange'));
 
                 // Assert
                 Assert.ok(true, 'App does not crash when history object is incomplete');

--- a/vNext/extensions/applicationinsights-analytics-js/Tests/ApplicationInsights.tests.ts
+++ b/vNext/extensions/applicationinsights-analytics-js/Tests/ApplicationInsights.tests.ts
@@ -26,16 +26,6 @@ export class ApplicationInsightsTests extends TestClass {
     }
 
     public registerTests() {
-        this.testCase({
-            name: '_createDomEvent: creates new event if constructor is undefined',
-            test: () => {
-                const origEvent = (window as any).Event;
-                (window as any).Event = {};
-                const event = ApplicationInsights['_createDomEvent']('something');
-                Assert.equal('something', event.type);
-                (window as any).Event = origEvent;
-            }
-        });
 
         this.testCase({
             name: 'enableAutoRouteTracking: event listener is added to the popstate event',
@@ -79,7 +69,7 @@ export class ApplicationInsightsTests extends TestClass {
                     instrumentationKey: '',
                     enableAutoRouteTracking: true
                 }, [appInsights, channel]);
-                window.dispatchEvent(ApplicationInsights['_createDomEvent']('locationchange'));
+                window.dispatchEvent(Util.createDomEvent('locationchange'));
                 this.clock.tick(500);
 
                 // Assert
@@ -113,11 +103,11 @@ export class ApplicationInsightsTests extends TestClass {
                     instrumentationKey: '',
                     enableAutoRouteTracking: true
                 }, [appInsights, channel]);
-                window.dispatchEvent(ApplicationInsights['_createDomEvent']('locationchange'));
+                window.dispatchEvent(Util.createDomEvent('locationchange'));
                 this.clock.tick(200);
 
                 // set up second dispatch
-                window.dispatchEvent(ApplicationInsights['_createDomEvent']('locationchange'));
+                window.dispatchEvent(Util.createDomEvent('locationchange'));
                 this.clock.tick(500);
 
 
@@ -156,7 +146,7 @@ export class ApplicationInsightsTests extends TestClass {
                     instrumentationKey: '',
                     enableAutoRouteTracking: true
                 }, [appInsights, channel]);
-                window.dispatchEvent(ApplicationInsights['_createDomEvent']('locationchange'));
+                window.dispatchEvent(Util.createDomEvent('locationchange'));
 
                 // Assert
                 Assert.ok(true, 'App does not crash when history object is incomplete');

--- a/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
+++ b/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
@@ -92,18 +92,6 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
         return config;
     }
 
-    private static _createDomEvent(eventName: string): Event {
-        let event: Event = null;
-
-        if (typeof Event === "function") { // Use Event constructor when available
-            event = new Event(eventName);
-        } else { // Event has no constructor in IE
-            event = document.createEvent("Event");
-            event.initEvent(eventName, true, true);
-        }
-
-        return event;
-    }
 
     public processTelemetry(env: ITelemetryItem) {
         var doNotSendItem = false;
@@ -606,20 +594,20 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
 
             history.pushState = ( f => function pushState() {
                 var ret = f.apply(this, arguments);
-                window.dispatchEvent(ApplicationInsights._createDomEvent(_self.config.namePrefix + "pushState"));
-                window.dispatchEvent(ApplicationInsights._createDomEvent(_self.config.namePrefix + "locationchange"));
+                window.dispatchEvent(Util.createDomEvent(_self.config.namePrefix + "pushState"));
+                window.dispatchEvent(Util.createDomEvent(_self.config.namePrefix + "locationchange"));
                 return ret;
             })(history.pushState);
 
             history.replaceState = ( f => function replaceState(){
                 var ret = f.apply(this, arguments);
-                window.dispatchEvent(ApplicationInsights._createDomEvent(_self.config.namePrefix + "replaceState"));
-                window.dispatchEvent(ApplicationInsights._createDomEvent(_self.config.namePrefix + "locationchange"));
+                window.dispatchEvent(Util.createDomEvent(_self.config.namePrefix + "replaceState"));
+                window.dispatchEvent(Util.createDomEvent(_self.config.namePrefix + "locationchange"));
                 return ret;
             })(history.replaceState);
 
             window.addEventListener(_self.config.namePrefix + "popstate",()=>{
-                window.dispatchEvent(ApplicationInsights._createDomEvent(_self.config.namePrefix + "locationchange"));
+                window.dispatchEvent(Util.createDomEvent(_self.config.namePrefix + "locationchange"));
             });
 
             window.addEventListener(_self.config.namePrefix + "locationchange", () => {

--- a/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
+++ b/vNext/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
@@ -92,6 +92,19 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
         return config;
     }
 
+    private static _createDomEvent(eventName: string): Event {
+        let event: Event = null;
+
+        if (typeof Event === "function") { // Use Event constructor when available
+            event = new Event(eventName);
+        } else { // Event has no constructor in IE
+            event = document.createEvent("Event");
+            event.initEvent(eventName, true, true);
+        }
+
+        return event;
+    }
+
     public processTelemetry(env: ITelemetryItem) {
         var doNotSendItem = false;
         var telemetryInitializersCount = this._telemetryInitializers.length;
@@ -581,7 +594,8 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
          */
         if (this.config.enableAutoRouteTracking === true
             && typeof history === "object" && typeof history.pushState === "function" && typeof history.replaceState === "function"
-            && typeof window === "object") {
+            && typeof window === "object"
+            && typeof Event !== "undefined") {
             const _self = this;
             // Find the properties plugin
             extensions.forEach(extension => {
@@ -592,20 +606,20 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
 
             history.pushState = ( f => function pushState() {
                 var ret = f.apply(this, arguments);
-                window.dispatchEvent(new Event(_self.config.namePrefix + "pushState"));
-                window.dispatchEvent(new Event(_self.config.namePrefix + "locationchange"));
+                window.dispatchEvent(ApplicationInsights._createDomEvent(_self.config.namePrefix + "pushState"));
+                window.dispatchEvent(ApplicationInsights._createDomEvent(_self.config.namePrefix + "locationchange"));
                 return ret;
             })(history.pushState);
 
             history.replaceState = ( f => function replaceState(){
                 var ret = f.apply(this, arguments);
-                window.dispatchEvent(new Event(_self.config.namePrefix + "replaceState"));
-                window.dispatchEvent(new Event(_self.config.namePrefix + "locationchange"));
+                window.dispatchEvent(ApplicationInsights._createDomEvent(_self.config.namePrefix + "replaceState"));
+                window.dispatchEvent(ApplicationInsights._createDomEvent(_self.config.namePrefix + "locationchange"));
                 return ret;
             })(history.replaceState);
 
             window.addEventListener(_self.config.namePrefix + "popstate",()=>{
-                window.dispatchEvent(new Event(_self.config.namePrefix + "locationchange"));
+                window.dispatchEvent(ApplicationInsights._createDomEvent(_self.config.namePrefix + "locationchange"));
             });
 
             window.addEventListener(_self.config.namePrefix + "locationchange", () => {

--- a/vNext/shared/AppInsightsCommon/Tests/Util.tests.ts
+++ b/vNext/shared/AppInsightsCommon/Tests/Util.tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="./TestFramework/Common.ts" />
 
-import { UrlHelper, CorrelationIdHelper } from "../src/Util";
+import { UrlHelper, CorrelationIdHelper, Util } from "../src/Util";
 import { ICorrelationConfig } from "../src/Interfaces/ICorrelationConfig";
 
 export class UtilTests extends TestClass {
@@ -16,6 +16,17 @@ export class UtilTests extends TestClass {
     public testCleanup() {}
 
     public registerTests() {
+        this.testCase({
+            name: 'createDomEvent: creates new event if constructor is undefined',
+            test: () => {
+                const origEvent = (window as any).Event;
+                (window as any).Event = {};
+                const event = Util.createDomEvent('something');
+                Assert.equal('something', event.type);
+                (window as any).Event = origEvent;
+            }
+        });
+
         this.testCase({
             name: "UrlHelper: parseUrl should contain host field even if document.createElement is not defined",
             test: () => {

--- a/vNext/shared/AppInsightsCommon/src/Util.ts
+++ b/vNext/shared/AppInsightsCommon/src/Util.ts
@@ -20,6 +20,19 @@ export class Util {
     ];
     public static NotSpecified = "not_specified";
 
+    public static createDomEvent(eventName: string): Event {
+        let event: Event = null;
+
+        if (typeof Event === "function") { // Use Event constructor when available
+            event = new Event(eventName);
+        } else { // Event has no constructor in IE
+            event = document.createEvent("Event");
+            event.initEvent(eventName, true, true);
+        }
+
+        return event;
+    }
+
     /*
      * Force the SDK not to use local and session storage
     */


### PR DESCRIPTION
Fixes #998 

Adds analytics plugin polyfill for `new Event` so that it can be run in Ie