### PR TITLE
Fix incorrect closure in _createMethods in snippet.js

### DIFF
--- a/AISKU/snippet/snippet.js
+++ b/AISKU/snippet/snippet.js
@@ -224,19 +224,20 @@
     
         function _createMethods(methods) {
             while (methods.length) {
-                var name = methods.pop();
-                // Define a temporary method that queues-up a the real method call
-                appInsights[name] = function () {
-                    // Capture the original arguments passed to the method
-                    var originalArguments = arguments;
-                    if (!loadFailed) { // If we have detected that the main script failed to load then stop queuing events that will never be processed
-                        // Queue-up a call to the real method
-                        appInsights.queue.push(function () {
-                            // Invoke the real method with the captured original arguments
-                            appInsights[name].apply(appInsights, originalArguments);
-                        });
-                    }
-                };
+                (function (name) {
+                    // Define a temporary method that queues-up a the real method call
+                    appInsights[name] = function () {
+                        // Capture the original arguments passed to the method
+                        var originalArguments = arguments;
+                        if (!loadFailed) { // If we have detected that the main script failed to load then stop queuing events that will never be processed
+                            // Queue-up a call to the real method
+                            appInsights.queue.push(function () {
+                                // Invoke the real method with the captured original arguments
+                                appInsights[name].apply(appInsights, originalArguments);
+                            });
+                        }
+                    };
+                })(methods.pop());
             }
         }
 


### PR DESCRIPTION
This fixes #1283.

This PR ensures AppInsights stub methods use the correct method names when tracking method calls before JS dependency has been downloaded.