### PR TITLE
docs: Add new setup method

### DIFF
--- a/AISKU/README.md
+++ b/AISKU/README.md
@@ -22,4 +22,4 @@
 
 
 Application Insights AI SKU is a package that combines commonly used packages for Web scenarios.
-Refer to [ApplicationInsights-JS](https://github.com/microsoft/applicationinsights-js) for more details on getting started.
+Refer to [our GitHub page](https://github.com/microsoft/applicationinsights-js) for more details on getting started.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,24 @@ appInsights.loadAppInsights();
 appInsights.trackPageView();
 ```
 
+#### (Alternative Setup Method) Include AI JS SDK script and initialize statically
+
+Use this approach if you would like to host AI JS SDK script on your endpoint or bundle it with other scripts. One popular example is Cordova applications (see [this blog post](http://www.teamfoundation.co.za/2016/02/application-insights-and-typescript/). After JS script has loaded, include the following snippet to initialize Application Insights:
+```html
+<!-- the snippet below assumes that JS SDK script has already loaded -->
+<script type="text/javascript" src="/pathToAIJSSDK.js"></script>
+<script type="text/javascript">
+    var snippet = {
+        config: {
+            instrumentationKey: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx"
+        }
+    };
+    var init = new Microsoft.ApplicationInsights.ApplicationInsights(snippet);
+    var appInsights = init.loadAppInsights();
+    appInsights.trackPageView();
+</script>
+```
+
 ### Sending Telemetry to the Azure Portal
 
 If initialized using the snippet, your Application Insights instance is located by default at `window.appInsights`

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -1,7 +1,9 @@
-﻿# Microsoft Application Insights JavaScript SDK
+﻿# (DEPRECATED) Microsoft Application Insights JavaScript SDK
 
  [![Build Status](https://travis-ci.org/microsoft/ApplicationInsights-JS.svg?branch=master)](https://travis-ci.org/microsoft/ApplicationInsights-JS)
  [![npm version](https://badge.fury.io/js/applicationinsights-js.svg)](https://badge.fury.io/js/applicationinsights-js)
+
+> *Note:* This package has been moved to [@microsoft/applicationinsights-web](https://www.npmjs.com/package/@microsoft/applicationinsights-web). Please install that package instead to get the latest updates and changes to Application Insights.
 
 [Application Insights](https://azure.microsoft.com/services/application-insights/) tells you about your app's performance and usage. By adding a few lines of code to your web pages, you get data about how many users you have, which pages are most popular, how fast pages load, whether they throw exceptions, and more. And you can add code to track more detailed user activity.
 


### PR DESCRIPTION
Adds "static initialization" setup instructions which existed on the legacy version of the SDK.