### PR TITLE
[Release] Increase to version 2.5.5

### DIFF
--- a/AISKU/package.json
+++ b/AISKU/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-web",
-    "version": "2.5.4",
+    "version": "2.5.5",
     "description": "Microsoft Application Insights Javascript SDK API 1.0 beta",
     "main": "dist/applicationinsights-web.js",
     "module": "dist-esm/applicationinsights-web.js",
@@ -52,12 +52,12 @@
     "dependencies": {
         "@microsoft/dynamicproto-js": "^0.5.2",
         "@microsoft/applicationinsights-shims" : "1.0.0",
-        "@microsoft/applicationinsights-analytics-js": "2.5.4",
-        "@microsoft/applicationinsights-channel-js": "2.5.4",
-        "@microsoft/applicationinsights-common": "2.5.4",
-        "@microsoft/applicationinsights-core-js": "2.5.4",
-        "@microsoft/applicationinsights-dependencies-js": "2.5.4",
-        "@microsoft/applicationinsights-properties-js": "2.5.4"
+        "@microsoft/applicationinsights-analytics-js": "2.5.5",
+        "@microsoft/applicationinsights-channel-js": "2.5.5",
+        "@microsoft/applicationinsights-common": "2.5.5",
+        "@microsoft/applicationinsights-core-js": "2.5.5",
+        "@microsoft/applicationinsights-dependencies-js": "2.5.5",
+        "@microsoft/applicationinsights-properties-js": "2.5.5"
     },
     "license": "MIT"
 }

--- a/AISKULight/package.json
+++ b/AISKULight/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-web-basic",
-    "version": "2.5.4",
+    "version": "2.5.5",
     "description": "Microsoft Application Insights Javascript SDK core and channel",
     "main": "dist/applicationinsights-web-basic.js",
     "module": "dist-esm/index.js",
@@ -29,9 +29,9 @@
     "dependencies": {
         "@microsoft/dynamicproto-js": "^0.5.2",
         "@microsoft/applicationinsights-shims" : "1.0.0",
-        "@microsoft/applicationinsights-common": "2.5.4",
-        "@microsoft/applicationinsights-channel-js": "2.5.4",
-        "@microsoft/applicationinsights-core-js": "2.5.4"
+        "@microsoft/applicationinsights-common": "2.5.5",
+        "@microsoft/applicationinsights-channel-js": "2.5.5",
+        "@microsoft/applicationinsights-core-js": "2.5.5"
     },
     "peerDependencies": {
     },

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,35 @@
 # Releases
 
+## 2.5.5
+
+### Updated React plugin to v3.0.0
+
+- Updated to TypeScript 3.x
+- Removed React plugin from main rush pipeline
+- #991 Don't work with React HOOKS
+  - #1120 Introducing React Hooks for AppInsights #1120
+
+### New Package applicationinsights-shims v1.0.0
+
+- Created to remove dependency on TSLib as v 1.13.0 has introduced build breaks
+  - provides internal implementation of __extends() and __assign() when no pre-existing version is present
+
+### Changelog
+
+- #1278 Add optional 'eventsSendRequest' notification to NotificationManager
+- #1269 TsLib v1.13.0 has breaking change (Remove dependency on TSLib)
+  - Added new package **'applicationinsights-shims@1.0.0'**
+- Removed React plugin from main rush pipeline
+- #991 Don't work with React HOOKS
+  - #1120 Introducing React Hooks for AppInsights #1120
+- #1274 Fix for withAITracking wrapping functional components.
+- Using crypto to generate GUIDs when available (Make GUID more random)
+- #1260 [BUG] Can't include Correlation Header on IE can fail
+- #1258 Update snippet to support reporting script load failures
+- #1251 [BUG] ajax.ts is using string trim() which is not supported on IE7/8
+- #1249 Identify whether the script is being consumed via the CDN or NPM package
+- Several minor documentation updates
+
 ## 2.5.4
 
 ### Changelog

--- a/channels/applicationinsights-channel-js/Tests/Sender.tests.ts
+++ b/channels/applicationinsights-channel-js/Tests/Sender.tests.ts
@@ -375,7 +375,7 @@ export class SenderTests extends TestClass {
                 Assert.ok(baseData.ver);
                 Assert.equal(2, baseData.ver);
 
-                Assert.equal("javascript:2.5.4", appInsightsEnvelope.tags["ai.internal.sdkVersion"]);
+                Assert.equal("javascript:2.5.5", appInsightsEnvelope.tags["ai.internal.sdkVersion"]);
             }
         })
 

--- a/channels/applicationinsights-channel-js/package.json
+++ b/channels/applicationinsights-channel-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-channel-js",
-    "version": "2.5.4",
+    "version": "2.5.5",
     "description": "Microsoft Application Insights JavaScript SDK Channel",
     "main": "dist/applicationinsights-channel-js.js",
     "module": "dist-esm/applicationinsights-channel-js.js",
