### PR TITLE
include response error data

### DIFF
--- a/AISKU/Tests/applicationinsights.e2e.tests.ts
+++ b/AISKU/Tests/applicationinsights.e2e.tests.ts
@@ -61,6 +61,7 @@ export class ApplicationInsightsTests extends TestClass {
                 disableFetchTracking: false,
                 enableRequestHeaderTracking: true,
                 enableResponseHeaderTracking: true,
+                includeResponseErrorData: true,
                 maxBatchInterval: 2500,
                 disableExceptionTracking: false,
                 namePrefix: this.sessionPrefix,

--- a/AISKU/Tests/applicationinsights.e2e.tests.ts
+++ b/AISKU/Tests/applicationinsights.e2e.tests.ts
@@ -61,7 +61,6 @@ export class ApplicationInsightsTests extends TestClass {
                 disableFetchTracking: false,
                 enableRequestHeaderTracking: true,
                 enableResponseHeaderTracking: true,
-                includeResponseErrorData: true,
                 maxBatchInterval: 2500,
                 disableExceptionTracking: false,
                 namePrefix: this.sessionPrefix,

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Most configuration fields are named such that they can be defaulted to falsey. A
 | enableAutoRouteTracking | false | Automatically track route changes in Single Page Applications (SPA). If true, each route change will send a new Pageview to Application Insights. Hash route changes changes (`example.com/foo#bar`) are also recorded as new page views.
 | enableRequestHeaderTracking | false | If true, AJAX & Fetch request headers is tracked, default is false.
 | enableResponseHeaderTracking | false | If true, AJAX & Fetch request's response headers is tracked, default is false.
+| disableAjaxErrorStatusText | false | Default false, include response error data text in dependency event on failed AJAX requests. If true, disable this track.
 | distributedTracingMode | `DistributedTracingModes.AI` | Sets the distributed tracing mode. If AI_AND_W3C mode or W3C mode is set, W3C trace context headers (traceparent/tracestate) will be generated and included in all outgoing requests. AI_AND_W3C is provided for back-compatibility with any legacy Application Insights instrumented services.
 | enableUnhandledPromiseRejectionTracking | false | If true, unhandled promise rejections will be autocollected and reported as a javascript error. When disableExceptionTracking is true (dont track exceptions) the config value will be ignored and unhandled promise rejections will not be reported.
 ## Single Page Applications

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Most configuration fields are named such that they can be defaulted to falsey. A
 | enableAutoRouteTracking | false | Automatically track route changes in Single Page Applications (SPA). If true, each route change will send a new Pageview to Application Insights. Hash route changes changes (`example.com/foo#bar`) are also recorded as new page views.
 | enableRequestHeaderTracking | false | If true, AJAX & Fetch request headers is tracked, default is false.
 | enableResponseHeaderTracking | false | If true, AJAX & Fetch request's response headers is tracked, default is false.
-| disableAjaxErrorStatusText | false | Default false, include response error data text in dependency event on failed AJAX requests. If true, disable this track.
+| enableAjaxErrorStatusText | false | Default false. If true, include response error data text in dependency event on failed AJAX requests.
 | distributedTracingMode | `DistributedTracingModes.AI` | Sets the distributed tracing mode. If AI_AND_W3C mode or W3C mode is set, W3C trace context headers (traceparent/tracestate) will be generated and included in all outgoing requests. AI_AND_W3C is provided for back-compatibility with any legacy Application Insights instrumented services.
 | enableUnhandledPromiseRejectionTracking | false | If true, unhandled promise rejections will be autocollected and reported as a javascript error. When disableExceptionTracking is true (dont track exceptions) the config value will be ignored and unhandled promise rejections will not be reported.
 ## Single Page Applications

--- a/extensions/applicationinsights-dependencies-js/Tests/Selenium/ajax.tests.ts
+++ b/extensions/applicationinsights-dependencies-js/Tests/Selenium/ajax.tests.ts
@@ -117,11 +117,11 @@ export class AjaxTests extends TestClass {
         });
 
         this.testCase({
-            name: "Ajax: xhr respond error data is tracked as part C data when disableAjaxErrorStatusText flag is false",
+            name: "Ajax: xhr respond error data is tracked as part C data when enableAjaxErrorStatusText flag is true",
             test: () => {
                 let ajaxMonitor = new AjaxMonitor();
                 let appInsightsCore = new AppInsightsCore();
-                let coreConfig: IConfiguration & IConfig = { instrumentationKey: "abc", disableAjaxTracking: false, disableAjaxErrorStatusText: false };
+                let coreConfig: IConfiguration & IConfig = { instrumentationKey: "abc", disableAjaxTracking: false, enableAjaxErrorStatusText: true };
                 appInsightsCore.initialize(coreConfig, [ajaxMonitor, new TestChannelPlugin()]);
 
                 var trackStub = this.sandbox.stub(ajaxMonitor, "trackDependencyDataInternal");

--- a/extensions/applicationinsights-dependencies-js/Tests/Selenium/ajax.tests.ts
+++ b/extensions/applicationinsights-dependencies-js/Tests/Selenium/ajax.tests.ts
@@ -117,11 +117,11 @@ export class AjaxTests extends TestClass {
         });
 
         this.testCase({
-            name: "Ajax: xhr respond error data is tracked as part C data when includeResponseErrorData flag is true",
+            name: "Ajax: xhr respond error data is tracked as part C data when disableAjaxErrorStatusText flag is false",
             test: () => {
                 let ajaxMonitor = new AjaxMonitor();
                 let appInsightsCore = new AppInsightsCore();
-                let coreConfig: IConfiguration & IConfig = { instrumentationKey: "abc", disableAjaxTracking: false, includeResponseErrorData: true };
+                let coreConfig: IConfiguration & IConfig = { instrumentationKey: "abc", disableAjaxTracking: false, disableAjaxErrorStatusText: false };
                 appInsightsCore.initialize(coreConfig, [ajaxMonitor, new TestChannelPlugin()]);
 
                 var trackStub = this.sandbox.stub(ajaxMonitor, "trackDependencyDataInternal");
@@ -137,7 +137,7 @@ export class AjaxTests extends TestClass {
                 // assert
                 Assert.ok(trackStub.calledOnce, "trackDependencyDataInternal is called");
                 Assert.equal("Ajax", trackStub.args[0][0].type, "request is Ajax type");
-                Assert.notEqual(undefined, trackStub.args[0][0].properties.responseError, "xhr request's reponse error is stored in part C");
+                Assert.notEqual(undefined, trackStub.args[0][0].properties.responseText, "xhr request's reponse error is stored in part C");
             }
         });
 

--- a/extensions/applicationinsights-dependencies-js/Tests/Selenium/ajax.tests.ts
+++ b/extensions/applicationinsights-dependencies-js/Tests/Selenium/ajax.tests.ts
@@ -117,6 +117,32 @@ export class AjaxTests extends TestClass {
         });
 
         this.testCase({
+            name: "Ajax: xhr respond error data is tracked as part C data when includeResponseErrorData flag is true",
+            test: () => {
+                let ajaxMonitor = new AjaxMonitor();
+                let appInsightsCore = new AppInsightsCore();
+                let coreConfig: IConfiguration & IConfig = { instrumentationKey: "abc", disableAjaxTracking: false, includeResponseErrorData: true };
+                appInsightsCore.initialize(coreConfig, [ajaxMonitor, new TestChannelPlugin()]);
+
+                var trackStub = this.sandbox.stub(ajaxMonitor, "trackDependencyDataInternal");
+
+                // act
+                var xhr = new XMLHttpRequest();
+                xhr.open("GET", "http://microsoft.com");
+                xhr.send();
+
+                // Emulate response
+                (<any>xhr).respond(403, {}, "error data with status code 403");
+
+                // assert
+                Assert.ok(trackStub.calledOnce, "trackDependencyDataInternal is called");
+                Assert.equal("Ajax", trackStub.args[0][0].type, "request is Ajax type");
+                Assert.notEqual(undefined, trackStub.args[0][0].properties.responseError, "xhr request's reponse error is stored in part C");
+            }
+        });
+
+
+        this.testCase({
             name: "Fetch: fetch with disabled flag isn't tracked",
             test: () => {
                 if (typeof fetch === 'undefined') {

--- a/extensions/applicationinsights-dependencies-js/src/ajax.ts
+++ b/extensions/applicationinsights-dependencies-js/src/ajax.ts
@@ -50,7 +50,7 @@ export class AjaxMonitor extends BaseTelemetryPlugin implements IDependenciesPlu
             enableCorsCorrelation: false,
             enableRequestHeaderTracking: false,
             enableResponseHeaderTracking: false,
-            includeResponseErrorData: false
+            disableAjaxErrorStatusText: false
         }
         return config;
     }
@@ -68,7 +68,7 @@ export class AjaxMonitor extends BaseTelemetryPlugin implements IDependenciesPlu
             correlationHeaderDomains: undefined,
             enableRequestHeaderTracking: undefined,
             enableResponseHeaderTracking: undefined,
-            includeResponseErrorData: undefined
+            disableAjaxErrorStatusText: undefined
         }
     }
 
@@ -559,9 +559,9 @@ export class AjaxMonitor extends BaseTelemetryPlugin implements IDependenciesPlu
                 }
             }
 
-            if (_self._config.includeResponseErrorData && xhr.status >= 400) {
+            if (!_self._config.disableAjaxErrorStatusText && xhr.status >= 400) {
                 dependency.properties = dependency.properties || {};
-                dependency.properties.responseError = xhr.statusText + " - " + xhr.responseText;
+                dependency.properties.responseText = xhr.statusText + " - " + xhr.responseText;
             }
 
             _self.trackDependencyDataInternal(dependency);

--- a/extensions/applicationinsights-dependencies-js/src/ajax.ts
+++ b/extensions/applicationinsights-dependencies-js/src/ajax.ts
@@ -559,7 +559,7 @@ export class AjaxMonitor extends BaseTelemetryPlugin implements IDependenciesPlu
                 }
             }
 
