### PR TITLE
Fix size check which "nightly" is added to the bundle

### DIFF
--- a/AISKULight/Tests/Unit/src/AISKULightSize.Tests.ts
+++ b/AISKULight/Tests/Unit/src/AISKULightSize.Tests.ts
@@ -4,8 +4,8 @@ import * as pako from "pako";
 export class AISKULightSizeCheck extends AITestClass {
     private readonly MAX_RAW_SIZE = 70;
     private readonly MAX_BUNDLE_SIZE = 70;
-    private readonly MAX_RAW_DEFLATE_SIZE = 28;
-    private readonly MAX_BUNDLE_DEFLATE_SIZE = 28;
+    private readonly MAX_RAW_DEFLATE_SIZE = 29;
+    private readonly MAX_BUNDLE_DEFLATE_SIZE = 29;
     private readonly rawFilePath = "../dist/applicationinsights-web-basic.min.js";
     private readonly prodFilePath = "../browser/aib.2.min.js";
 


### PR DESCRIPTION
The Nightly deployment is failure because the "version" string included contains "nightly" which just pushes the compressed size of AISKU Lite now.