### PR TITLE
Add clickanalytics plugin url config back

### DIFF
--- a/extensions/applicationinsights-clickanalytics-js/Tests/Unit/src/ClickEventTest.ts
+++ b/extensions/applicationinsights-clickanalytics-js/Tests/Unit/src/ClickEventTest.ts
@@ -10,6 +10,7 @@ import { PageAction } from "../../../src/events/PageAction";
 import { DomContentHandler } from '../../../src/handlers/DomContentHandler';
 import { IPageActionOverrideValues } from '../../../src/Interfaces/Datamodel'
 import { mergeConfig } from "../../../src/common/Utils";
+import { sanitizeUrl } from "../../../src/DataCollector";
 
 
 
@@ -1050,6 +1051,59 @@ export class ClickEventTest extends AITestClass {
                 pageAction.capturePageAction(element);
                 this.clock.tick(500);
                 Assert.equal(false, spy.called);
+            }
+        });
+
+        this.testCase({
+            name: "Test sanitizeUrl",
+            test: () => {
+                let fakeLocation1 = null;
+                let fakeLocation2 = {
+                    protocol:"https:",
+                    hostname:"www.test.com",
+                    host:"www.test.com",
+                    port:"3000",
+                    pathname:"/path",
+                    hash:"#test",
+                    search:"?q=search&rlz=1C1CHBF"
+                } as any;
+                let fakeLocation3 = {
+                    protocol:"https:",
+                    host:"www.test.com",
+                    port:"",
+                    pathname:"",
+                    hash:"",
+                    search:"?q=search&rlz=1C1CHBF"
+                } as any;
+
+                const config1 = {
+                    urlCollectHash: true,
+                    urlCollectQuery: true
+                };
+                const config2 = {
+                    urlCollectHash: false,
+                    urlCollectQuery: false
+                };
+                const config3 = {
+                    urlCollectHash:false,
+                    urlCollectQuery: true
+                };
+
+                
+                let url1 = sanitizeUrl(config1, fakeLocation1);
+                Assert.equal(null, url1);
+
+                let url2 = sanitizeUrl(config2, fakeLocation2);
+                Assert.equal("https://www.test.com:3000/path", url2);
+
+                let url3 = sanitizeUrl(config1,fakeLocation2);
+                Assert.equal("https://www.test.com:3000/path#test?q=search&rlz=1C1CHBF", url3);
+
+                let url4 = sanitizeUrl(config3, fakeLocation3);
+                Assert.equal("https://www.test.com?q=search&rlz=1C1CHBF", url4);
+
+                let url5 = sanitizeUrl(config1, fakeLocation3);
+                Assert.equal("https://www.test.com?q=search&rlz=1C1CHBF", url5);
             }
         });
     }

--- a/extensions/applicationinsights-clickanalytics-js/src/DataCollector.ts
+++ b/extensions/applicationinsights-clickanalytics-js/src/DataCollector.ts
@@ -132,6 +132,15 @@ export function sanitizeUrl(config: IClickAnalyticsConfiguration, location: Loca
     var url = location.protocol + "//" + (location.hostname || location.host) +         // location.hostname is not supported on Opera and Opera for Android
         (isValueAssigned(location.port) ? ":" + location.port : "") +
         location.pathname;
+        
+    if (!!config.urlCollectHash) { // false by default
+        url += (isValueAssigned(location.hash)? location.hash : "");
+    }
+
+    if (!!config.urlCollectQuery) { // false by default
+        url += (isValueAssigned(location.search)? location.search : "");
+    }
+
     return url;
 }
 

--- a/extensions/applicationinsights-clickanalytics-js/src/Interfaces/Datamodel.ts
+++ b/extensions/applicationinsights-clickanalytics-js/src/Interfaces/Datamodel.ts
@@ -43,6 +43,14 @@ export interface IClickAnalyticsConfiguration {
      * Default will be false
      */
     dropInvalidEvents?: boolean;
+    /**
+    * Enables the logging of values after a "#" character of the URL. Default is "false."
+    */
+    urlCollectHash?: boolean;
+    /**
+    * Enables the logging of the query string of the URL. Default is "false."
+    */
+    urlCollectQuery?: boolean;
 }
 
 /**


### PR DESCRIPTION
Details on this issue: https://github.com/microsoft/ApplicationInsights-JS/issues/1863

`urlCollectQuery` and `urlCollectHash` configs are removed in this PR: https://github.com/microsoft/ApplicationInsights-JS/pull/1444
  and the changes on Readme are back in PR: https://github.com/microsoft/ApplicationInsights-JS/pull/1455 due to auto merge