-            if (_self._config.includeResponseErrorData && xhr.status !== 200) {
+            if (_self._config.includeResponseErrorData && xhr.status >= 400) {
                 dependency.properties = dependency.properties || {};
                 dependency.properties.responseError = xhr.statusText + " - " + xhr.responseText;
             }

--- a/extensions/applicationinsights-dependencies-js/src/ajax.ts
+++ b/extensions/applicationinsights-dependencies-js/src/ajax.ts
@@ -49,7 +49,8 @@ export class AjaxMonitor extends BaseTelemetryPlugin implements IDependenciesPlu
             appId: undefined,
             enableCorsCorrelation: false,
             enableRequestHeaderTracking: false,
-            enableResponseHeaderTracking: false
+            enableResponseHeaderTracking: false,
+            includeResponseErrorData: false
         }
         return config;
     }
@@ -66,7 +67,8 @@ export class AjaxMonitor extends BaseTelemetryPlugin implements IDependenciesPlu
             enableCorsCorrelation: undefined,
             correlationHeaderDomains: undefined,
             enableRequestHeaderTracking: undefined,
-            enableResponseHeaderTracking: undefined
+            enableResponseHeaderTracking: undefined,
+            includeResponseErrorData: undefined
         }
     }
 
@@ -555,6 +557,11 @@ export class AjaxMonitor extends BaseTelemetryPlugin implements IDependenciesPlu
                         dependency.properties.responseHeaders = responseHeaderMap;
                     }
                 }
