### PR TITLE
fix for withAITracking wrapping functional components.

### DIFF
--- a/extensions/applicationinsights-react-js/src/withAITracking.tsx
+++ b/extensions/applicationinsights-react-js/src/withAITracking.tsx
@@ -17,7 +17,10 @@ import ReactPlugin from './ReactPlugin';
 export default function withAITracking<P>(reactPlugin: ReactPlugin, Component: React.ComponentType<P>, componentName?: string, className?: string): React.ComponentClass<P> {
 
   if (componentName === undefined || componentName === null || typeof componentName !== 'string') {
-    componentName = Component.prototype.constructor.name;
+    componentName = Component.prototype && 
+          Component.prototype.constructor && 
+          Component.prototype.constructor.name || 
+          'Anonymous component';
   }
 
   if (className === undefined || className === null || typeof className !== 'string') {

--- a/extensions/applicationinsights-react-js/src/withAITracking.tsx
+++ b/extensions/applicationinsights-react-js/src/withAITracking.tsx
@@ -20,7 +20,7 @@ export default function withAITracking<P>(reactPlugin: ReactPlugin, Component: R
     componentName = Component.prototype && 
           Component.prototype.constructor && 
           Component.prototype.constructor.name || 
-          'Anonymous component';
+          'Unknown';
   }
 
   if (className === undefined || className === null || typeof className !== 'string') {


### PR DESCRIPTION
fix for issues #1274 and #1117

Can also use empty string instead of 'Anonymous component'. Let me know which is preferred.