### PR TITLE
bug fix - give value to name & uri for pageViewPerformance event when…

### DIFF
--- a/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/Telemetry/PageViewManager.ts
+++ b/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/Telemetry/PageViewManager.ts
@@ -55,14 +55,14 @@ export class PageViewManager {
     * In all cases page view performance is sent once (only for the 1st call of trackPageView), or not sent if navigation timing is not supported.
     */
     public trackPageView(pageView: IPageViewTelemetry, customProperties?: { [key: string]: any }) {
-        const name = pageView.name;
+        let name = pageView.name;
         if (CoreUtils.isNullOrUndefined(name) || typeof name !== "string") {
-            pageView.name = window.document && window.document.title || "";
+            name = pageView.name = window.document && window.document.title || "";
         }
 
-        const uri = pageView.uri;
+        let uri = pageView.uri;
         if (CoreUtils.isNullOrUndefined(uri) || typeof uri !== "string") {
-            pageView.uri = window.location && window.location.href || "";
+            uri = pageView.uri = window.location && window.location.href || "";
         }
 
         // case 1a. if performance timing is not supported by the browser, send the page view telemetry with the duration provided by the user. If the user


### PR DESCRIPTION
… undefined