### PR TITLE
fix: force ver casting btwn cs 4.0 and cs 2.0

### DIFF
--- a/vNext/AISKU/Tests/TelemetryValidation/CommonValidator.ts
+++ b/vNext/AISKU/Tests/TelemetryValidation/CommonValidator.ts
@@ -11,6 +11,10 @@ export class CommonValidator implements ITypeValidator {
             return false;
         };
 
+        if (item.data.baseData.ver !== 2) {
+            return false;
+        }
+
         // verify item.data has baseType field
         if (!item.data.baseType) {
             return false;

--- a/vNext/AISKU/Tests/TelemetryValidation/ExceptionValidator.ts
+++ b/vNext/AISKU/Tests/TelemetryValidation/ExceptionValidator.ts
@@ -12,10 +12,15 @@ export class ExceptionValidator implements ITypeValidator {
         }
 
         // verify item has ver and exceptions fields
-        if (!item.data.baseData || 
-            !item.data.baseData.ver || 
+        if (!item.data.baseData ||
+            !item.data.baseData.ver ||
             !item.data.baseData.exceptions) {
             return false;
+        }
+
+        // Exception.ver should be a number for breeze channel, but a string in CS4.0
+        if (item.data.baseData.ver !== 2) {
+            return false; // not a valid breeze exception
         }
 
         if (!ExceptionValidator._validateExceptions(item.data.baseData.exceptions)) {
@@ -27,10 +32,10 @@ export class ExceptionValidator implements ITypeValidator {
 
     private static _validateExceptions(exceptions: any[]): boolean {
         // verify exceptions has typeName, message, hasFullStack, stack, parsedStack fields
-        if (!exceptions[0].typeName || 
-            !exceptions[0].message || 
-            !exceptions[0].hasFullStack || 
-            !exceptions[0].stack || 
+        if (!exceptions[0].typeName ||
+            !exceptions[0].message ||
+            !exceptions[0].hasFullStack ||
+            !exceptions[0].stack ||
             !exceptions[0].parsedStack) {
             return false;
         }

--- a/vNext/AISKU/Tests/applicationinsights.e2e.tests.ts
+++ b/vNext/AISKU/Tests/applicationinsights.e2e.tests.ts
@@ -71,6 +71,9 @@ export class ApplicationInsightsTests extends TestClass {
             });
             init.loadAppInsights();
             this._ai = init;
+            this._ai.addTelemetryInitializer((item: ITelemetryItem) => {
+                Assert.equal("4.0", item.ver, "Telemetry items inside telemetry initializers should be in CS4.0 format");
+            });
 
 
             // Setup Sinon stuff
@@ -706,7 +709,7 @@ export class ApplicationInsightsTests extends TestClass {
                         return PageViewPerformanceValidator.PageViewPerformanceValidator.Validate(payload, baseType);
                     case RemoteDependencyData.dataType:
                         return RemoteDepdencyValidator.RemoteDepdencyValidator.Validate(payload, baseType);
-        
+
                     default:
                         return EventValidator.EventValidator.Validate(payload, baseType);
                 }

--- a/vNext/extensions/applicationinsights-analytics-js/Tests/ApplicationInsights.tests.ts
+++ b/vNext/extensions/applicationinsights-analytics-js/Tests/ApplicationInsights.tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="./TestFramework/Common.ts" />
 
-import { Util, Exception, SeverityLevel, Trace, PageViewPerformance, PageView, IConfig } from "@microsoft/applicationinsights-common";
+import { Util, Exception, SeverityLevel, Trace, PageViewPerformance, IConfig, IExceptionInternal } from "@microsoft/applicationinsights-common";
 import {
     ITelemetryItem, AppInsightsCore,
     IPlugin, IConfiguration
@@ -360,6 +360,11 @@ export class ApplicationInsightsTests extends TestClass {
                 // Test
                 appInsights.trackException({error: new Error(), severityLevel: SeverityLevel.Critical});
                 Assert.ok(trackStub.calledOnce, "single exception is tracked");
+
+                // Verify ver is a string, as required by CS4.0
+                const baseData = (trackStub.args[0][0] as ITelemetryItem).baseData as IExceptionInternal;
+                Assert.equal("string", typeof baseData.ver, "Exception.ver should be a string for CS4.0");
+                Assert.equal("4.0", baseData.ver);
             }
         });
 

--- a/vNext/extensions/applicationinsights-dependencies-js/src/TraceParent.ts
+++ b/vNext/extensions/applicationinsights-dependencies-js/src/TraceParent.ts
@@ -1,7 +1,7 @@
 import { Util } from '@microsoft/applicationinsights-common';
 
 export class Traceparent {
-    private static DEFAULT_TRACE_FLAG = "00";
+    private static DEFAULT_TRACE_FLAG = "01";
     private static DEFAULT_VERSION = "00";
     public spanId: string;
     public traceFlag: string = Traceparent.DEFAULT_TRACE_FLAG;

--- a/vNext/shared/AppInsightsCommon/Tests/Exception.tests.ts
+++ b/vNext/shared/AppInsightsCommon/Tests/Exception.tests.ts
@@ -24,7 +24,8 @@ export class ExceptionTests extends TestClass {
                 var exceptionInterface: IExceptionInternal = exception.toInterface();
                 Assert.deepEqual(exception.id, exceptionInterface.id);
                 Assert.deepEqual(exception.problemGroup, exceptionInterface.problemGroup);
-                Assert.deepEqual(exception.ver, exceptionInterface.ver);
+                Assert.deepEqual("4.0", exceptionInterface.ver, "Default format expects CS4.0");
+                Assert.deepEqual(2, exception.ver, "Breeze format expects CS2.0");
                 Assert.deepEqual(exception.isManual, exceptionInterface.isManual);
                 Assert.deepEqual(exception.exceptions.map((exception: any) => exception.toInterface()), exceptionInterface.exceptions);
                 Assert.deepEqual(exception.severityLevel, exceptionInterface.severityLevel);

--- a/vNext/shared/AppInsightsCommon/src/Interfaces/IExceptionTelemetry.ts
+++ b/vNext/shared/AppInsightsCommon/src/Interfaces/IExceptionTelemetry.ts
@@ -95,7 +95,7 @@ export interface IAutoExceptionTelemetry {
 }
 
 export interface IExceptionInternal {
-    ver: number;
+    ver: string;
     id: string;
     exceptions: IExceptionDetailsInternal[];
     severityLevel?: SeverityLevel | number;

--- a/vNext/shared/AppInsightsCommon/src/Telemetry/Exception.ts
+++ b/vNext/shared/AppInsightsCommon/src/Telemetry/Exception.ts
@@ -10,7 +10,7 @@ import { FieldType } from '../Enums';
 import { SeverityLevel } from '../Interfaces/Contracts/Generated/SeverityLevel';
 import { Util } from '../Util';
 import { IDiagnosticLogger, CoreUtils } from '@microsoft/applicationinsights-core-js';
-import { IExceptionInternal, IExceptionTelemetry, IExceptionDetailsInternal, IExceptionStackFrameInternal } from '../Interfaces/IExceptionTelemetry';
+import { IExceptionInternal, IExceptionDetailsInternal, IExceptionStackFrameInternal } from '../Interfaces/IExceptionTelemetry';
 
 export class Exception extends ExceptionData implements ISerializable {
 
@@ -51,7 +51,7 @@ export class Exception extends ExceptionData implements ISerializable {
             if (exception.problemGroup) this.problemGroup = exception.problemGroup;
 
             // bool/int types, use isNullOrUndefined
-            if (!CoreUtils.isNullOrUndefined(exception.ver)) this.ver = exception.ver;
+            this.ver = 2; // TODO: handle the CS"4.0" ==> breeze 2 conversion in a better way
             if (!CoreUtils.isNullOrUndefined(exception.isManual)) this.isManual = exception.isManual;
         }
 
@@ -72,7 +72,7 @@ export class Exception extends ExceptionData implements ISerializable {
             || undefined;
 
         return <IExceptionInternal>{
-            ver: ver,
+            ver: "4.0", // TODO: handle the CS"4.0" ==> breeze 2 conversion in a better way
             exceptions: exceptionDetailsInterface,
             severityLevel,
             properties,


### PR DESCRIPTION
When used with app insights channel, SDK will convert `exception.ver: string = "4.0"` to `exception.ver: number = 2`. Currently it just force casts it between 4.0 and 2.0 since these are the only versions we care about. On updates to CS4.1, 5.0, etc these tests will fail as an alert.
/cc @hectorhdzg 