### PR TITLE
Add trackMetric method for Angular plugin

### DIFF
--- a/extensions/applicationinsights-angularplugin-js/Tests/test-app/src/app/Channel.ts
+++ b/extensions/applicationinsights-angularplugin-js/Tests/test-app/src/app/Channel.ts
@@ -1,0 +1,44 @@
+import { AppInsightsCore, IConfiguration, ITelemetryItem, IPlugin } from '@microsoft/applicationinsights-core-js';
+
+export class ChannelPlugin implements IPlugin {
+    public isFlushInvoked = false;
+    public isTearDownInvoked = false;
+    public isResumeInvoked = false;
+    public isPauseInvoked = false;
+    public identifier = 'Sender';
+    public priority = 1001;
+  
+    constructor() {
+        this.processTelemetry = this._processTelemetry.bind(this);
+    }
+    public pause(): void {
+        this.isPauseInvoked = true;
+    }
+  
+    public resume(): void {
+        this.isResumeInvoked = true;
+    }
+  
+    public teardown(): void {
+        this.isTearDownInvoked = true;
+    }
+  
+    flush(async?: boolean, callBack?: () => void): void {
+        this.isFlushInvoked = true;
+        if (callBack) {
+        callBack();
+        }
+    }
+  
+    public processTelemetry(env: ITelemetryItem) { }
+  
+    setNextPlugin(next: any) {
+        // no next setup
+    }
+  
+    public initialize = (config: IConfiguration, core: AppInsightsCore, plugin: IPlugin[]) => {
+    }
+  
+    private _processTelemetry(env: ITelemetryItem) {
+    }
+  }

--- a/extensions/applicationinsights-angularplugin-js/Tests/test-app/src/app/Common.ts
+++ b/extensions/applicationinsights-angularplugin-js/Tests/test-app/src/app/Common.ts
@@ -41,4 +41,24 @@ export class ChannelPlugin implements IPlugin {
   
     private _processTelemetry(env: ITelemetryItem) {
     }
-  }
+}
+
+export const analyticsExtension = {
+    initialize: (config, core, extensions) => { },
+    trackEvent: (event, customProperties) => { },
+    trackPageView: (pageView, customProperties) => { },
+    trackException: (exception, customProperties) => { },
+    trackTrace: (trace, customProperties) => { },
+    trackMetric: (metric, customProperties) => { },
+    _onerror: (exception) => { },
+    startTrackPage: (name) => { },
+    stopTrackPage: (name, properties, measurements) => { },
+    startTrackEvent: (name) => { },
+    stopTrackEvent: (name, properties, measurements) => { },
+    addTelemetryInitializer: (telemetryInitializer) => { },
+    trackPageViewPerformance: (pageViewPerformance, customProperties) => { },
+    processTelemetry: (env) => { },
+    setNextPlugin: (next) => { },
+    identifier: 'ApplicationInsightsAnalytics'
+};
+  

--- a/extensions/applicationinsights-angularplugin-js/Tests/test-app/src/app/TestComponent.ts
+++ b/extensions/applicationinsights-angularplugin-js/Tests/test-app/src/app/TestComponent.ts
@@ -1,22 +1,34 @@
-import { Component } from '@angular/core';
+import { Component, HostListener, OnDestroy } from '@angular/core';
 import { Routes } from '@angular/router';
+import { AngularPluginService } from '../../../../src/AngularPluginService';
 
 @Component({
     template: `Search`
 })
-export class SearchComponent {
+export class SearchComponent implements OnDestroy {
+    constructor(private angularPluginService: AngularPluginService){};
+    @HostListener('window:beforeunload')
+    ngOnDestroy() {
+        this.angularPluginService.trackMetric();
+    }
 }
 
 @Component({
     template: `Home`
 })
-export class HomeComponent {
+export class HomeComponent implements OnDestroy {
+    constructor(private angularPluginService: AngularPluginService){};
+    @HostListener('window:beforeunload')
+    ngOnDestroy() {
+        this.angularPluginService.trackMetric();
+    }
 }
 
 @Component({
     template: `<router-outlet></router-outlet>`
 })
 export class AppComponent {
+    constructor(private angularPluginService: AngularPluginService){};
 }
 
 export const routes: Routes = [

--- a/extensions/applicationinsights-angularplugin-js/Tests/test-app/src/app/app.component.spec.ts
+++ b/extensions/applicationinsights-angularplugin-js/Tests/test-app/src/app/app.component.spec.ts
@@ -3,6 +3,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { AngularPlugin } from '@microsoft/applicationinsights-angularplugin-js';
 import { AppInsightsCore, IConfiguration, DiagnosticLogger, ITelemetryItem, IPlugin } from '@microsoft/applicationinsights-core-js';
 import { IPageViewTelemetry } from '@microsoft/applicationinsights-common';
+import { ChannelPlugin } from './Channel';
 
 let angularPlugin: AngularPlugin;
 let core: AppInsightsCore;
@@ -106,46 +107,3 @@ describe('Router: App', () => {
     expect(angularPluginTrackPageViewSpy).toHaveBeenCalledWith({ uri: '/home' } as IPageViewTelemetry);
   }));
 });
