### PR TITLE
[Release][React] Release Fix for v3.1.2

### DIFF
--- a/extensions/applicationinsights-react-js/package.json
+++ b/extensions/applicationinsights-react-js/package.json
@@ -11,7 +11,6 @@
         "url": "https://github.com/microsoft/ApplicationInsights-JS/tree/master/extensions/applicationinsights-react-js"
     },
     "scripts": {
-        "prepublishOnly": "npm install && npm run build",
         "build": "npm run build:esm && npm run build:browser",
         "build:esm": "tsc -p tsconfig.json",
         "build:browser": "rollup -c",

--- a/extensions/applicationinsights-react-native/package.json
+++ b/extensions/applicationinsights-react-native/package.json
@@ -10,7 +10,6 @@
         "url": "https://github.com/microsoft/ApplicationInsights-JS/tree/master/extensions/applicationinsights-react-native"
     },
     "scripts": {
-        "prepublishOnly": "npm install && npm run build",
         "build": "npm run build:esm && npm run build:package",
         "build:esm": "tsc -p tsconfig.json",
         "build:test": "tsc -p Tests/tsconfig.json",


### PR DESCRIPTION
- Remove prepublishOnly script as it's already packed during build validation