### PR TITLE
add samesite=none to legacy cookies

### DIFF
--- a/legacy/JavaScript/JavaScriptSDK/Util.ts
+++ b/legacy/JavaScript/JavaScriptSDK/Util.ts
@@ -320,6 +320,7 @@ module Microsoft.ApplicationInsights {
          * helper method to set userId and sessionId cookie
          */
         public static setCookie(name, value, domain?) {
+            value = value + ";SameSite=None";
             var domainAttrib = "";
             var secureAttrib = "";
 


### PR DESCRIPTION
Legacy clone of appending `;SameSite=None` to new `ai_user`, `ai_session` cookies