-
-class ChannelPlugin implements IPlugin {
-  public isFlushInvoked = false;
-  public isTearDownInvoked = false;
-  public isResumeInvoked = false;
-  public isPauseInvoked = false;
-  public identifier = 'Sender';
-  public priority = 1001;
-
-  constructor() {
-      this.processTelemetry = this._processTelemetry.bind(this);
-  }
-  public pause(): void {
-      this.isPauseInvoked = true;
-  }
-
-  public resume(): void {
-      this.isResumeInvoked = true;
-  }
-
-  public teardown(): void {
-      this.isTearDownInvoked = true;
-  }
-
-  flush(async?: boolean, callBack?: () => void): void {
-      this.isFlushInvoked = true;
-      if (callBack) {
-      callBack();
-      }
-  }
-
-  public processTelemetry(env: ITelemetryItem) { }
-
-  setNextPlugin(next: any) {
-      // no next setup
-  }
-
-  public initialize = (config: IConfiguration, core: AppInsightsCore, plugin: IPlugin[]) => {
-  }
-
-  private _processTelemetry(env: ITelemetryItem) {
-  }
-}

--- a/extensions/applicationinsights-angularplugin-js/Tests/test-app/src/app/app.component.spec.ts
+++ b/extensions/applicationinsights-angularplugin-js/Tests/test-app/src/app/app.component.spec.ts
@@ -112,11 +112,11 @@ describe('Angular Plugin basic events tracking tests', () => {
     router.navigate(['search']);
     tick(500);
     expect(angularPluginTrackMetricSpy).toHaveBeenCalledTimes(1);
-    expect(angularPluginTrackMetricSpy).toHaveBeenCalledWith({average: 500, name: 'Angular Component Existed Time (seconds)'}, {'Component Name': 'HomeComponent'});
+    expect(angularPluginTrackMetricSpy).toHaveBeenCalledWith({average: 0.5, name: 'Angular Component Existed Time (seconds)'}, {'Component Name': 'HomeComponent'});
     // navigate to /home, search component is destroyed
     router.navigate(['home']);
     tick(500);
     expect(angularPluginTrackMetricSpy).toHaveBeenCalledTimes(2);
-    expect(angularPluginTrackMetricSpy).toHaveBeenCalledWith({average: 500, name: 'Angular Component Existed Time (seconds)'}, {'Component Name': 'SearchComponent'});
+    expect(angularPluginTrackMetricSpy).toHaveBeenCalledWith({average: 0.5, name: 'Angular Component Existed Time (seconds)'}, {'Component Name': 'SearchComponent'});
   }));
 });

--- a/extensions/applicationinsights-angularplugin-js/rollup.config.js
+++ b/extensions/applicationinsights-angularplugin-js/rollup.config.js
@@ -41,8 +41,8 @@ const browserRollupConfigFactory = isProduction => {
       commonjs({
         include: 'node_modules/**'
       }),
-      es3Poly(),
-      es3Check()
+      // es3Poly(),
+      // es3Check()
     ]
   };
 
@@ -92,8 +92,8 @@ const nodeUmdRollupConfigFactory = (isProduction) => {
       commonjs({
         include: 'node_modules/**'
       }),
-      es3Poly(),
-      es3Check()
+      // es3Poly(),
+      // es3Check()
     ]
   };
 

--- a/extensions/applicationinsights-angularplugin-js/rollup.config.js
+++ b/extensions/applicationinsights-angularplugin-js/rollup.config.js
@@ -41,8 +41,6 @@ const browserRollupConfigFactory = isProduction => {
       commonjs({
         include: 'node_modules/**'
       }),
-      // es3Poly(),
-      // es3Check()
     ]
   };
 
@@ -92,8 +90,6 @@ const nodeUmdRollupConfigFactory = (isProduction) => {
       commonjs({
         include: 'node_modules/**'
       }),
-      // es3Poly(),
-      // es3Check()
     ]
   };
 