@@ -32,8 +32,8 @@
     },
     "dependencies": {
         "@microsoft/applicationinsights-shims" : "1.0.0",
-        "@microsoft/applicationinsights-core-js": "2.5.4",
-        "@microsoft/applicationinsights-common": "2.5.4"
+        "@microsoft/applicationinsights-core-js": "2.5.5",
+        "@microsoft/applicationinsights-common": "2.5.5"
     },
     "license": "MIT"
 }

--- a/channels/applicationinsights-channel-js/src/EnvelopeCreator.ts
+++ b/channels/applicationinsights-channel-js/src/EnvelopeCreator.ts
@@ -20,7 +20,7 @@ const baseType: string = "baseType";
 const baseData: string = "baseData";
 
 export abstract class EnvelopeCreator {
-    public static Version = "2.5.4";
+    public static Version = "2.5.5";
 
     protected static extractPropsAndMeasurements(data: { [key: string]: any }, properties: { [key: string]: any }, measurements: { [key: string]: any }) {
         if (!CoreUtils.isNullOrUndefined(data)) {

--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -56,53 +56,53 @@
     },
     "@rush-temp/applicationinsights-analytics-js": {
       "version": "0.0.0",
-      "from": "projects/applicationinsights-analytics-js.tgz",
-      "resolved": "file:projects/applicationinsights-analytics-js.tgz"
+      "from": "projects\\applicationinsights-analytics-js.tgz",
+      "resolved": "file:projects\\applicationinsights-analytics-js.tgz"
     },
     "@rush-temp/applicationinsights-channel-js": {
       "version": "0.0.0",
-      "from": "projects/applicationinsights-channel-js.tgz",
-      "resolved": "file:projects/applicationinsights-channel-js.tgz"
+      "from": "projects\\applicationinsights-channel-js.tgz",
+      "resolved": "file:projects\\applicationinsights-channel-js.tgz"
     },
     "@rush-temp/applicationinsights-common": {
       "version": "0.0.0",
-      "from": "projects/applicationinsights-common.tgz",
-      "resolved": "file:projects/applicationinsights-common.tgz"
+      "from": "projects\\applicationinsights-common.tgz",
+      "resolved": "file:projects\\applicationinsights-common.tgz"
     },
     "@rush-temp/applicationinsights-core-js": {
       "version": "0.0.0",
-      "from": "projects/applicationinsights-core-js.tgz",
-      "resolved": "file:projects/applicationinsights-core-js.tgz"
+      "from": "projects\\applicationinsights-core-js.tgz",
+      "resolved": "file:projects\\applicationinsights-core-js.tgz"
     },
     "@rush-temp/applicationinsights-dependencies-js": {
       "version": "0.0.0",
-      "from": "projects/applicationinsights-dependencies-js.tgz",
-      "resolved": "file:projects/applicationinsights-dependencies-js.tgz"
+      "from": "projects\\applicationinsights-dependencies-js.tgz",
+      "resolved": "file:projects\\applicationinsights-dependencies-js.tgz"
     },
     "@rush-temp/applicationinsights-properties-js": {
       "version": "0.0.0",
-      "from": "projects/applicationinsights-properties-js.tgz",
-      "resolved": "file:projects/applicationinsights-properties-js.tgz"
+      "from": "projects\\applicationinsights-properties-js.tgz",
+      "resolved": "file:projects\\applicationinsights-properties-js.tgz"
     },
     "@rush-temp/applicationinsights-rollup-es3": {
       "version": "0.0.0",
-      "from": "projects/applicationinsights-rollup-es3.tgz",
-      "resolved": "file:projects/applicationinsights-rollup-es3.tgz"
+      "from": "projects\\applicationinsights-rollup-es3.tgz",
+      "resolved": "file:projects\\applicationinsights-rollup-es3.tgz"
     },
     "@rush-temp/applicationinsights-shims": {
       "version": "0.0.0",
-      "from": "projects/applicationinsights-shims.tgz",
-      "resolved": "file:projects/applicationinsights-shims.tgz"
+      "from": "projects\\applicationinsights-shims.tgz",
+      "resolved": "file:projects\\applicationinsights-shims.tgz"
     },
     "@rush-temp/applicationinsights-web": {
       "version": "0.0.0",
-      "from": "projects/applicationinsights-web.tgz",
-      "resolved": "file:projects/applicationinsights-web.tgz"
+      "from": "projects\\applicationinsights-web.tgz",
+      "resolved": "file:projects\\applicationinsights-web.tgz"
     },
     "@rush-temp/applicationinsights-web-basic": {
       "version": "0.0.0",
-      "from": "projects/applicationinsights-web-basic.tgz",
-      "resolved": "file:projects/applicationinsights-web-basic.tgz"
+      "from": "projects\\applicationinsights-web-basic.tgz",
+      "resolved": "file:projects\\applicationinsights-web-basic.tgz"
     },
     "@types/estree": {
       "version": "0.0.39",
@@ -130,9 +130,9 @@
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz"
     },
     "@types/node": {
-      "version": "14.0.5",
+      "version": "14.0.9",
       "from": "@types/node@*",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.5.tgz"
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.9.tgz"
     },
     "abbrev": {
       "version": "1.1.1",
@@ -1131,9 +1131,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz"
     },
     "ignore": {
-      "version": "5.1.6",
+      "version": "5.1.8",
       "from": "ignore@^5.1.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.6.tgz"
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz"
     },
     "indent-string": {
       "version": "2.1.0",

--- a/extensions/applicationinsights-analytics-js/package.json
+++ b/extensions/applicationinsights-analytics-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-analytics-js",
-    "version": "2.5.4",
+    "version": "2.5.5",
     "description": "Microsoft Application Insights Javascript SDK apis",
     "main": "dist/applicationinsights-analytics-js.js",
     "module": "dist-esm/applicationinsights-analytics-js.js",
@@ -19,7 +19,7 @@
     },
     "devDependencies": {
         "@microsoft/applicationinsights-rollup-es3" : "1.1.1",
-        "@microsoft/applicationinsights-properties-js": "2.5.4",
+        "@microsoft/applicationinsights-properties-js": "2.5.5",
         "typescript": "2.5.3",
         "globby": "^11.0.0",
         "rollup-plugin-node-resolve": "^3.4.0",
@@ -36,8 +36,8 @@
     "dependencies": {
         "@microsoft/dynamicproto-js": "^0.5.2",
         "@microsoft/applicationinsights-shims" : "1.0.0",
-        "@microsoft/applicationinsights-core-js": "2.5.4",
-        "@microsoft/applicationinsights-common": "2.5.4"
+        "@microsoft/applicationinsights-core-js": "2.5.5",
+        "@microsoft/applicationinsights-common": "2.5.5"
     },
     "license": "MIT"
 }

--- a/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
+++ b/extensions/applicationinsights-analytics-js/src/JavaScriptSDK/ApplicationInsights.ts
@@ -36,7 +36,7 @@ function _dispatchEvent(target:EventTarget, evnt: Event) {
 }
 
 export class ApplicationInsights extends BaseTelemetryPlugin implements IAppInsights, IAppInsightsInternal {
-    public static Version = "2.5.4"; // Not currently used anywhere
+    public static Version = "2.5.5"; // Not currently used anywhere
 
     public static getDefaultConfig(config?: IConfig): IConfig {
         if (!config) {

--- a/extensions/applicationinsights-angular-js/package.json
+++ b/extensions/applicationinsights-angular-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-angular-js",
-    "version": "2.5.4",
+    "version": "2.5.5",
     "description": "Microsoft Application Insights Angular plugin",
     "main": "dist/applicationinsights-angular-js.js",
     "module": "dist-esm/applicationinsights-angular-js.js",
@@ -39,8 +39,8 @@
     },
     "dependencies": {
         "@microsoft/applicationinsights-shims" : "1.0.0",
-        "@microsoft/applicationinsights-common": "2.5.4",
-        "@microsoft/applicationinsights-core-js": "2.5.4"
+        "@microsoft/applicationinsights-common": "2.5.5",
+        "@microsoft/applicationinsights-core-js": "2.5.5"
     },
     "license": "MIT"
 }

--- a/extensions/applicationinsights-dependencies-js/package.json
+++ b/extensions/applicationinsights-dependencies-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-dependencies-js",
-    "version": "2.5.4",
+    "version": "2.5.5",
     "description": "Microsoft Application Insights XHR dependencies plugin",
     "main": "dist/applicationinsights-dependencies-js.js",
     "module": "dist-esm/applicationinsights-dependencies-js.js",
@@ -35,8 +35,8 @@
     "dependencies": {
         "@microsoft/dynamicproto-js": "^0.5.2",
         "@microsoft/applicationinsights-shims" : "1.0.0",
-        "@microsoft/applicationinsights-core-js": "2.5.4",
-        "@microsoft/applicationinsights-common": "2.5.4"
+        "@microsoft/applicationinsights-core-js": "2.5.5",
+        "@microsoft/applicationinsights-common": "2.5.5"
     },
     "license": "MIT"
 }

--- a/extensions/applicationinsights-properties-js/package.json
+++ b/extensions/applicationinsights-properties-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-properties-js",
-    "version": "2.5.4",
+    "version": "2.5.5",
     "description": "Microsoft Application Insights properties (Part A) plugin",
     "main": "dist/applicationinsights-properties-js.js",
     "module": "dist-esm/applicationinsights-properties-js.js",
@@ -33,8 +33,8 @@
     },
     "dependencies": {
         "@microsoft/applicationinsights-shims" : "1.0.0",
-        "@microsoft/applicationinsights-core-js": "2.5.4",
-        "@microsoft/applicationinsights-common": "2.5.4"
+        "@microsoft/applicationinsights-core-js": "2.5.5",
+        "@microsoft/applicationinsights-common": "2.5.5"
     },
     "license": "MIT"
 }

