### PR TITLE
Cherry-Picking beta fix so merging master -> beta stops breaking nightly beta release

### DIFF
--- a/AISKU/Tests/Unit/src/AISKUSize.Tests.ts
+++ b/AISKU/Tests/Unit/src/AISKUSize.Tests.ts
@@ -9,9 +9,12 @@ export class AISKUSizeCheck extends AITestClass {
     private readonly MAX_RAW_DEFLATE_SIZE = 46;
     private readonly MAX_BUNDLE_DEFLATE_SIZE = 47;
     private readonly rawFilePath = "../dist/applicationinsights-web.min.js";
-    private readonly prodFilePath = "../browser/ai.2.min.js";
+    // Automatically updated by version scripts
+    private readonly currentVer = "2.8.5";
+    private readonly prodFilePath = `../browser/ai.${this.currentVer[0]}.min.js`;
 
     public testInitialize() {
+
     }
 
     public testFinishedCleanup(): void {

--- a/AISKU/Tests/Unit/src/CdnPackaging.tests.ts
+++ b/AISKU/Tests/Unit/src/CdnPackaging.tests.ts
@@ -12,6 +12,8 @@ const enum CdnFormat {
 }
 
 export class CdnPackagingChecks extends AITestClass {
+    // Automatically updated by version scripts
+    private readonly currentVer = "2.8.5";
 
     public testInitialize() {
     }
@@ -46,15 +48,15 @@ export class CdnPackagingChecks extends AITestClass {
     }
 
     private checkFullPackaging(): void {
-        this._checkPackaging("../browser/ai.2.js", CdnFormat.Umd);
-        this._checkPackaging("../browser/ai.2.gbl.js", CdnFormat.Gbl);
-        this._checkPackaging("../browser/ai.2.cjs.js", CdnFormat.CommonJs);
+        this._checkPackaging(`../browser/ai.${this.currentVer[0]}.js`, CdnFormat.Umd);
+        this._checkPackaging(`../browser/ai.${this.currentVer[0]}.gbl.js`, CdnFormat.Gbl);
+        this._checkPackaging(`../browser/ai.${this.currentVer[0]}.cjs.js`, CdnFormat.CommonJs);
     }
 
     private addMinifiedPackaging(): void {
-        this._checkPackaging("../browser/ai.2.min.js", CdnFormat.Umd);
-        this._checkPackaging("../browser/ai.2.gbl.min.js", CdnFormat.Gbl);
-        this._checkPackaging("../browser/ai.2.cjs.min.js", CdnFormat.CommonJs);
+        this._checkPackaging(`../browser/ai.${this.currentVer[0]}.min.js`, CdnFormat.Umd);
+        this._checkPackaging(`../browser/ai.${this.currentVer[0]}.gbl.min.js`, CdnFormat.Gbl);
+        this._checkPackaging(`../browser/ai.${this.currentVer[0]}.cjs.min.js`, CdnFormat.CommonJs);
     }
     
     private _validateExpectedExports(theExports: any) {


### PR DESCRIPTION
[Beta] Update size tests to automatically use the major number from the current version (#1873)

- this is automatically updated by the version scripts