### PR TITLE
Enable and maintain compatibility for older browsers including IE8 #1075

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,3 +253,4 @@ package-deps.json
 aicore.tests.js*
 aicore.tests.d.ts
 ai.tests.d.ts
+/.vs

--- a/AISKU/rollup.config.js
+++ b/AISKU/rollup.config.js
@@ -39,6 +39,7 @@ const browserRollupConfigFactory = (isProduction, libVersion = '2') => {
     browserRollupConfig.output.file = `browser/ai.${libVersion}.min.js`;
     browserRollupConfig.plugins.push(
       uglify({
+        ie8: true,
         output: {
           preamble: banner
         }
@@ -75,6 +76,7 @@ const nodeUmdRollupConfigFactory = (isProduction) => {
     nodeRollupConfig.output.file = `dist/applicationinsights-web.min.js`;
     nodeRollupConfig.plugins.push(
       uglify({
+        ie8: true,
         output: {
           preamble: banner
         }

--- a/AISKU/src/Initialization.ts
+++ b/AISKU/src/Initialization.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { IConfiguration, AppInsightsCore, IAppInsightsCore, LoggingSeverity, _InternalMessageId, ITelemetryItem, ICustomProperties, IChannelControls } from "@microsoft/applicationinsights-core-js";
+import { CoreUtils, IConfiguration, AppInsightsCore, IAppInsightsCore, LoggingSeverity, _InternalMessageId, ITelemetryItem, ICustomProperties, IChannelControls } from "@microsoft/applicationinsights-core-js";
 import { ApplicationInsights } from "@microsoft/applicationinsights-analytics-js";
 import { Util, IConfig, IDependencyTelemetry, IPageViewPerformanceTelemetry,IPropertiesPlugin,
         IPageViewTelemetry, IExceptionTelemetry, IAutoExceptionTelemetry, ITraceTelemetry, ITelemetryContext,
@@ -230,8 +230,8 @@ export class Initialization implements IApplicationInsights {
      * @memberof Initialization
      */
     public flush(async: boolean = true) {
-        this.core.getTransmissionControls().forEach(channels => {
-            channels.forEach(channel => {
+        CoreUtils.arrForEach(this.core.getTransmissionControls(), channels => {
+            CoreUtils.arrForEach(channels, channel => {
                 channel.flush(async);
             })
         })
@@ -244,8 +244,8 @@ export class Initialization implements IApplicationInsights {
      * @memberof Initialization
      */
     public onunloadFlush(async: boolean = true) {
-        this.core.getTransmissionControls().forEach(channels => {
-            channels.forEach((channel: IChannelControls & Sender) => {
+        CoreUtils.arrForEach(this.core.getTransmissionControls(), channels => {
+            CoreUtils.arrForEach(channels, (channel: IChannelControls & Sender) => {
                 if (channel.onunloadFlush) {
                     channel.onunloadFlush();
                 } else {

--- a/AISKU/tsconfig.json
+++ b/AISKU/tsconfig.json
@@ -4,7 +4,7 @@
     "inlineSources": true,
     "noImplicitAny": false,
     "module": "es6",
-    "target": "es5",
+    "target": "es3",
     "moduleResolution": "Node",
     "alwaysStrict": true,
     "suppressImplicitAnyIndexErrors": true,

--- a/AISKULight/index.ts
+++ b/AISKULight/index.ts
@@ -78,8 +78,8 @@ export class ApplicationInsights {
      * @memberof ApplicationInsights
      */
     public flush(async: boolean = true) {
-        this.core.getTransmissionControls().forEach(controls => {
-            controls.forEach(plugin => {
+        CoreUtils.arrForEach(this.core.getTransmissionControls(), controls => {
+            CoreUtils.arrForEach(controls, plugin => {
                 async
                     ? (plugin as Sender).flush()
                     : (plugin as Sender).triggerSend(async);

--- a/AISKULight/rollup.config.js
+++ b/AISKULight/rollup.config.js
@@ -39,6 +39,7 @@ const browserRollupConfigFactory = (isProduction, libV = '2') => {
     browserRollupConfig.output.file = `browser/aib.${libV}.min.js`;
     browserRollupConfig.plugins.push(
       uglify({
+        ie8: true,
         output: {
           preamble: banner
         }
@@ -75,6 +76,7 @@ const nodeUmdRollupConfigFactory = (isProduction) => {
     nodeRollupConfig.output.file = `dist/applicationinsights-web-basic.min.js`;
     nodeRollupConfig.plugins.push(
       uglify({
+        ie8: true,
         output: {
           preamble: banner
         }

--- a/AISKULight/tsconfig.json
+++ b/AISKULight/tsconfig.json
@@ -4,7 +4,7 @@
     "inlineSources": true,
     "noImplicitAny": false,
     "module": "es6",
-    "target": "es5",
+    "target": "es3",
     "moduleResolution": "Node",
     "alwaysStrict": true,
     "suppressImplicitAnyIndexErrors": true,

--- a/channels/applicationinsights-channel-js/rollup.config.js
+++ b/channels/applicationinsights-channel-js/rollup.config.js
@@ -40,6 +40,7 @@ const browserRollupConfigFactory = isProduction => {
     browserRollupConfig.output.file = "browser/applicationinsights-channel-js.min.js";
     browserRollupConfig.plugins.push(
       uglify({
+        ie8: true,
         output: {
           preamble: banner
         }
@@ -76,6 +77,7 @@ const nodeUmdRollupConfigFactory = (isProduction) => {
     nodeRollupConfig.output.file = `dist/${outputName}.min.js`;
     nodeRollupConfig.plugins.push(
       uglify({
+        ie8: true,
         output: {
           preamble: banner
         }

--- a/channels/applicationinsights-channel-js/src/EnvelopeCreator.ts
+++ b/channels/applicationinsights-channel-js/src/EnvelopeCreator.ts
@@ -194,8 +194,8 @@ export abstract class EnvelopeCreator {
         // deals with tags.push({object})
         for(let i = item.tags.length - 1; i >= 0; i--){
             const tg = item.tags[i];
-            // Object.keys returns an array of keys
-            Object.keys(tg).forEach(key => {
+            // CoreUtils.objKeys returns an array of keys
+            CoreUtils.arrForEach(CoreUtils.objKeys(tg), key => {
                 tgs[key] = tg[key];
             })
             item.tags.splice(i, 1);

--- a/channels/applicationinsights-channel-js/src/Sender.ts
+++ b/channels/applicationinsights-channel-js/src/Sender.ts
@@ -277,7 +277,7 @@ export class Sender implements IChannelControlsAI {
             let doNotSendItem = false;
             // this is for running in legacy mode, where customer may already have a custom initializer present
             if (telemetryItem.tags && telemetryItem.tags[ProcessLegacy]) {
-                telemetryItem.tags[ProcessLegacy].forEach((callBack: (env: IEnvelope) => boolean | void) => {
+                CoreUtils.arrForEach(telemetryItem.tags[ProcessLegacy], (callBack: (env: IEnvelope) => boolean | void) => {
                     try {
                         if (callBack && callBack(aiEnvelope) === false) {
                             doNotSendItem = true;

--- a/channels/applicationinsights-channel-js/tsconfig.json
+++ b/channels/applicationinsights-channel-js/tsconfig.json
@@ -5,7 +5,7 @@
     "noImplicitAny": false,
     "module": "es6",
     "moduleResolution": "Node",
-    "target": "es5",
+    "target": "es3",
     "alwaysStrict": true,
     "suppressImplicitAnyIndexErrors": true,
     "allowSyntheticDefaultImports": true,

--- a/extensions/applicationinsights-analytics-js/rollup.config.js
+++ b/extensions/applicationinsights-analytics-js/rollup.config.js
@@ -40,6 +40,7 @@ const browserRollupConfigFactory = isProduction => {
     browserRollupConfig.output.file = `browser/${outputName}.min.js`;
     browserRollupConfig.plugins.push(
       uglify({
+        ie8: true,
         output: {
           preamble: banner
         }
@@ -76,6 +77,7 @@ const nodeUmdRollupConfigFactory = (isProduction) => {
     nodeRollupConfig.output.file = `dist/${outputName}.min.js`;
     nodeRollupConfig.plugins.push(
       uglify({
+        ie8: true,
         output: {
           preamble: banner
         }

--- a/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
+++ b/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
@@ -585,7 +585,7 @@ export class ApplicationInsights implements IAppInsights, ITelemetryPlugin, IApp
             && typeof Event !== "undefined") {
             const _self = this;
             // Find the properties plugin
-            extensions.forEach(extension => {
+            CoreUtils.arrForEach(extensions, extension => {
                 if (extension.identifier === PropertiesPluginIdentifier) {
                     this._properties = extension as properties.PropertiesPlugin;
                 }

--- a/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/Telemetry/PageViewManager.ts
+++ b/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/Telemetry/PageViewManager.ts
@@ -73,7 +73,7 @@ export class PageViewManager {
                 pageView,
                 customProperties
             );
-            this._channel().forEach(queues => { queues.forEach(q => q.flush(true)) })
+            CoreUtils.arrForEach(this._channel(), queues => { CoreUtils.arrForEach(queues, q => q.flush(true)) })
 
             // no navigation timing (IE 8, iOS Safari 8.4, Opera Mini 8 - see http://caniuse.com/#feat=nav-timing)
             this._logger.throwInternal(
@@ -115,7 +115,7 @@ export class PageViewManager {
                 pageView,
                 customProperties
             );
-            this._channel().forEach(queues => { queues.forEach(q => q.flush(true)) })
+            CoreUtils.arrForEach(this._channel(), queues => { CoreUtils.arrForEach(queues, q => q.flush(true)) })
             pageViewSent = true;
         }
 
@@ -141,7 +141,7 @@ export class PageViewManager {
                         this.appInsights.sendPageViewInternal(
                             pageView,
                             customProperties);
-                        this._channel().forEach(queues => { queues.forEach(q => q.flush(true)) })
+                            CoreUtils.arrForEach(this._channel(), queues => { CoreUtils.arrForEach(queues, q => q.flush(true)) })
                     } else {
                         if (!pageViewSent) {
                             customProperties["duration"] = pageViewPerformance.durationMs;
@@ -154,7 +154,7 @@ export class PageViewManager {
                             this.appInsights.sendPageViewPerformanceInternal(pageViewPerformance, customProperties);
                             this.pageViewPerformanceSent = true;
                         }
-                        this._channel().forEach(queues => { queues.forEach(q => q.flush(true)) })
+                        CoreUtils.arrForEach(this._channel(), queues => { CoreUtils.arrForEach(queues, q => q.flush(true)) })
                     }
                 } else if (DateTimeUtils.GetDuration(start, +new Date) > maxDurationLimit) {
                     // if performance timings are not ready but we exceeded the maximum duration limit, just log a page view telemetry
@@ -166,7 +166,7 @@ export class PageViewManager {
                             pageView,
                             customProperties
                         );
-                        this._channel().forEach(queues => { queues.forEach(q => q.flush(true)) })
+                        CoreUtils.arrForEach(this._channel(), queues => { CoreUtils.arrForEach(queues, q => q.flush(true)) })
                     }
                 }
             } catch (e) {

--- a/extensions/applicationinsights-analytics-js/tsconfig.json
+++ b/extensions/applicationinsights-analytics-js/tsconfig.json
@@ -5,7 +5,7 @@
     "noImplicitAny": false,
     "module": "es6",
     "moduleResolution": "Node",
-    "target": "es5",
+    "target": "es3",
     "alwaysStrict": true,
     "suppressImplicitAnyIndexErrors": true,
     "allowSyntheticDefaultImports": true,

--- a/extensions/applicationinsights-angular-js/src/AngularPlugin.ts
+++ b/extensions/applicationinsights-angular-js/src/AngularPlugin.ts
@@ -28,7 +28,7 @@ export default class AngularPlugin implements ITelemetryPlugin {
                 ? (config.extensionConfig[this.identifier] as IAngularExtensionConfig)
                 : { router: null };
         this._logger = core.logger;
-        extensions.forEach(ext => {
+        CoreUtils.arrForEach(extensions, ext => {
             const identifier = (ext as ITelemetryPlugin).identifier;
             if (identifier === 'ApplicationInsightsAnalytics') {
                 this._analyticsPlugin = (ext as any) as IAppInsights;

--- a/extensions/applicationinsights-dependencies-js/rollup.config.js
+++ b/extensions/applicationinsights-dependencies-js/rollup.config.js
@@ -40,6 +40,7 @@ const browserRollupConfigFactory = isProduction => {
     browserRollupConfig.output.file = `browser/${outputName}.min.js`;
     browserRollupConfig.plugins.push(
       uglify({
+        ie8: true,
         output: {
           preamble: banner
         }
@@ -76,6 +77,7 @@ const nodeUmdRollupConfigFactory = (isProduction) => {
     nodeRollupConfig.output.file = `dist/${outputName}.min.js`;
     nodeRollupConfig.plugins.push(
       uglify({
+        ie8: true,
         output: {
           preamble: banner
         }

--- a/extensions/applicationinsights-dependencies-js/src/ajax.ts
+++ b/extensions/applicationinsights-dependencies-js/src/ajax.ts
@@ -521,7 +521,7 @@ export class AjaxMonitor implements ITelemetryPlugin, IDependenciesPlugin, IInst
             }
 
             if (this._config.enableRequestHeaderTracking) {
-                if (Object.keys(xhr.ajaxData.requestHeaders).length > 0) {
+                if (CoreUtils.objKeys(xhr.ajaxData.requestHeaders).length > 0) {
                     dependency.properties = dependency.properties || {};
                     dependency.properties.requestHeaders = {};
                     dependency.properties.requestHeaders = xhr.ajaxData.requestHeaders;
@@ -535,13 +535,13 @@ export class AjaxMonitor implements ITelemetryPlugin, IDependenciesPlugin, IInst
                     // the regex converts the header string into an array of individual headers
                     const arr = headers.trim().split(/[\r\n]+/);
                     const responseHeaderMap = {};
-                    arr.forEach((line) => {
+                    CoreUtils.arrForEach(arr, (line) => {
                         const parts = line.split(': ');
                         const header = parts.shift();
                         const value = parts.join(': ');
                         responseHeaderMap[header] = value;
                     });
-                    if (Object.keys(responseHeaderMap).length > 0) {
+                    if (CoreUtils.objKeys(responseHeaderMap).length > 0) {
                         dependency.properties = dependency.properties || {};
                         dependency.properties.responseHeaders = {};
                         dependency.properties.responseHeaders = responseHeaderMap;
@@ -678,7 +678,7 @@ export class AjaxMonitor implements ITelemetryPlugin, IDependenciesPlugin, IInst
                 }
 
                 if (this._config.enableRequestHeaderTracking) {
-                    if (Object.keys(ajaxData.requestHeaders).length > 0) {
+                    if (CoreUtils.objKeys(ajaxData.requestHeaders).length > 0) {
                         dependency.properties = dependency.properties || {};
                         dependency.properties.requestHeaders = ajaxData.requestHeaders;
                     }               
@@ -689,7 +689,7 @@ export class AjaxMonitor implements ITelemetryPlugin, IDependenciesPlugin, IInst
                     response.headers.forEach((value, name) => {
                         responseHeaderMap[name] = value;
                     });
-                    if (Object.keys(responseHeaderMap).length > 0) {
+                    if (CoreUtils.objKeys(responseHeaderMap).length > 0) {
                         dependency.properties = dependency.properties || {};
                         dependency.properties.responseHeaders = responseHeaderMap;
                     }

--- a/extensions/applicationinsights-dependencies-js/tsconfig.json
+++ b/extensions/applicationinsights-dependencies-js/tsconfig.json
@@ -5,7 +5,7 @@
     "noImplicitAny": false,
     "module": "es6",
     "moduleResolution": "Node",
-    "target": "es5",
+    "target": "es3",
     "alwaysStrict": true,
     "suppressImplicitAnyIndexErrors": true,
     "allowSyntheticDefaultImports": true,

--- a/extensions/applicationinsights-properties-js/rollup.config.js
+++ b/extensions/applicationinsights-properties-js/rollup.config.js
@@ -40,6 +40,7 @@ const browserRollupConfigFactory = isProduction => {
     browserRollupConfig.output.file = `browser/${outputName}.min.js`;
     browserRollupConfig.plugins.push(
       uglify({
+        ie8: true,
         output: {
           preamble: banner
         }
@@ -76,6 +77,7 @@ const nodeUmdRollupConfigFactory = (isProduction) => {
     nodeRollupConfig.output.file = `dist/${outputName}.min.js`;
     nodeRollupConfig.plugins.push(
       uglify({
+        ie8: true,
         output: {
           preamble: banner
         }

--- a/extensions/applicationinsights-properties-js/src/Context/User.ts
+++ b/extensions/applicationinsights-properties-js/src/Context/User.ts
@@ -3,7 +3,7 @@
 
 import { ITelemetryConfig } from '../Interfaces/ITelemetryConfig';
 import { Util, IUser } from '@microsoft/applicationinsights-common';
-import { IDiagnosticLogger, _InternalMessageId, LoggingSeverity } from '@microsoft/applicationinsights-core-js';
+import { IDiagnosticLogger, _InternalMessageId, LoggingSeverity, CoreUtils } from '@microsoft/applicationinsights-core-js';
 
 export class User implements IUser {
 
@@ -63,7 +63,7 @@ export class User implements IUser {
         if (!this.id) {
             this.id = Util.newId();
             const date = new Date();
-            const acqStr = Util.toISOStringForIE8(date);
+            const acqStr = CoreUtils.toISOString(date);
             this.accountAcquisitionDate = acqStr;
             this.isNewUser = true;
             // without expiration, cookies expire at the end of the session

--- a/extensions/applicationinsights-properties-js/src/TelemetryContext.ts
+++ b/extensions/applicationinsights-properties-js/src/TelemetryContext.ts
@@ -3,7 +3,7 @@
  * @copyright Microsoft 2018
  */
 
-import { ITelemetryItem, IDiagnosticLogger } from '@microsoft/applicationinsights-core-js';
+import { ITelemetryItem, IDiagnosticLogger, CoreUtils } from '@microsoft/applicationinsights-core-js';
 import { Session, _SessionManager } from './Context/Session';
 import { Extensions, ITelemetryContext, IOperatingSystem, ITelemetryTrace, IWeb, SampleRate, CtxTagKeys } from '@microsoft/applicationinsights-common';
 import { Application } from './Context/Application';
@@ -168,22 +168,22 @@ export class TelemetryContext implements ITelemetryContext {
     }
 
     public cleanUp(event:ITelemetryItem) {
-        if (event.ext[Extensions.DeviceExt] && Object.keys(event.ext[Extensions.DeviceExt]).length === 0) {
+        if (event.ext[Extensions.DeviceExt] && CoreUtils.objKeys(event.ext[Extensions.DeviceExt]).length === 0) {
             delete event.ext[Extensions.DeviceExt];
         }
-        if (event.ext[Extensions.UserExt] && Object.keys(event.ext[Extensions.UserExt]).length === 0) {
+        if (event.ext[Extensions.UserExt] && CoreUtils.objKeys(event.ext[Extensions.UserExt]).length === 0) {
             delete event.ext[Extensions.UserExt];
         }
-        if (event.ext[Extensions.WebExt] && Object.keys(event.ext[Extensions.WebExt]).length === 0) {
+        if (event.ext[Extensions.WebExt] && CoreUtils.objKeys(event.ext[Extensions.WebExt]).length === 0) {
             delete event.ext[Extensions.WebExt];
         }
-        if (event.ext[Extensions.OSExt] && Object.keys(event.ext[Extensions.OSExt]).length === 0) {
+        if (event.ext[Extensions.OSExt] && CoreUtils.objKeys(event.ext[Extensions.OSExt]).length === 0) {
             delete event.ext[Extensions.OSExt];
         }
-        if (event.ext[Extensions.AppExt] && Object.keys(event.ext[Extensions.AppExt]).length === 0) {
+        if (event.ext[Extensions.AppExt] && CoreUtils.objKeys(event.ext[Extensions.AppExt]).length === 0) {
             delete event.ext[Extensions.AppExt];
         }
-        if (event.ext[Extensions.TraceExt] && Object.keys(event.ext[Extensions.TraceExt]).length === 0) {
+        if (event.ext[Extensions.TraceExt] && CoreUtils.objKeys(event.ext[Extensions.TraceExt]).length === 0) {
             delete event.ext[Extensions.TraceExt];
         }
     }

--- a/extensions/applicationinsights-properties-js/tsconfig.json
+++ b/extensions/applicationinsights-properties-js/tsconfig.json
@@ -5,7 +5,7 @@
     "noImplicitAny": false,
     "module": "es6",
     "moduleResolution": "Node",
-    "target": "es5",
+    "target": "es3",
     "alwaysStrict": true,
     "suppressImplicitAnyIndexErrors": true,
     "allowSyntheticDefaultImports": true,

--- a/extensions/applicationinsights-react-js/rollup.config.js
+++ b/extensions/applicationinsights-react-js/rollup.config.js
@@ -47,6 +47,7 @@ const browserRollupConfigFactory = isProduction => {
     browserRollupConfig.output.file = `browser/${outputName}.min.js`;
     browserRollupConfig.plugins.push(
       uglify({
+        ie8: true,
         output: {
           preamble: banner
         }
@@ -89,6 +90,7 @@ const nodeUmdRollupConfigFactory = (isProduction) => {
     nodeRollupConfig.output.file = `dist/${outputName}.min.js`;
     nodeRollupConfig.plugins.push(
       uglify({
+        ie8: true,
         output: {
           preamble: banner
         }

--- a/extensions/applicationinsights-react-js/src/ReactPlugin.ts
+++ b/extensions/applicationinsights-react-js/src/ReactPlugin.ts
@@ -29,7 +29,7 @@ export default class ReactPlugin implements ITelemetryPlugin {
                 ? (config.extensionConfig[this.identifier] as IReactExtensionConfig)
                 : { history: null };
         this._logger = core.logger;
-        extensions.forEach(ext => {
+        CoreUtils.arrForEach(extensions, ext => {
             const identifier = (ext as ITelemetryPlugin).identifier;
             if (identifier === 'ApplicationInsightsAnalytics') {
                 this._analyticsPlugin = (ext as any) as IAppInsights;

--- a/extensions/applicationinsights-react-js/test/tsconfig.json
+++ b/extensions/applicationinsights-react-js/test/tsconfig.json
@@ -8,7 +8,8 @@
         "target": "es5",
         "alwaysStrict": true,
         "declaration": true,
-        "jsx": "react"
+        "jsx": "react",
+        "allowJs": true
     },
     "files": []
 }

--- a/extensions/applicationinsights-react-js/tsconfig.json
+++ b/extensions/applicationinsights-react-js/tsconfig.json
@@ -5,7 +5,7 @@
     "noImplicitAny": false,
     "module": "es6",
     "moduleResolution": "Node",
-    "target": "es5",
+    "target": "es3",
     "jsx": "react",
     "alwaysStrict": true,
     "suppressImplicitAnyIndexErrors": true,

--- a/extensions/applicationinsights-react-native/tsconfig.json
+++ b/extensions/applicationinsights-react-native/tsconfig.json
@@ -5,7 +5,7 @@
     "noImplicitAny": false,
     "module": "es6",
     "moduleResolution": "Node",
-    "target": "es5",
+    "target": "es3",
     "alwaysStrict": true,
     "suppressImplicitAnyIndexErrors": true,
     "allowSyntheticDefaultImports": true,

--- a/shared/AppInsightsCommon/rollup.config.js
+++ b/shared/AppInsightsCommon/rollup.config.js
@@ -40,6 +40,7 @@ const browserRollupConfigFactory = isProduction => {
     browserRollupConfig.output.file = `browser/${outputName}.min.js`;
     browserRollupConfig.plugins.push(
       uglify({
+        ie8: true,
         output: {
           preamble: banner
         }
@@ -76,6 +77,7 @@ const nodeUmdRollupConfigFactory = (isProduction) => {
     nodeRollupConfig.output.file = `dist/${outputName}.min.js`;
     nodeRollupConfig.plugins.push(
       uglify({
+        ie8: true,
         output: {
           preamble: banner
         }

--- a/shared/AppInsightsCommon/src/ConnectionStringParser.ts
+++ b/shared/AppInsightsCommon/src/ConnectionStringParser.ts
@@ -5,6 +5,7 @@
 
 import { ConnectionString, ConnectionStringKey } from "./Interfaces/ConnectionString";
 import { DEFAULT_BREEZE_ENDPOINT } from "./Constants";
+import { CoreUtils } from "@microsoft/applicationinsights-core-js";
 
 export class ConnectionStringParser {
     private static _FIELDS_SEPARATOR = ";";
@@ -17,7 +18,7 @@ export class ConnectionStringParser {
 
         const kvPairs = connectionString.split(ConnectionStringParser._FIELDS_SEPARATOR);
 
-        const result: ConnectionString = kvPairs.reduce((fields: ConnectionString, kv: string) => {
+        const result: ConnectionString = CoreUtils.arrReduce(kvPairs, (fields: ConnectionString, kv: string) => {
             const kvParts = kv.split(ConnectionStringParser._FIELD_KEY_VALUE_SEPARATOR);
 
             if (kvParts.length === 2) { // only save fields with valid formats
@@ -28,7 +29,7 @@ export class ConnectionStringParser {
             return fields;
         }, {});
 
-        if (Object.keys(result).length > 0) {
+        if (CoreUtils.objKeys(result).length > 0) {
             // this is a valid connection string, so parse the results
 
             if (result.endpointsuffix) {

--- a/shared/AppInsightsCommon/src/Telemetry/Common/Envelope.ts
+++ b/shared/AppInsightsCommon/src/Telemetry/Common/Envelope.ts
@@ -7,7 +7,7 @@ import { IEnvelope } from '../../Interfaces/Telemetry/IEnvelope';
 import { DataSanitizer } from './DataSanitizer';
 import { FieldType } from '../../Enums';
 import { Util } from '../../Util';
-import { IDiagnosticLogger } from '@microsoft/applicationinsights-core-js';
+import { IDiagnosticLogger, CoreUtils } from '@microsoft/applicationinsights-core-js';
 
 export class Envelope extends AIEnvelope implements IEnvelope {
 
@@ -24,7 +24,7 @@ export class Envelope extends AIEnvelope implements IEnvelope {
 
         this.name = DataSanitizer.sanitizeString(logger, name) || Util.NotSpecified;
         this.data = data;
-        this.time = Util.toISOStringForIE8(new Date());
+        this.time = CoreUtils.toISOString(new Date());
 
         this.aiDataContract = {
             time: FieldType.Required,

--- a/shared/AppInsightsCommon/src/Telemetry/Exception.ts
+++ b/shared/AppInsightsCommon/src/Telemetry/Exception.ts
@@ -59,7 +59,7 @@ export class Exception extends ExceptionData implements ISerializable {
 
     public static CreateFromInterface(logger: IDiagnosticLogger, exception: IExceptionInternal): Exception {
         const exceptions: _ExceptionDetails[] = exception.exceptions
-            && exception.exceptions.map((ex: IExceptionDetailsInternal) => _ExceptionDetails.CreateFromInterface(logger, ex));
+            && CoreUtils.arrMap(exception.exceptions, (ex: IExceptionDetailsInternal) => _ExceptionDetails.CreateFromInterface(logger, ex));
         const exceptionData = new Exception(logger, {...exception, exceptions});
         return exceptionData;
     }
@@ -68,7 +68,7 @@ export class Exception extends ExceptionData implements ISerializable {
         const { exceptions, properties, measurements, severityLevel, ver, problemGroup, id, isManual } = this;
 
         const exceptionDetailsInterface = exceptions instanceof Array
-            && exceptions.map((exception: _ExceptionDetails) => exception.toInterface())
+            && CoreUtils.arrMap(exceptions, (exception: _ExceptionDetails) => exception.toInterface())
             || undefined;
 
         return {
@@ -135,7 +135,7 @@ export class _ExceptionDetails extends ExceptionDetails implements ISerializable
 
     public toInterface(): IExceptionDetailsInternal {
         const parsedStack = this.parsedStack instanceof Array
-            && this.parsedStack.map((frame: _StackFrame) => frame.toInterface());
+            && CoreUtils.arrMap(this.parsedStack, (frame: _StackFrame) => frame.toInterface());
 
         const exceptionDetailsInterface: IExceptionDetailsInternal = {
             id: this.id,
@@ -152,7 +152,7 @@ export class _ExceptionDetails extends ExceptionDetails implements ISerializable
 
     public static CreateFromInterface(logger, exception: IExceptionDetailsInternal): _ExceptionDetails {
         const parsedStack = (exception.parsedStack instanceof Array
-            && exception.parsedStack.map(frame => _StackFrame.CreateFromInterface(frame)))
+            &&CoreUtils.arrMap(exception.parsedStack, frame => _StackFrame.CreateFromInterface(frame)))
             || exception.parsedStack;
 
         const exceptionDetails = new _ExceptionDetails(logger, {...exception, parsedStack});

--- a/shared/AppInsightsCommon/src/TelemetryItemCreator.ts
+++ b/shared/AppInsightsCommon/src/TelemetryItemCreator.ts
@@ -34,7 +34,7 @@ export class TelemetryItemCreator {
 
         const telemetryItem: ITelemetryItem = {
             name: envelopeName,
-            time: new Date().toISOString(),
+            time: CoreUtils.toISOString(new Date()),
             iKey: "", // this will be set in TelemetryContext
             ext: systemProperties ? systemProperties : {}, // part A
             tags: [],

--- a/shared/AppInsightsCommon/src/Util.ts
+++ b/shared/AppInsightsCommon/src/Util.ts
@@ -8,6 +8,9 @@ import { RequestHeaders } from "./RequestResponseHeaders";
 import { DataSanitizer } from "./Telemetry/Common/DataSanitizer";
 import { ICorrelationConfig } from "./Interfaces/ICorrelationConfig";
 
+// Adding common usage of prototype as a string to enable indexed lookup to assist with minification
+const prototype = "prototype";
+
 export class Util {
     private static document: any = typeof document !== "undefined" ? document : {};
     private static _canUseLocalStorage: boolean = undefined;
@@ -452,51 +455,23 @@ export class Util {
      * Check if an object is of type Array
      */
     public static isArray(obj: any): boolean {
-        return Object.prototype.toString.call(obj) === "[object Array]";
+        return Object[prototype].toString.call(obj) === "[object Array]";
     }
 
     /**
      * Check if an object is of type Error
      */
     public static isError(obj: any): boolean {
-        return Object.prototype.toString.call(obj) === "[object Error]";
+        return Object[prototype].toString.call(obj) === "[object Error]";
     }
 
     /**
      * Check if an object is of type Date
      */
-    public static isDate(obj: any): boolean {
-        return Object.prototype.toString.call(obj) === "[object Date]";
-    }
+    public static isDate = CoreUtils.isDate;
 
-    /**
-     * Convert a date to I.S.O. format in IE8
-     */
-    public static toISOStringForIE8(date: Date) {
-        if (Util.isDate(date)) {
-            if (Date.prototype.toISOString) {
-                return date.toISOString();
-            } else {
-                const pad = (num: number) => {
-                    let r = String(num);
-                    if (r.length === 1) {
-                        r = "0" + r;
-                    }
-
-                    return r;
-                }
-
-                return date.getUTCFullYear()
-                    + "-" + pad(date.getUTCMonth() + 1)
-                    + "-" + pad(date.getUTCDate())
-                    + "T" + pad(date.getUTCHours())
-                    + ":" + pad(date.getUTCMinutes())
-                    + ":" + pad(date.getUTCSeconds())
-                    + "." + String((date.getUTCMilliseconds() / 1000).toFixed(3)).slice(2, 5)
-                    + "Z";
-            }
-        }
-    }
+    // Keeping this name for backward compatibility (for now)
+    public static toISOStringForIE8 = CoreUtils.toISOString;
 
     /**
      * Gets IE version if we are running on IE, or null otherwise
@@ -542,7 +517,7 @@ export class Util {
      * Returns string representation of an object suitable for diagnostics logging.
      */
     public static dump(object: any): string {
-        const objectTypeDump: string = Object.prototype.toString.call(object);
+        const objectTypeDump: string = Object[prototype].toString.call(object);
         let propertyValueDump: string = JSON.stringify(object);
         if (objectTypeDump === "[object Error]") {
             propertyValueDump = "{ stack: '" + object.stack + "', message: '" + object.message + "', name: '" + object.name + "'";
@@ -555,7 +530,7 @@ export class Util {
      * Returns the name of object if it's an Error. Otherwise, returns empty string.
      */
     public static getExceptionName(object: any): string {
-        const objectTypeDump: string = Object.prototype.toString.call(object);
+        const objectTypeDump: string = Object[prototype].toString.call(object);
         if (objectTypeDump === "[object Error]") {
             return object.name;
         }
@@ -686,7 +661,7 @@ export class CorrelationIdHelper {
         const includedDomains = config && config.correlationHeaderDomains;
         if (includedDomains) {
             let matchExists;
-            includedDomains.forEach((domain) => {
+            CoreUtils.arrForEach(includedDomains, (domain) => {
                 const regex = new RegExp(domain.toLowerCase().replace(/\./g, "\.").replace(/\*/g, ".*"));
                 matchExists = matchExists || regex.test(requestHost);
             });

--- a/shared/AppInsightsCommon/tsconfig.json
+++ b/shared/AppInsightsCommon/tsconfig.json
@@ -5,7 +5,7 @@
     "noImplicitAny": false,
     "module": "es6",
     "moduleResolution": "Node",
-    "target": "es5",
+    "target": "es3",
     "alwaysStrict": true,
     "suppressImplicitAnyIndexErrors": true,
     "allowSyntheticDefaultImports": true,

--- a/shared/AppInsightsCore/rollup.config.js
+++ b/shared/AppInsightsCore/rollup.config.js
@@ -41,6 +41,7 @@ const browserRollupConfigFactory = isProduction => {
     browserRollupConfig.output.file = `browser/${outputName}.min.js`;
     browserRollupConfig.plugins.push(
       uglify({
+        ie8: true,
         output: {
           preamble: banner
         }
@@ -77,6 +78,7 @@ const nodeUmdRollupConfigFactory = (isProduction) => {
     nodeRollupConfig.output.file = `dist/${outputName}.min.js`;
     nodeRollupConfig.plugins.push(
       uglify({
+        ie8: true,
         output: {
           preamble: banner
         }

--- a/shared/AppInsightsCore/src/JavaScriptSDK/AppInsightsCore.ts
+++ b/shared/AppInsightsCore/src/JavaScriptSDK/AppInsightsCore.ts
@@ -85,11 +85,11 @@ export class AppInsightsCore extends BaseCore implements IAppInsightsCore {
         return setInterval(() => {
             const queue: _InternalLogMessage[] = this.logger ? this.logger.queue : [];
 
-            queue.forEach((logMessage: _InternalLogMessage) => {
+            CoreUtils.arrForEach(queue, (logMessage: _InternalLogMessage) => {
                 const item: ITelemetryItem = {
                     name: eventName ? eventName : "InternalMessageId: " + logMessage.messageId,
                     iKey: this.config.instrumentationKey,
-                    time: new Date().toISOString(),
+                    time: CoreUtils.toISOString(new Date()),
                     baseType: _InternalLogMessage.dataType,
                     baseData: { message: logMessage.message }
                 };

--- a/shared/AppInsightsCore/src/JavaScriptSDK/BaseCore.ts
+++ b/shared/AppInsightsCore/src/JavaScriptSDK/BaseCore.ts
@@ -45,7 +45,7 @@ export class BaseCore implements IAppInsightsCore {
 
         this._notificationManager = notificationManager;
         if (!this._notificationManager) {
-            this._notificationManager = Object.create({
+            this._notificationManager = CoreUtils.objCreate({
                 addNotificationListener: (listener) => {},
                 removeNotificationListener: (listener) => {},
                 eventsSent: (events) => {},
@@ -63,7 +63,7 @@ export class BaseCore implements IAppInsightsCore {
 
         this.logger = logger;
         if (!this.logger) {
-            this.logger = Object.create({
+            this.logger = CoreUtils.objCreate({
                 throwInternal: (severity, msgId, msg: string, properties?: Object, isUserAct = false) => {},
                 warnToConsole: (message: string) => {},
                 resetInternalMessageCount: () => {}
@@ -74,7 +74,7 @@ export class BaseCore implements IAppInsightsCore {
         this._extensions.push(...extensions, ...this.config.extensions);
 
         // Initial validation 
-        this._extensions.forEach((extension: ITelemetryPlugin) => {
+        CoreUtils.arrForEach(this._extensions, (extension: ITelemetryPlugin) => {
             let isValid = true;
             if (CoreUtils.isNullOrUndefined(extension) || CoreUtils.isNullOrUndefined(extension.initialize)) {
                 isValid = false;
@@ -110,7 +110,7 @@ export class BaseCore implements IAppInsightsCore {
 
         // Check if any two extensions have the same priority, then warn to console
         const priority = {};
-        this._extensions.forEach(ext => {
+        CoreUtils.arrForEach(this._extensions, ext => {
             const t = (ext as ITelemetryPlugin);
             if (t && t.priority) {
                 if (!CoreUtils.isNullOrUndefined(priority[t.priority])) {
@@ -144,7 +144,7 @@ export class BaseCore implements IAppInsightsCore {
         this._channelController.initialize(this.config, this, this._extensions);
 
         // initialize remaining regular plugins
-        this._extensions.forEach(ext => {
+        CoreUtils.arrForEach(this._extensions, ext => {
             const e = ext as ITelemetryPlugin;
             if (e && e.priority < this._channelController.priority) {
                 ext.initialize(this.config, this, this._extensions); // initialize
@@ -163,7 +163,7 @@ export class BaseCore implements IAppInsightsCore {
     }
 
     getTransmissionControls(): IChannelControls[][] {
-        return this._channelController.ChannelControls;
+        return this._channelController.getChannelControls();
     }
 
     track(telemetryItem: ITelemetryItem) {
@@ -173,7 +173,7 @@ export class BaseCore implements IAppInsightsCore {
         }
         if (!telemetryItem.time) {
             // add default timestamp if not passed in
-            telemetryItem.time = new Date().toISOString();
+            telemetryItem.time = CoreUtils.toISOString(new Date());
         }
         if (CoreUtils.isNullOrUndefined(telemetryItem.ver)) {
             // CommonSchema 4.0

--- a/shared/AppInsightsCore/src/JavaScriptSDK/ChannelController.ts
+++ b/shared/AppInsightsCore/src/JavaScriptSDK/ChannelController.ts
@@ -24,7 +24,7 @@ export class ChannelController implements ITelemetryPlugin {
     private channelQueue: IChannelControls[][];
 
     public processTelemetry(item: ITelemetryItem) {
-        this.channelQueue.forEach(queues => {
+        CoreUtils.arrForEach(this.channelQueue, queues => {
             // pass on to first item in queue
             if (queues.length > 0) {
                 queues[0].processTelemetry(item);
@@ -32,7 +32,7 @@ export class ChannelController implements ITelemetryPlugin {
         });
     }
 
-    public get ChannelControls(): IChannelControls[][] {
+    public getChannelControls(): IChannelControls[][] {
         return this.channelQueue;
     }
 
@@ -44,7 +44,7 @@ export class ChannelController implements ITelemetryPlugin {
         this.channelQueue = new Array<IChannelControls[]>();
         if (config.channels) {
             let invalidChannelIdentifier;
-            config.channels.forEach(queue => {
+            CoreUtils.arrForEach(config.channels, queue => {
 
                 if (queue && queue.length > 0) {
                     queue = queue.sort((a, b) => { // sort based on priority within each queue
@@ -56,7 +56,7 @@ export class ChannelController implements ITelemetryPlugin {
                     }
 
                     // Initialize each plugin
-                    queue.forEach(queueItem => {
+                    CoreUtils.arrForEach(queue, queueItem => {
                         if (queueItem.priority < ChannelControllerPriority) {
                             invalidChannelIdentifier = queueItem.identifier;
                         }
@@ -91,10 +91,19 @@ export class ChannelController implements ITelemetryPlugin {
                 arr[i - 1].setNextPlugin(arr[i]);
             }
             // Initialize each plugin
-            arr.forEach(queueItem => queueItem.initialize(config, core, extensions));
+            CoreUtils.arrForEach(arr, queueItem => queueItem.initialize(config, core, extensions));
 
             this.channelQueue.push(arr);
         }
     }
+
+    /**
+     * Static constructor, attempt to create accessors
+     */
+    // tslint:disable-next-line
+    private static _staticInit = (() => {
+        // Dynamically create get/set property accessors
+        CoreUtils.objDefineAccessors(ChannelController.prototype, "ChannelControls", ChannelController.prototype.getChannelControls);
+    })();
 }
 

--- a/shared/AppInsightsCore/src/JavaScriptSDK/CoreUtils.ts
+++ b/shared/AppInsightsCore/src/JavaScriptSDK/CoreUtils.ts
@@ -2,6 +2,9 @@
 // Licensed under the MIT License.
 "use strict";
 
+// Added to help with minfication
+let prototype = "prototype";
+
 export class CoreUtils {
     public static _canUseCookies: boolean;
 
@@ -9,11 +12,17 @@ export class CoreUtils {
         return input === null || input === undefined;
     }
 
+    /**
+     * Check if an object is of type Date
+     */
+    public static isDate(obj: any): boolean {
+        return Object[prototype].toString.call(obj) === "[object Date]";
+    }
 
-/**
- * Creates a new GUID.
- * @return {string} A GUID.
- */
+    /**
+     * Creates a new GUID.
+     * @return {string} A GUID.
+     */
 
     public static disableCookies() {
         CoreUtils._canUseCookies = false;
@@ -26,8 +35,227 @@ export class CoreUtils {
         });
     }
 
+    /**
+     * Convert a date to I.S.O. format in IE8
+     */
+    public static toISOString(date: Date) {
+        if (CoreUtils.isDate(date)) {
+            const pad = (num: number) => {
+                let r = String(num);
+                if (r.length === 1) {
+                    r = "0" + r;
+                }
 
+                return r;
+            }
 
+            return date.getUTCFullYear()
+                + "-" + pad(date.getUTCMonth() + 1)
+                + "-" + pad(date.getUTCDate())
+                + "T" + pad(date.getUTCHours())
+                + ":" + pad(date.getUTCMinutes())
+                + ":" + pad(date.getUTCSeconds())
+                + "." + String((date.getUTCMilliseconds() / 1000).toFixed(3)).slice(2, 5)
+                + "Z";
+        }
+    }
 
+    /**
+     * Performs the specified action for each element in an array. This helper exists to avoid adding a polyfil for older browsers
+     * that do not define Array.prototype.xxxx (eg. ES3 only, IE8) just in case any page checks for presence/absence of the prototype
+     * implementation. Note: For consistency this will not use the Array.prototype.xxxx implementation if it exists as this would
+     * cause a testing requirement to test with and without the implementations
+     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array.
+     * @param thisArg  [Optional] An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     */
+    public static arrForEach<T>(arr: T[], callbackfn: (value: T, index?: number, array?: T[]) => void, thisArg?: any):void {
+        let len = arr.length;
+        for (let idx = 0; idx < len; ++idx) {
+            if (idx in arr) {
+                callbackfn.call(thisArg || arr, arr[idx], idx, arr);
+            }
+        }
+    }
+
+    /**
+     * Returns the index of the first occurrence of a value in an array. This helper exists to avoid adding a polyfil for older browsers
+     * that do not define Array.prototype.xxxx (eg. ES3 only, IE8) just in case any page checks for presence/absence of the prototype
+     * implementation. Note: For consistency this will not use the Array.prototype.xxxx implementation if it exists as this would
+     * cause a testing requirement to test with and without the implementations
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the search starts at index 0.
+     */
+    public static arrIndexOf<T>(arr: T[], searchElement: T, fromIndex?: number): number {
+        let len = arr.length;
+        let from = fromIndex || 0;
+        for (let lp = Math.max(from >= 0 ? from : len - Math.abs(from), 0); lp < len; lp++) {
+            if (lp in arr && arr[lp] === searchElement) {
+                return lp;
+            }
+        }
+
+        return -1;
+    }
+
+    /**
+     * Calls a defined callback function on each element of an array, and returns an array that contains the results. This helper exists 
+     * to avoid adding a polyfil for older browsers that do not define Array.prototype.xxxx (eg. ES3 only, IE8) just in case any page 
+     * checks for presence/absence of the prototype implementation. Note: For consistency this will not use the Array.prototype.xxxx 
+     * implementation if it exists as this would cause a testing requirement to test with and without the implementations
+     * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     */
+    public static arrMap<T,R>(arr: T[], callbackfn: (value: T, index?: number, array?: T[]) => R, thisArg?: any): R[] {
+        let len = arr.length;
+        let _this = thisArg || arr;
+        let results = new Array(len);
+        
+        for (let lp = 0; lp < len; lp++) {
+            if (lp in arr) {
+                results[lp] = callbackfn.call(_this, arr[lp], arr);
+            }
+        }
+
+        return results;
+    }
+
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is
+     * provided as an argument in the next call to the callback function. This helper exists to avoid adding a polyfil for older browsers that do not define
+     * Array.prototype.xxxx (eg. ES3 only, IE8) just in case any page checks for presence/absence of the prototype implementation. Note: For consistency 
+     * this will not use the Array.prototype.xxxx implementation if it exists as this would cause a testing requirement to test with and without the implementations
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+     */
+    public static arrReduce<T,R>(arr: T[], callbackfn: (previousValue: T|R, currentValue?: T, currentIndex?: number, array?: T[]) => R, initialValue?: R): R {
+        let len = arr.length;
+        let lp = 0;
+        let value;
+
+        // Specifically checking the number of passed arguments as the value could be anything
+        if (arguments.length >= 3) {
+            value = arguments[2];
+        } else {
+            while (lp < len && !(lp in arr)) {
+                lp++;
+            }
+
+            value = arr[lp++];
+        }
+
+        while (lp < len) {
+            if (lp in arr) {
+                value = callbackfn(value, arr[lp], lp, arr);
+            }
+            lp++;
+        }
+
+        return value;
+    }
+
+    /**
+     * Creates an object that has the specified prototype, and that optionally contains specified properties. This helper exists to avoid adding a polyfil
+     * for older browsers that do not define Object.create (eg. ES3 only, IE8) just in case any page checks for presence/absence of the prototype implementation.
+     * Note: For consistency this will not use the Object.create implementation if it exists as this would cause a testing requirement to test with and without the implementations
+     * @param obj Object to use as a prototype. May be null
+     */
+    public static objCreate(obj:object):any {
+        if (obj == null) {
+            return {};
+        }
+
+        let type = typeof obj;
+        if (type !== 'object' && type !== 'function') {
+            throw new TypeError('Object prototype may only be an Object: ' + obj)
+        }
+
+        function tmpFunc() {};
+        tmpFunc[prototype] = obj;
+
+        return new tmpFunc();
+    }
+
+    /**
+     * Returns the names of the enumerable string properties and methods of an object. This helper exists to avoid adding a polyfil for older browsers 
+     * that do not define Object.create (eg. ES3 only, IE8) just in case any page checks for presence/absence of the prototype implementation.
+     * Note: For consistency this will not use the Object.create implementation if it exists as this would cause a testing requirement to test with and without the implementations
+     * @param obj Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+     */
+     public static objKeys(obj: {}): string[] {
+        var hasOwnProperty = Object[prototype].hasOwnProperty;
+        var hasDontEnumBug = !({ toString: null }).propertyIsEnumerable('toString');
+
+        let type = typeof obj;
+        if (type !== 'function' && (type !== 'object' || obj === null)) {
+            throw new TypeError('objKeys called on non-object');
+        }
+
+        let result:string[] = [];
+        
+        for (let prop in obj) {
+            if (hasOwnProperty.call(obj, prop)) {
+                result.push(prop);
+            }
+        }
+
+        if (hasDontEnumBug) {
+            let dontEnums = [
+                'toString',
+                'toLocaleString',
+                'valueOf',
+                'hasOwnProperty',
+                'isPrototypeOf',
+                'propertyIsEnumerable',
+                'constructor'
+            ];
+            let dontEnumsLength = dontEnums.length;
+            
+            for (let lp = 0; lp < dontEnumsLength; lp++) {
+                if (hasOwnProperty.call(obj, dontEnums[lp])) {
+                    result.push(dontEnums[lp]);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Try to define get/set object property accessors for the target object/prototype, this will provide compatibility with
+     * existing API definition when run within an ES5+ container that supports accessors but still enable the code to be loaded
+     * and executed in an ES3 container, providing basic IE8 compatibility.
+     * @param target The object on which to define the property.
+     * @param prop The name of the property to be defined or modified.
+     * @param getProp The getter function to wire against the getter.
+     * @param setProp The setter function to wire against the setter.
+     * @returns True if it was able to create the accessors otherwise false
+     */
+    public static objDefineAccessors<T>(target:any, prop:string, getProp?:() => T, setProp?: (v:T) => void) : boolean
+    {
+        let defineProp = Object["defineProperty"];
+        if (defineProp) {
+            try {
+                let descriptor:PropertyDescriptor = {
+                    enumerable: true,
+                    configurable: true
+                }
+
+                if (getProp) {
+                    descriptor.get = getProp;
+                }
+                if (setProp) {
+                    descriptor.set = setProp;
+                }
+
+                defineProp(target, prop, descriptor);
+                return true;
+            } catch (e) {
+                // IE8 Defines a defineProperty on Object but it's only supported for DOM elements so it will throw
+                // We will just ignore this here.
+            }
+        }
+
+        return false;
+    }
 }
 const GuidRegex = /[xy]/g;

--- a/shared/AppInsightsCore/src/JavaScriptSDK/NotificationManager.ts
+++ b/shared/AppInsightsCore/src/JavaScriptSDK/NotificationManager.ts
@@ -3,6 +3,7 @@
 import { ITelemetryItem } from "../JavaScriptSDK.Interfaces/ITelemetryItem";
 import { INotificationListener } from "../JavaScriptSDK.Interfaces/INotificationListener";
 import { INotificationManager } from './../JavaScriptSDK.Interfaces/INotificationManager';
+import { CoreUtils } from "./CoreUtils";
 
 /**
  * Class to manage sending notifications to all the listeners.
@@ -23,10 +24,10 @@ export class NotificationManager implements INotificationManager {
      * @param {INotificationListener} listener - AWTNotificationListener to remove.
      */
     removeNotificationListener(listener: INotificationListener): void {
-        let index: number = this.listeners.indexOf(listener);
+        let index: number = CoreUtils.arrIndexOf(this.listeners, listener);
         while (index > -1) {
             this.listeners.splice(index, 1);
-            index = this.listeners.indexOf(listener);
+            index = CoreUtils.arrIndexOf(this.listeners, listener);
         }
     }
 

--- a/shared/AppInsightsCore/tsconfig.json
+++ b/shared/AppInsightsCore/tsconfig.json
@@ -5,7 +5,7 @@
     "noImplicitAny": false,
     "module": "es6",
     "moduleResolution": "node",
-    "target": "es5",
+    "target": "es3",
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "inlineSources": true,
     "noImplicitAny": false,
     "module": "amd",
-    "target": "es5",
+    "target": "es3",
     "alwaysStrict": true,
     "declaration": true
   },


### PR DESCRIPTION
Is your feature request related to a problem? Please describe.
As an SDK there are numerous users which cannot control the browsers that customers use. As such we need to ensure that the SDK continues to work and does not break the JS execution when loaded in an older browser.

Describe the solution you'd like
As part of this we need to have the generated be compatible with ES3 and use either polyfil implementations or striped back emulation of any required ES5/6 supported features.