--- a/extensions/applicationinsights-properties-js/src/Context/Internal.ts
+++ b/extensions/applicationinsights-properties-js/src/Context/Internal.ts
@@ -4,7 +4,7 @@
 import { IInternal } from '@microsoft/applicationinsights-common';
 import { ITelemetryConfig } from '../Interfaces/ITelemetryConfig';
 
-const Version = "2.5.4";
+const Version = "2.5.5";
 
 export class Internal implements IInternal {
 

--- a/extensions/applicationinsights-react-js/package.json
+++ b/extensions/applicationinsights-react-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-react-js",
-    "version": "2.5.4",
+    "version": "3.0.0",
     "description": "Microsoft Application Insights React plugin",
     "main": "dist/applicationinsights-react-js.js",
     "module": "dist-esm/applicationinsights-react-js.js",
@@ -46,9 +46,9 @@
         "typescript": "3.9.3"
     },
     "dependencies": {
-        "@microsoft/applicationinsights-shims" : "1.0.0",
-        "@microsoft/applicationinsights-core-js": "2.5.4",
-        "@microsoft/applicationinsights-common": "2.5.4",
+        "@microsoft/applicationinsights-shims" : "^1.0.0",
+        "@microsoft/applicationinsights-core-js": "^2.5.4",
+        "@microsoft/applicationinsights-common": "^2.5.4",
         "history": "^4.10.1"
     },
     "peerDependencies": {

--- a/extensions/applicationinsights-react-native/package.json
+++ b/extensions/applicationinsights-react-native/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-react-native",
-    "version": "2.2.3",
+    "version": "2.2.4",
     "description": "Microsoft Application Insights React Native Plugin",
     "main": "dist-esm/index.js",
     "types": "dist-esm/index.d.ts",
@@ -37,8 +37,8 @@
     },
     "dependencies": {
         "@microsoft/applicationinsights-shims" : "^1.0.0",
-        "@microsoft/applicationinsights-common": "^2.5.0",
-        "@microsoft/applicationinsights-core-js": "^2.5.0"
+        "@microsoft/applicationinsights-common": "^2.5.4",
+        "@microsoft/applicationinsights-core-js": "^2.5.4"
     },
     "peerDependencies": {
         "react-native": "*",

--- a/shared/AppInsightsCommon/package.json
+++ b/shared/AppInsightsCommon/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-common",
-    "version": "2.5.4",
+    "version": "2.5.5",
     "description": "Microsoft Application Insights Common JavaScript Library",
     "main": "./dist/applicationinsights-common.js",
     "module": "./dist-esm/applicationinsights-common.js",
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@microsoft/applicationinsights-shims" : "1.0.0",
-        "@microsoft/applicationinsights-core-js": "2.5.4"
+        "@microsoft/applicationinsights-core-js": "2.5.5"
     },
     "license": "MIT"
 }

