### PR TITLE
chore: bump to use latest RNDI package

### DIFF
--- a/extensions/applicationinsights-react-native/Tests/tsconfig.json
+++ b/extensions/applicationinsights-react-native/Tests/tsconfig.json
@@ -7,7 +7,8 @@
         "moduleResolution": "Node",
         "target": "es5",
         "alwaysStrict": true,
-        "declaration": true
-    },
-    "files": []
+        "declaration": true,
+        "outFile": "./Selenium/reactnativeplugin.tests.js"
+      },
+      "include": ["Selenium/**/*.ts"],
 }

--- a/extensions/applicationinsights-react-native/package.json
+++ b/extensions/applicationinsights-react-native/package.json
@@ -40,7 +40,7 @@
     },
     "peerDependencies": {
         "react-native": "*",
-        "react-native-device-info": "^3.1.4"
+        "react-native-device-info": "^4.0.1"
     },
     "license": "MIT"
 }

--- a/extensions/applicationinsights-react-native/package.json
+++ b/extensions/applicationinsights-react-native/package.json
@@ -12,13 +12,14 @@
     "scripts": {
         "prepublishOnly": "npm run build",
         "build": "npm run build:esm && npm run build:browser",
-        "build:esm": "grunt reactnative",
+        "build:esm": "tsc -p tsconfig.json",
+        "build:test": "tsc -p Tests/tsconfig.json",
         "build:browser": "echo \"No browser version\"",
-        "test": "grunt reactnativetests",
+        "test": "npm run build:test && grunt reactnativetests",
         "lint": "tslint -p tsconfig.json"
     },
     "devDependencies": {
-        "typescript": "2.5.3",
+        "typescript": "^3.6.4",
         "grunt": "1.0.1",
         "grunt-contrib-qunit": "2.0.0",
         "grunt-contrib-uglify": "3.1.0",
@@ -27,11 +28,12 @@
         "rollup-plugin-replace": "^2.1.0",
         "rollup-plugin-uglify": "^6.0.0",
         "rollup": "^0.66.0",
-        "react-native-device-info": "^3.1.4",
+        "react-native-device-info": "^4.0.1",
         "react-native": "0.59.8",
         "react": "16.8.3",
         "tslint": "^5.19.0",
-        "tslint-config-prettier": "^1.18.0"
+        "tslint-config-prettier": "^1.18.0",
+        "qunit": "^2.9.3"
     },
     "dependencies": {
         "@microsoft/applicationinsights-core-js": "^2.2.4",

--- a/extensions/applicationinsights-react-native/src/ReactNativePlugin.ts
+++ b/extensions/applicationinsights-react-native/src/ReactNativePlugin.ts
@@ -79,9 +79,9 @@ export class ReactNativePlugin implements ITelemetryPlugin {
      * Automatically collects native device info for this device
      */
     private _collectDeviceInfo() {
-        this._device.deviceClass = DeviceInfo.getDeviceTypeSync();
-        this._device.id = DeviceInfo.getUniqueIdSync(); // Installation ID
-        this._device.model = DeviceInfo.getModelSync();
+        this._device.deviceClass = DeviceInfo.getDeviceType();
+        this._device.id = DeviceInfo.getUniqueId(); // Installation ID
+        this._device.model = DeviceInfo.getModel();
     }
 
     private _applyDeviceContext(item: ITelemetryItem) {

--- a/extensions/applicationinsights-react-native/src/ReactNativePlugin.ts
+++ b/extensions/applicationinsights-react-native/src/ReactNativePlugin.ts
@@ -79,7 +79,7 @@ export class ReactNativePlugin implements ITelemetryPlugin {
      * Automatically collects native device info for this device
      */
     private _collectDeviceInfo() {
-        this._device.deviceClass = DeviceInfo.getDeviceType();
+        this._device.deviceClass = DeviceInfo.getDeviceTypeSync();
         this._device.id = DeviceInfo.getUniqueId(); // Installation ID
         this._device.model = DeviceInfo.getModel();
     }

--- a/extensions/applicationinsights-react-native/tsconfig.json
+++ b/extensions/applicationinsights-react-native/tsconfig.json
@@ -13,9 +13,9 @@
     "noEmitHelpers": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
-    "declarationDir": "extensions/applicationinsights-react-native/dist-esm",
+    "declarationDir": "dist-esm",
     "outDir": "dist-esm",
-    "rootDir": "extensions/applicationinsights-react-native/src"
+    "rootDir": "src"
   },
   "include": [
     "./src/**/*.ts"

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -364,7 +364,7 @@ module.exports = function (grunt) {
     grunt.registerTask("react", ["ts:react"]);
     grunt.registerTask("reacttests", ["run:reacttests"]);
     grunt.registerTask("reactnative", ["ts:reactnative"]);
-    grunt.registerTask("reactnativetests", ["ts:reactnative", "ts:reactnativetests", "qunit:reactnative"]);
+    grunt.registerTask("reactnativetests", ["qunit:reactnative"]);
     grunt.registerTask("deps", ["ts:deps"]);
     grunt.registerTask("depstest", ["ts:deps", "ts:depstest", "qunit:deps"]);
     grunt.registerTask("aichannel", ["ts:aichannel"]);


### PR DESCRIPTION
Update RN plugin to use latest [device info version](https://github.com/react-native-community/react-native-device-info/wiki/V3-to-V4-Migration-Guide).