### PR TITLE
Do not clean telemetryInitializers during initialization

### DIFF
--- a/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
+++ b/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
@@ -524,7 +524,7 @@ export class ApplicationInsights extends BaseTelemetryPlugin implements IAppInsi
         this._pageViewManager = new PageViewManager(this, this.config.overridePageViewDuration, this.core, this._pageViewPerformanceManager);
         this._pageVisitTimeManager = new PageVisitTimeManager(this.diagLog(), (pageName, pageUrl, pageVisitTime) => this.trackPageVisitTime(pageName, pageUrl, pageVisitTime))
 
-        this._telemetryInitializers = [];
+        this._telemetryInitializers = this._telemetryInitializers || [];
         this._addDefaultTelemetryInitializers(configGetters);
 
 


### PR DESCRIPTION
User can specify telemetryInitializers before calling initialize we are currently deleting them, initialize can be only called once so there is not issue with adding duplicated default telemetryInitializers