### PR TITLE
Added support for logging unhandled promise rejections

### DIFF
--- a/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
+++ b/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
@@ -593,14 +593,14 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
             !this.config.autoUnhandledPromiseInstrumented) {
             // We want to enable exception auto collection and it has not been done so yet
             const onunhandledrejection = "onunhandledrejection";
-            const originalOnUnhandledRejection = window[onunhandledrejection];
-            window.onunhandledrejection = (error: PromiseRejectionEvent) => {
-                const handled = originalOnUnhandledRejection && (originalOnUnhandledRejection.call(window, error) as any);
+            const originalOnUnhandledRejection = _window[onunhandledrejection];
+            _window.onunhandledrejection = (error: PromiseRejectionEvent) => {
+                const handled = originalOnUnhandledRejection && (originalOnUnhandledRejection.call(_window, error) as any);
                 if (handled !== true) { // handled could be typeof function
                     instance._onerror({
                         message: error.reason.toString(),
                         error: error.reason instanceof Error ? error.reason : new Error(error.reason.toString()),
-                        url: window.location.href,
+                        url: _window.location.href,
                         lineNumber: 0,
                         columnNumber: 0
                     });

--- a/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
+++ b/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
@@ -590,7 +590,7 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
         }
 
         if (this.config.disableExceptionTracking === false &&
-            !this.config.autoUnhandledPromiseInstrumented) {
+            !this.config.autoUnhandledPromiseInstrumented && _window) {
             // We want to enable exception auto collection and it has not been done so yet
             const onunhandledrejection = "onunhandledrejection";
             const originalOnUnhandledRejection = _window[onunhandledrejection];

--- a/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
+++ b/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
@@ -27,6 +27,10 @@ import * as properties from "@microsoft/applicationinsights-properties-js";
 
 "use strict";
 
+declare global {
+    interface Window { onunhandledrejection: ((this: Window, ev: PromiseRejectionEvent) => any) | null; }
+}
+
 const durationProperty: string = "duration";
 
 export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IAppInsightsInternal {
@@ -594,8 +598,11 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
                 const handled = originalOnUnhandledRejection && (originalOnUnhandledRejection.call(window, error) as any);
                 if (handled !== true) { // handled could be typeof function
                     instance._onerror({
-                        reason: error.reason,
-                        error
+                        message: error.reason.toString(),
+                        error: error.reason instanceof Error ? error.reason : new Error(error.reason.toString()),
+                        url: window.location.href,
+                        lineNumber: 0,
+                        columnNumber: 0
                     });
                 }
 

--- a/shared/AppInsightsCommon/src/Interfaces/IConfig.ts
+++ b/shared/AppInsightsCommon/src/Interfaces/IConfig.ts
@@ -312,6 +312,14 @@ export interface IConfig {
      */
     autoExceptionInstrumented?: boolean;
     correlationHeaderDomains?: string[]
+
+    /**
+     * @ignore
+     * @description Internal only
+     * @type {boolean}
+     * @memberof IConfig
+     */
+    autoUnhandledPromiseInstrumented?: boolean;
 }
 
 export class ConfigurationManager {


### PR DESCRIPTION
- New global handled for unhandledrejection, similar to onerror
- New config property to test for

Addresses #1013

Replaced #1069 