### PR TITLE
Fixed release notes, previously used a deprecated file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,7 +662,7 @@ It is expected that most users will be using the `Public` URL, however, it is al
 
 ## Release Notes
 
-[Changelist](./CHANGELIST.md)
+[Releases](https://github.com/microsoft/ApplicationInsights-JS/releases)
 
 ## Browser Support
 

--- a/README.md
+++ b/README.md
@@ -662,7 +662,8 @@ It is expected that most users will be using the `Public` URL, however, it is al
 
 ## Release Notes
 
-[Releases](https://github.com/microsoft/ApplicationInsights-JS/releases)
+- [Releases](https://github.com/microsoft/ApplicationInsights-JS/releases)
+- [Changelist Notes](./RELEASES.md)
 
 ## Browser Support
 


### PR DESCRIPTION
The file linked in the 'Changelist' had been deprecated, moved to https://github.com/microsoft/ApplicationInsights-JS/releases , an active and dynamically supported list of releases.