### PR TITLE
udpate pollInternalLogs method of core

### DIFF
--- a/vNext/shared/AppInsightsCore/src/JavaScriptSDK.Interfaces/IAppInsightsCore.ts
+++ b/vNext/shared/AppInsightsCore/src/JavaScriptSDK.Interfaces/IAppInsightsCore.ts
@@ -47,5 +47,5 @@ export interface IAppInsightsCore {
      */
     removeNotificationListener(listener: INotificationListener): void;
 
-    pollInternalLogs(intervalMS?: number, eventName?: string): number;
+    pollInternalLogs(eventName?: string): number;
 }

--- a/vNext/shared/AppInsightsCore/src/JavaScriptSDK.Interfaces/IAppInsightsCore.ts
+++ b/vNext/shared/AppInsightsCore/src/JavaScriptSDK.Interfaces/IAppInsightsCore.ts
@@ -47,5 +47,5 @@ export interface IAppInsightsCore {
      */
     removeNotificationListener(listener: INotificationListener): void;
 
-    pollInternalLogs(intervalMS?: number): number;
+    pollInternalLogs(intervalMS?: number, eventName?: string): number;
 }

--- a/vNext/shared/AppInsightsCore/src/JavaScriptSDK/AppInsightsCore.ts
+++ b/vNext/shared/AppInsightsCore/src/JavaScriptSDK/AppInsightsCore.ts
@@ -208,7 +208,7 @@ export class AppInsightsCore implements IAppInsightsCore {
     /**
      * Periodically check logger.queue for
      */
-    pollInternalLogs(): number {
+    pollInternalLogs(intervalMS?: number, eventName?: string): number {
         let interval = this.config.diagnosticLogInterval;
         if (!(interval > 0)) {
             interval = 10000;
@@ -219,7 +219,7 @@ export class AppInsightsCore implements IAppInsightsCore {
 
             queue.forEach((logMessage: _InternalLogMessage) => {
                 const item: ITelemetryItem = {
-                    name: "InternalMessageId: " + logMessage.messageId,
+                    name: eventName ? eventName : "InternalMessageId: " + logMessage.messageId,
                     iKey: this.config.instrumentationKey,
                     time: new Date().toISOString(),
                     baseType: _InternalLogMessage.dataType,

--- a/vNext/shared/AppInsightsCore/src/JavaScriptSDK/AppInsightsCore.ts
+++ b/vNext/shared/AppInsightsCore/src/JavaScriptSDK/AppInsightsCore.ts
@@ -208,7 +208,7 @@ export class AppInsightsCore implements IAppInsightsCore {
     /**
      * Periodically check logger.queue for
      */
-    pollInternalLogs(intervalMS?: number, eventName?: string): number {
+    pollInternalLogs(eventName?: string): number {
         let interval = this.config.diagnosticLogInterval;
         if (!(interval > 0)) {
             interval = 10000;


### PR DESCRIPTION
update this function interface so 1P can pass in a eventName to update the name filed of an item of MessageData type.