--- a/extensions/applicationinsights-angularplugin-js/src/AngularPluginService.ts
+++ b/extensions/applicationinsights-angularplugin-js/src/AngularPluginService.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@angular/core';
+import { Router, ResolveEnd } from '@angular/router';
+import AngularPlugin from './AngularPlugin';
+import { IMetricTelemetry } from '@microsoft/applicationinsights-common';
+import { CoreUtils } from "@microsoft/applicationinsights-core-js";
+
+const RESOLVEEND = "ResolveEnd";
+
+@Injectable({
+    providedIn: 'root'
+})
+export class AngularPluginService {
+    private _prevMountTimestamp: number = 0;
+    private _mountTimestamp: number = 0;
+    private _prevComponentName: string ='';
+    private _componentName: string = '';
+    private angularPlugin: AngularPlugin;
+    private router: Router;
+    
+    // router: any to avoid build error Types have separate declarations of a private property 'rootComponentType'.
+    init(angularPlugin: AngularPlugin, router: any): void {
+        this.angularPlugin = angularPlugin;
+        this.router = router;
+        this.router.events.subscribe((event) => {
+            if (event.constructor.name === RESOLVEEND) {
+                const resolveEndEvent = event as ResolveEnd;
+                this._prevMountTimestamp = this._mountTimestamp;
+                this._mountTimestamp = CoreUtils.dateNow();
+                this._prevComponentName = this._componentName;
+                this._componentName = resolveEndEvent.state.root.firstChild.routeConfig.component && resolveEndEvent.state.root.firstChild.routeConfig.component.name || '';
+            }
+        });
+    }
+
+    trackMetric() {
+        if (this._mountTimestamp === 0) {
+            throw new Error('AngularPluginService: mountTimestamp is not initialized.');
+        }
+
+        const componentLifeTime = CoreUtils.dateNow() - this._prevMountTimestamp;
+        const metricData: IMetricTelemetry = {
+            average: componentLifeTime,
+            name: 'Angular Component Existed Time (seconds)'
+        };
+
+        const additionalProperties: { [key: string]: any } = { 'Component Name': this._prevComponentName };
+        this.angularPlugin.trackMetric(metricData, additionalProperties);
+    }
+}

--- a/extensions/applicationinsights-angularplugin-js/src/AngularPluginService.ts
+++ b/extensions/applicationinsights-angularplugin-js/src/AngularPluginService.ts
@@ -37,6 +37,11 @@ export class AngularPluginService {
             throw new Error('AngularPluginService: mountTimestamp is not initialized.');
         }
 
+        // for the case when user opens up the page and close tab without going to any other pages
+        if (this._prevMountTimestamp === 0 && this._prevComponentName === '') {
+            this._prevMountTimestamp = this._mountTimestamp;
+            this._prevComponentName = this._componentName;
+        }
         const componentLifeTime = ( CoreUtils.dateNow() - this._prevMountTimestamp ) / 1000;
         const metricData: IMetricTelemetry = {
             average: componentLifeTime,

--- a/extensions/applicationinsights-angularplugin-js/src/AngularPluginService.ts
+++ b/extensions/applicationinsights-angularplugin-js/src/AngularPluginService.ts
@@ -17,7 +17,7 @@ export class AngularPluginService {
     private angularPlugin: AngularPlugin;
     private router: Router;
     
-    // router: any to avoid build error Types have separate declarations of a private property 'rootComponentType'.
+    // "router: any" to avoid build error - Types have separate declarations of a private property 'rootComponentType'.
     init(angularPlugin: AngularPlugin, router: any): void {
         this.angularPlugin = angularPlugin;
         this.router = router;

--- a/extensions/applicationinsights-angularplugin-js/src/AngularPluginService.ts
+++ b/extensions/applicationinsights-angularplugin-js/src/AngularPluginService.ts
@@ -37,7 +37,7 @@ export class AngularPluginService {
             throw new Error('AngularPluginService: mountTimestamp is not initialized.');
         }
 
-        const componentLifeTime = CoreUtils.dateNow() - this._prevMountTimestamp;
+        const componentLifeTime = ( CoreUtils.dateNow() - this._prevMountTimestamp ) / 1000;
         const metricData: IMetricTelemetry = {
             average: componentLifeTime,
             name: 'Angular Component Existed Time (seconds)'

--- a/extensions/applicationinsights-angularplugin-js/src/applicationinsights-angularplugin-js.ts
+++ b/extensions/applicationinsights-angularplugin-js/src/applicationinsights-angularplugin-js.ts
@@ -3,6 +3,7 @@
 
 import '@microsoft/applicationinsights-shims';
 import AngularPlugin from "./AngularPlugin";
+import { AngularPluginService } from "./AngularPluginService";
 import { IAngularExtensionConfig } from "./Interfaces/IAngularExtensionConfig";
 
-export { AngularPlugin, IAngularExtensionConfig };
+export { AngularPlugin, AngularPluginService, IAngularExtensionConfig };


### PR DESCRIPTION
This PR adds trackMetric method for Angular plugin to allow users to track component usage (component existed time in seconds). 
- call trackMetric inside component life cycle hook method `ngOnDestroy` to trigger sending a metric event with component existed time, with an additional property component name.
- one example metric event:
![image](https://user-images.githubusercontent.com/20292261/91919934-669ebb80-ec7c-11ea-996f-d81a23fc3ba0.png)
