### PR TITLE
Extracting HOC tracked component class base for re-use

### DIFF
--- a/extensions/applicationinsights-react-js/src/applicationinsights-react-js.ts
+++ b/extensions/applicationinsights-react-js/src/applicationinsights-react-js.ts
@@ -3,7 +3,7 @@
 
 import { IReactExtensionConfig } from "./Interfaces/IReactExtensionConfig";
 import ReactPlugin from "./ReactPlugin";
-import withAITracking from "./withAITracking";
+import withAITracking, { AITrackedComponentBase } from "./withAITracking";
 import AppInsightsErrorBoundary from "./AppInsightsErrorBoundary"
 import {
   AppInsightsContext,
@@ -20,5 +20,6 @@ export {
   AppInsightsContext,
   useAppInsightsContext,
   useTrackEvent,
-  useTrackMetric
+  useTrackMetric,
+  AITrackedComponentBase
 };

--- a/extensions/applicationinsights-react-js/src/withAITracking.tsx
+++ b/extensions/applicationinsights-react-js/src/withAITracking.tsx
@@ -2,9 +2,91 @@
 // Licensed under the MIT License.
 
 import { IMetricTelemetry } from '@microsoft/applicationinsights-common';
-import { CoreUtils } from '@microsoft/applicationinsights-core-js';
+import { dateNow } from '@microsoft/applicationinsights-core-js';
 import * as React from 'react';
 import ReactPlugin from './ReactPlugin';
+
+/**
+ * Higher-order component base class to hook Application Insights tracking 
+ * in a React component's lifecycle.
+ */
+export abstract class AITrackedComponentBase<P> extends React.Component<P> {
+  protected _mountTimestamp: number = 0;
+  protected _firstActiveTimestamp: number = 0;
+  protected _idleStartTimestamp: number = 0;
+  protected _lastActiveTimestamp: number = 0;
+  protected _totalIdleTime: number = 0;
+  protected _idleCount: number = 0;
+  protected _idleTimeout: number = 5000;
+  protected _intervalId?: any;
+  protected _componentName: string;
+  protected _reactPlugin: ReactPlugin;
+
+  public constructor(props: P, reactPlugin: ReactPlugin, componentName: string,) {
+    super(props);
+
+    this._reactPlugin = reactPlugin;
+    this._componentName = componentName;
+  }
+
+  public componentDidMount() {
+    this._mountTimestamp = dateNow();
+    this._firstActiveTimestamp = 0;
+    this._totalIdleTime = 0;
+    this._lastActiveTimestamp = 0;
+    this._idleStartTimestamp = 0;
+    this._idleCount = 0;
+
+    this._intervalId = setInterval(() => {
+      if (this._lastActiveTimestamp > 0 && this._idleStartTimestamp === 0 && dateNow() - this._lastActiveTimestamp >= this._idleTimeout) {
+        this._idleStartTimestamp = dateNow();
+        this._idleCount++;
+      }
+    }, 100);
+  }
+
+  public componentWillUnmount() {
+    if (this._mountTimestamp === 0) {
+      throw new Error('withAITracking:componentWillUnmount: mountTimestamp is not initialized.');
+    }
+    if (this._intervalId) {
+      clearInterval(this._intervalId);
+    }
+
+    if (this._firstActiveTimestamp === 0) {
+      return;
+    }
+
+    const engagementTime = this.getEngagementTimeSeconds();
+    const metricData: IMetricTelemetry = {
+      average: engagementTime,
+      name: 'React Component Engaged Time (seconds)',
+      sampleCount: 1
+    };
+
+    const additionalProperties: { [key: string]: any } = { 'Component Name': this._componentName };
+    this._reactPlugin.trackMetric(metricData, additionalProperties);
+  }
+
+  protected trackActivity = (e: React.SyntheticEvent<any>): void => {
+    if (this._firstActiveTimestamp === 0) {
+      this._firstActiveTimestamp = dateNow();
+      this._lastActiveTimestamp = this._firstActiveTimestamp;
+    } else {
+      this._lastActiveTimestamp = dateNow();
+    }
+
+    if (this._idleStartTimestamp > 0) {
+      const lastIdleTime = this._lastActiveTimestamp - this._idleStartTimestamp;
+      this._totalIdleTime += lastIdleTime;
+      this._idleStartTimestamp = 0;
+    }
+  }
+
+  private getEngagementTimeSeconds(): number {
+    return (dateNow() - this._firstActiveTimestamp - this._totalIdleTime - this._idleCount * this._idleTimeout) / 1000;
+  }
+}
 
 /**
  * Higher-order component function to hook Application Insights tracking 
@@ -18,63 +100,20 @@ import ReactPlugin from './ReactPlugin';
 export default function withAITracking<P>(reactPlugin: ReactPlugin, Component: React.ComponentType<P>, componentName?: string, className?: string): React.ComponentClass<P> {
 
   if (componentName === undefined || componentName === null || typeof componentName !== 'string') {
-    componentName = Component.prototype && 
-          Component.prototype.constructor && 
-          Component.prototype.constructor.name || 
-          'Unknown';
+    componentName = Component.prototype &&
+      Component.prototype.constructor &&
+      Component.prototype.constructor.name ||
+      'Unknown';
   }
 
   if (className === undefined || className === null || typeof className !== 'string') {
     className = '';
   }
 
-  return class extends React.Component<P> {
-    private _mountTimestamp: number = 0;
-    private _firstActiveTimestamp: number = 0;
-    private _idleStartTimestamp: number = 0;
-    private _lastActiveTimestamp: number = 0;
-    private _totalIdleTime: number = 0;
-    private _idleCount: number = 0;
-    private _idleTimeout: number = 5000;
-    private _intervalId?: any;
+  return class extends AITrackedComponentBase<P> {
 
-    public componentDidMount() {
-      this._mountTimestamp = CoreUtils.dateNow();
-      this._firstActiveTimestamp = 0;
-      this._totalIdleTime = 0;
-      this._lastActiveTimestamp = 0;
-      this._idleStartTimestamp = 0;
-      this._idleCount = 0;
-
-      this._intervalId = setInterval(() => {
-        if (this._lastActiveTimestamp > 0 && this._idleStartTimestamp === 0 && CoreUtils.dateNow() - this._lastActiveTimestamp >= this._idleTimeout) {
-          this._idleStartTimestamp = CoreUtils.dateNow();
-          this._idleCount++;
-        }
-      }, 100);
-    }
-
-    public componentWillUnmount() {
-      if (this._mountTimestamp === 0) {
-        throw new Error('withAITracking:componentWillUnmount: mountTimestamp is not initialized.');
-      }
-      if (this._intervalId) {
-        clearInterval(this._intervalId);
-      }
-
-      if (this._firstActiveTimestamp === 0) {
-        return;
-      }
-
-      const engagementTime = this.getEngagementTimeSeconds();
-      const metricData: IMetricTelemetry = {
-        average: engagementTime,
-        name: 'React Component Engaged Time (seconds)',
-        sampleCount: 1
-      };
-
-      const additionalProperties: { [key: string]: any } = { 'Component Name': componentName };
-      reactPlugin.trackMetric(metricData, additionalProperties);
+    public constructor(props: P) {
+      super(props, reactPlugin, componentName);
     }
 
     public render() {
@@ -91,25 +130,6 @@ export default function withAITracking<P>(reactPlugin: ReactPlugin, Component: R
           <Component {...this.props} />
         </div>
       );
-    }
-
-    private trackActivity = (e: React.SyntheticEvent<any>): void => {
-      if (this._firstActiveTimestamp === 0) {
-        this._firstActiveTimestamp = CoreUtils.dateNow();
-        this._lastActiveTimestamp = this._firstActiveTimestamp;
-      } else {
-        this._lastActiveTimestamp = CoreUtils.dateNow();
-      }
-
-      if (this._idleStartTimestamp > 0) {
-        const lastIdleTime = this._lastActiveTimestamp - this._idleStartTimestamp;
-        this._totalIdleTime += lastIdleTime;
-        this._idleStartTimestamp = 0;
-      }
-    }
-
-    private getEngagementTimeSeconds(): number {
-      return (CoreUtils.dateNow() - this._firstActiveTimestamp - this._totalIdleTime - this._idleCount * this._idleTimeout) / 1000;
     }
   }
 }

--- a/extensions/applicationinsights-react-js/src/withAITracking.tsx
+++ b/extensions/applicationinsights-react-js/src/withAITracking.tsx
@@ -22,7 +22,7 @@ export abstract class AITrackedComponentBase<P> extends React.Component<P> {
   protected _componentName: string;
   protected _reactPlugin: ReactPlugin;
 
-  public constructor(props: P, reactPlugin: ReactPlugin, componentName: string,) {
+  public constructor(props: P, reactPlugin: ReactPlugin, componentName: string) {
     super(props);
 
     this._reactPlugin = reactPlugin;


### PR DESCRIPTION
While withAITracking function is working in most of the cases, it's not useful in a scenario when a content of the wrapped component is not physically located under the component's DOM tree. 
An example of that is Modal component from Microsoft Fluent UI framework but there are many other similar cases too.
Therefore, a developer may sometimes need to create a custom version of the HOC function, which for example, as in the case of the Modal component would wrap a content instead of the component itself, however still have the same tracking functionality as the app insights library HOC function.

The change here extract the HOC class so it can be re-used and customized by consumers of the library