+            }
+
+            if (_self._config.includeResponseErrorData && xhr.status !== 200) {
+                dependency.properties = dependency.properties || {};
+                dependency.properties.responseError = xhr.statusText + " - " + xhr.responseText;
             }
 
             _self.trackDependencyDataInternal(dependency);

--- a/extensions/applicationinsights-dependencies-js/src/ajax.ts
+++ b/extensions/applicationinsights-dependencies-js/src/ajax.ts
@@ -50,7 +50,7 @@ export class AjaxMonitor extends BaseTelemetryPlugin implements IDependenciesPlu
             enableCorsCorrelation: false,
             enableRequestHeaderTracking: false,
             enableResponseHeaderTracking: false,
-            disableAjaxErrorStatusText: false
+            enableAjaxErrorStatusText: false
         }
         return config;
     }
@@ -68,7 +68,7 @@ export class AjaxMonitor extends BaseTelemetryPlugin implements IDependenciesPlu
             correlationHeaderDomains: undefined,
             enableRequestHeaderTracking: undefined,
             enableResponseHeaderTracking: undefined,
-            disableAjaxErrorStatusText: undefined
+            enableAjaxErrorStatusText: undefined
         }
     }
 
@@ -559,7 +559,7 @@ export class AjaxMonitor extends BaseTelemetryPlugin implements IDependenciesPlu
                 }
             }
 
