### PR TITLE
fix(rdd): parse correlationContext, if present

### DIFF
--- a/vNext/channels/applicationinsights-channel-js/Tests/Sender.tests.ts
+++ b/vNext/channels/applicationinsights-channel-js/Tests/Sender.tests.ts
@@ -406,7 +406,8 @@ export class SenderTests extends TestClass {
                         duration: 123,
                         type: 'Fetch',
                         data: 'some data',
-                        target: 'https://example.com/test/name'
+                        target: 'https://example.com/test/name?q=bar',
+                        correlationContext: "cid-v1:foo"
                     },
                     data: {
                         property1: "val1",
@@ -446,7 +447,7 @@ export class SenderTests extends TestClass {
                 Assert.equal(true, baseData.success);
                 Assert.equal(200, baseData.resultCode);
                 Assert.equal("Some name given", baseData.name);
-                Assert.equal("example.com", baseData.target);
+                Assert.equal("example.com| cid-v1:foo", baseData.target);
 
                 // Assert ver
                 Assert.ok(baseData.ver);

--- a/vNext/channels/applicationinsights-channel-js/src/EnvelopeCreator.ts
+++ b/vNext/channels/applicationinsights-channel-js/src/EnvelopeCreator.ts
@@ -256,8 +256,9 @@ export class DependencyEnvelopeCreator extends EnvelopeCreator {
         let success = bd.success;
         let resultCode = bd.responseCode;
         let requestAPI = bd.type;
+        let correlationContext = bd.correlationContext;
         let method = bd.properties && bd.properties[HttpMethod] ? bd.properties[HttpMethod] : "GET";
-        let baseData = new RemoteDependencyData(logger, id, absoluteUrl, command, duration, success, resultCode, method, requestAPI, customProperties, customMeasurements);
+        let baseData = new RemoteDependencyData(logger, id, absoluteUrl, command, duration, success, resultCode, method, requestAPI, correlationContext, customProperties, customMeasurements);
         let data = new Data<RemoteDependencyData>(RemoteDependencyData.dataType, baseData);
         return EnvelopeCreator.createEnvelope<RemoteDependencyData>(logger, RemoteDependencyData.envelopeType, telemetryItem, data);
     }

--- a/vNext/shared/AppInsightsCommon/src/Telemetry/RemoteDependencyData.ts
+++ b/vNext/shared/AppInsightsCommon/src/Telemetry/RemoteDependencyData.ts
@@ -42,7 +42,7 @@ export class RemoteDependencyData extends GeneratedRemoteDependencyData implemen
     /**
      * Constructs a new instance of the RemoteDependencyData object
      */
-    constructor(logger: IDiagnosticLogger, id: string, absoluteUrl: string, commandName: string, value: number, success: boolean, resultCode: number, method?: string, requestAPI: string = "Ajax", properties?: Object, measurements?: Object) {
+    constructor(logger: IDiagnosticLogger, id: string, absoluteUrl: string, commandName: string, value: number, success: boolean, resultCode: number, method?: string, requestAPI: string = "Ajax", correlationContext?: string, properties?: Object, measurements?: Object) {
         super();
 
         this.id = id;
@@ -56,6 +56,9 @@ export class RemoteDependencyData extends GeneratedRemoteDependencyData implemen
         var dependencyFields = AjaxHelper.ParseDependencyPath(logger, absoluteUrl, method, commandName);
         this.data = DataSanitizer.sanitizeUrl(logger, commandName) || dependencyFields.data; // get a value from hosturl if commandName not available
         this.target = DataSanitizer.sanitizeString(logger, dependencyFields.target);
+        if (correlationContext) {
+            this.target = `${this.target}| ${correlationContext}`;
+        }
         this.name = DataSanitizer.sanitizeString(logger, dependencyFields.name);
 
         this.properties = DataSanitizer.sanitizeProperties(logger, properties);


### PR DESCRIPTION
Parse currently unused `dependency.correlationContext` field and appends its value to `dependency.target` when envelope is constructed.

- Fixes #1019 