--- a/shared/AppInsightsCore/package.json
+++ b/shared/AppInsightsCore/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/applicationinsights-core-js",
     "author": "Microsoft Corporation",
-    "version": "2.5.4",
+    "version": "2.5.5",
     "description": "Microsoft Application Insights Core Javascript SDK",
     "keywords": [
         "azure",


### PR DESCRIPTION
## 2.5.5

- #1278 Add optional 'eventsSendRequest' notification to NotificationManager
- #1269 TsLib v1.13.0 has breaking change (Remove dependency on TSLib)
  - Added new package **'applicationinsights-shims@1.0.0'**
- #991 Don't work with React HOOKS
  - #1120 Introducing React Hooks for AppInsights #1120
- #1274 Fix for withAITracking wrapping functional components.
- Using crypto to generate GUIDs when available (Make GUID more random)
- #1260 [BUG] Can't include Correlation Header on IE can fail
- #1258 Update snippet to support reporting script load failures
- #1251 [BUG] ajax.ts is using string trim() which is not supported on IE7/8
- #1249 Identify whether the script is being consumed via the CDN or NPM package
- Several minor documentation updates

### New Package applicationinsights-shims v1.0.0

- Created to remove dependency on TSLib as v 1.13.0 has introduced build breaks
  - provides internal implementation of __extends() and __assign() when no pre-existing version is present