### PR TITLE
fix: add children prop to error boundary props

### DIFF
--- a/extensions/applicationinsights-react-js/src/AppInsightsErrorBoundary.tsx
+++ b/extensions/applicationinsights-react-js/src/AppInsightsErrorBoundary.tsx
@@ -8,6 +8,7 @@ import ReactPlugin from "./ReactPlugin";
 export interface IAppInsightsErrorBoundaryProps {
     appInsights: ReactPlugin
     onError: React.ComponentType<any>
+    children: React.ReactElement
 }
 
 export interface IAppInsightsErrorBoundaryState {


### PR DESCRIPTION
Closes  https://github.com/microsoft/ApplicationInsights-JS/issues/1804