-            if (!_self._config.disableAjaxErrorStatusText && xhr.status >= 400) {
+            if (_self._config.enableAjaxErrorStatusText && xhr.status >= 400) {
                 dependency.properties = dependency.properties || {};
                 dependency.properties.responseText = xhr.statusText + " - " + xhr.responseText;
             }

--- a/shared/AppInsightsCommon/src/Interfaces/IConfig.ts
+++ b/shared/AppInsightsCommon/src/Interfaces/IConfig.ts
@@ -300,7 +300,7 @@ export interface IConfig {
      * @memberof IConfig
      * @defaultValue false
      */
-    disableAjaxErrorStatusText?: boolean;
+    enableAjaxErrorStatusText?: boolean;
 
     /**
      * @description Default false. when tab is closed, the SDK will send all remaining telemetry using the [Beacon API](https://www.w3.org/TR/beacon)

--- a/shared/AppInsightsCommon/src/Interfaces/IConfig.ts
+++ b/shared/AppInsightsCommon/src/Interfaces/IConfig.ts
@@ -300,7 +300,7 @@ export interface IConfig {
      * @memberof IConfig
      * @defaultValue false
      */
-    includeResponseErrorData?: boolean;
+    disableAjaxErrorStatusText?: boolean;
 
     /**
      * @description Default false. when tab is closed, the SDK will send all remaining telemetry using the [Beacon API](https://www.w3.org/TR/beacon)

--- a/shared/AppInsightsCommon/src/Interfaces/IConfig.ts
+++ b/shared/AppInsightsCommon/src/Interfaces/IConfig.ts
@@ -295,6 +295,14 @@ export interface IConfig {
     enableResponseHeaderTracking?: boolean;
 
     /**
+     * @description An optional value that will track Resonse Error data through trackDependency function.
+     * @type {boolean}
+     * @memberof IConfig
+     * @defaultValue false
+     */
+    includeResponseErrorData?: boolean;
+
+    /**
      * @description Default false. when tab is closed, the SDK will send all remaining telemetry using the [Beacon API](https://www.w3.org/TR/beacon)
      * @type {boolean}
      * @memberof IConfig

--- a/shared/AppInsightsCommon/src/Interfaces/ICorrelationConfig.ts
+++ b/shared/AppInsightsCommon/src/Interfaces/ICorrelationConfig.ts
@@ -14,7 +14,7 @@ export interface ICorrelationConfig {
     appId?: string;
     enableRequestHeaderTracking?: boolean;
     enableResponseHeaderTracking?: boolean;
-    includeResponseErrorData?: boolean;
+    disableAjaxErrorStatusText?: boolean;
 
     correlationHeaderDomains?: string[]
 }

--- a/shared/AppInsightsCommon/src/Interfaces/ICorrelationConfig.ts
+++ b/shared/AppInsightsCommon/src/Interfaces/ICorrelationConfig.ts
@@ -14,7 +14,7 @@ export interface ICorrelationConfig {
     appId?: string;
     enableRequestHeaderTracking?: boolean;
     enableResponseHeaderTracking?: boolean;
-    disableAjaxErrorStatusText?: boolean;
+    enableAjaxErrorStatusText?: boolean;
 
     correlationHeaderDomains?: string[]
 }

--- a/shared/AppInsightsCommon/src/Interfaces/ICorrelationConfig.ts
+++ b/shared/AppInsightsCommon/src/Interfaces/ICorrelationConfig.ts
@@ -14,6 +14,7 @@ export interface ICorrelationConfig {
     appId?: string;
     enableRequestHeaderTracking?: boolean;
     enableResponseHeaderTracking?: boolean;
+    includeResponseErrorData?: boolean;
 
     correlationHeaderDomains?: string[]
 }


### PR DESCRIPTION
Include response error data in part C on dependency event when ajax respond code is not 200.

Closes: #1156 