### PR TITLE
XHR object is not extensible on salesforce platform

### DIFF
--- a/channels/applicationinsights-channel-js/src/Sender.ts
+++ b/channels/applicationinsights-channel-js/src/Sender.ts
@@ -539,7 +539,7 @@ export class Sender extends BaseTelemetryPlugin implements IChannelControlsAI {
      */
     private _xhrSender(payload: string[], isAsync: boolean) {
         const xhr = new XMLHttpRequest();
-        if (typeof Object.isExtensible !== 'function' || (typeof Object.isExtensible === 'function' && Object.isExtensible(xhr))) {
+        if (CoreUtils.isExtensible(xhr)) {
             xhr[DisabledPropertyName] = true;
         }
         xhr.open("POST", this._senderConfig.endpointUrl(), isAsync);

--- a/channels/applicationinsights-channel-js/src/Sender.ts
+++ b/channels/applicationinsights-channel-js/src/Sender.ts
@@ -539,7 +539,9 @@ export class Sender extends BaseTelemetryPlugin implements IChannelControlsAI {
      */
     private _xhrSender(payload: string[], isAsync: boolean) {
         const xhr = new XMLHttpRequest();
-        xhr[DisabledPropertyName] = true;
+        if (Object.isExtensible(xhr)) {
+            xhr[DisabledPropertyName] = true;
+        }
         xhr.open("POST", this._senderConfig.endpointUrl(), isAsync);
         xhr.setRequestHeader("Content-type", "application/json");
 

--- a/channels/applicationinsights-channel-js/src/Sender.ts
+++ b/channels/applicationinsights-channel-js/src/Sender.ts
@@ -539,7 +539,7 @@ export class Sender extends BaseTelemetryPlugin implements IChannelControlsAI {
      */
     private _xhrSender(payload: string[], isAsync: boolean) {
         const xhr = new XMLHttpRequest();
-        if (Object.isExtensible(xhr)) {
+        if (typeof Object.isExtensible !== 'function' || (typeof Object.isExtensible === 'function' && Object.isExtensible(xhr))) {
             xhr[DisabledPropertyName] = true;
         }
         xhr.open("POST", this._senderConfig.endpointUrl(), isAsync);

--- a/shared/AppInsightsCore/src/JavaScriptSDK/CoreUtils.ts
+++ b/shared/AppInsightsCore/src/JavaScriptSDK/CoreUtils.ts
@@ -402,7 +402,7 @@ export class CoreUtils {
      * @param target The object on which to determine extensibility.
      * @returns True if the object is extensible.
      */
-    public static isExtensible<T>(obj:object) : boolean {
+    public static isExtensible(obj:object) : boolean {
         let extensibleProp = Object["isExtensible"];
         if (extensibleProp) {
             try {

--- a/shared/AppInsightsCore/src/JavaScriptSDK/CoreUtils.ts
+++ b/shared/AppInsightsCore/src/JavaScriptSDK/CoreUtils.ts
@@ -397,6 +397,26 @@ export class CoreUtils {
     }
 
     /**
+     * Try to determine if the object is extensible when run within an >= ES5 container.
+     * For < ES5 containers where the method does not exist, always return true.
+     * @param target The object on which to determine extensibility.
+     * @returns True if the object is extensible.
+     */
+    public static isExtensible<T>(obj:object) : boolean {
+        let extensibleProp = Object["isExtensible"];
+        if (extensibleProp) {
+            try {
+                return extensibleProp(obj);
+            } catch (e) {
+                // ES5 will throw a typeError if user passes a primitive
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
      * Trys to add an event handler for the specified event to the window, body and document
      * @param eventName {string} - The name of the event
      * @param callback {any} - The callback function that needs to be executed for the given event


### PR DESCRIPTION
I'm unable to use ApplicationInsights-JS on the Salesforce Platform.  Salesforce has locked-down extending the XMLHttpRequest object with either of these methods:
```
Object.preventExtensions(XMLHttpRequest) 
// or 
Reflect.preventExtensions(XMLHttpRequest)
```
This change allows telemetry to be tracked on the Salesforce platform.  However, I'm not exactly sure the fallout of conditionally removing this property from xhr.  I'm submitting this for your feedback.  

Note: Also, I'm unable to satisfy the build because of ES3 support, though I believe I've sufficiently checked for existence before invoking the function.  The build continues to complain with: 

```
[Object.isExtensible(] is not supported in an ES3 environment, use a helper function or add explicit check for existence.
``` 

Thank you in advance for your time on my PR.