### PR TITLE
Followup for [Beta][Task]15982357: Dynamic config for Properties extension #1972

### DIFF
--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -1753,9 +1753,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001448",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001448.tgz",
-      "integrity": "sha512-tq2YI+MJnooG96XpbTRYkBxLxklZPOdLmNIOdIhvf7SNJan6u5vCKum8iT7ZfCt70m1GPkuC7P3TtX6UuhupuA==",
+      "version": "1.0.30001449",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001449.tgz",
+      "integrity": "sha512-CPB+UL9XMT/Av+pJxCKGhdx+yg1hzplvFJQlJ2n68PyQGMz9L/E2zCyLdOL8uasbouTUgnPl+y0tccI/se+BEw==",
       "funding": [
         {
           "type": "opencollective",
@@ -2225,9 +2225,9 @@
       }
     },
     "node_modules/eslint-plugin-security": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-1.6.0.tgz",
-      "integrity": "sha512-SGvyejbhW/dziRbzOroKX5bj8z/qtBOw7Q95C9CBbJQqBtFB2o4OxSM3MCO2u9noPp7B6DDaFGtXTx8ImPiO/A==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-1.7.0.tgz",
+      "integrity": "sha512-+ahcCh7M5w7fdFaNccaChBGq8nd3Wa+XvGJS+hY74kvrMhG4EuLbljRIjilOqh1iDMW/EckB1oOWmiVIYlVACQ==",
       "peer": true,
       "dependencies": {
         "safe-regex": "^2.1.1"
@@ -3157,9 +3157,9 @@
       }
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -5145,9 +5145,9 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -6856,9 +6856,9 @@
       "peer": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001448",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001448.tgz",
-      "integrity": "sha512-tq2YI+MJnooG96XpbTRYkBxLxklZPOdLmNIOdIhvf7SNJan6u5vCKum8iT7ZfCt70m1GPkuC7P3TtX6UuhupuA=="
+      "version": "1.0.30001449",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001449.tgz",
+      "integrity": "sha512-CPB+UL9XMT/Av+pJxCKGhdx+yg1hzplvFJQlJ2n68PyQGMz9L/E2zCyLdOL8uasbouTUgnPl+y0tccI/se+BEw=="
     },
     "chalk": {
       "version": "4.1.2",
@@ -7226,9 +7226,9 @@
       }
     },
     "eslint-plugin-security": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-1.6.0.tgz",
-      "integrity": "sha512-SGvyejbhW/dziRbzOroKX5bj8z/qtBOw7Q95C9CBbJQqBtFB2o4OxSM3MCO2u9noPp7B6DDaFGtXTx8ImPiO/A==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-1.7.0.tgz",
+      "integrity": "sha512-+ahcCh7M5w7fdFaNccaChBGq8nd3Wa+XvGJS+hY74kvrMhG4EuLbljRIjilOqh1iDMW/EckB1oOWmiVIYlVACQ==",
       "peer": true,
       "requires": {
         "safe-regex": "^2.1.1"
@@ -7926,9 +7926,9 @@
       "integrity": "sha512-t+UerCsQviSymAInD01Pw+Dn/usmz1sRO+3Zk1+lx8eg+WKpD2ulcwWqHHL0+aseRBr+3+vIhiG1K1JTwaIcTA=="
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "http-errors": {
       "version": "2.0.0",
@@ -9427,9 +9427,9 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "tsutils": {
       "version": "3.21.0",

--- a/extensions/applicationinsights-properties-js/Tests/Unit/src/SessionManager.Tests.ts
+++ b/extensions/applicationinsights-properties-js/Tests/Unit/src/SessionManager.Tests.ts
@@ -1,6 +1,6 @@
 import { Assert, AITestClass } from "@microsoft/ai-test-framework";
 import { SinonStub } from 'sinon';
-import { AppInsightsCore, DiagnosticLogger, createCookieMgr, newId, dateNow } from "@microsoft/applicationinsights-core-js";
+import { AppInsightsCore, DiagnosticLogger, createCookieMgr, newId, dateNow, createDynamicConfig } from "@microsoft/applicationinsights-core-js";
 import PropertiesPlugin from "../../../src/PropertiesPlugin";
 import { _SessionManager } from "../../../src/Context/Session";
 
@@ -64,13 +64,12 @@ export class SessionManagerTests extends AITestClass {
             test: () => {
 
                 var sessionPrefix = newId();
-                var config = {
+                var config = createDynamicConfig({
                     namePrefix: sessionPrefix,
                     sessionExpirationMs: undefined,
                     sessionRenewalMs: undefined,
                     cookieDomain: undefined
-
-                };
+                }).cfg;
                 // Setup
                 let cookie = "";
                 const cookieStub: SinonStub = this.sandbox.stub(this.core.getCookieMgr(), 'set').callsFake((cookieName, value, maxAge, domain, path) => {
@@ -92,14 +91,15 @@ export class SessionManagerTests extends AITestClass {
             test: () => {
 
                 var sessionPrefix = newId();
-                var config = {
+                var config = createDynamicConfig({
                     namePrefix: sessionPrefix,
                     sessionCookiePostfix: "testSessionCookieNamePostfix",
                     sessionExpirationMs: undefined,
                     sessionRenewalMs: undefined,
                     cookieDomain: undefined
 
-                };
+                }).cfg;
+
                 // Setup
                 let cookie = "";
                 const cookieStub: SinonStub = this.sandbox.stub(this.core.getCookieMgr(), 'set').callsFake((cookieName, value, maxAge, domain, path) => {
@@ -121,12 +121,12 @@ export class SessionManagerTests extends AITestClass {
             useFakeTimers: true,
             test: () => {
                 var sessionPrefix = newId();
-                var config = {
+                var config = createDynamicConfig({
                     namePrefix: sessionPrefix,
                     sessionExpirationMs: 30 * 60 * 1000,
                     sessionRenewalMs: 24 * 60 * 60 * 1000,
                     cookieDomain: undefined
-                };
+                }).cfg;
 
                 // Simulate 100ms as when zero the cookie values are deemed to be invalid
                 this.clock.tick(100);
@@ -152,12 +152,12 @@ export class SessionManagerTests extends AITestClass {
             useFakeTimers: true,
             test: () => {
                 var sessionPrefix = newId();
-                var config = {
+                var config = createDynamicConfig({
                     namePrefix: sessionPrefix,
                     sessionExpirationMs: 5000,
                     sessionRenewalMs: 24 * 60 * 60 * 1000,
                     cookieDomain: undefined
-                };
+                }).cfg;
 
                 // Simulate 100ms as when zero the cookie values are deemed to be invalid
                 this.clock.tick(100);
@@ -211,12 +211,12 @@ export class SessionManagerTests extends AITestClass {
             useFakeTimers: true,
             test: () => {
                 var sessionPrefix = newId();
-                var config = {
+                var config = createDynamicConfig({
                     namePrefix: sessionPrefix,
                     sessionExpirationMs: 86400000,
                     sessionRenewalMs: 5000,
                     cookieDomain: undefined
-                };
+                }).cfg;
 
                 // Simulate 100ms as when zero the cookie values are deemed to be invalid
                 this.clock.tick(100);
@@ -269,12 +269,12 @@ export class SessionManagerTests extends AITestClass {
             useFakeTimers: true,
             test: () => {
                 var sessionPrefix = newId();
-                var config = {
+                var config = createDynamicConfig({
                     namePrefix: sessionPrefix,
                     sessionExpirationMs: 30 * 60 * 1000,
                     sessionRenewalMs: 24 * 60 * 60 * 1000,
                     cookieDomain: undefined
-                };
+                }).cfg;
 
                 // Simulate 100ms as when zero the cookie values are deemed to be invalid
                 this.clock.tick(100);
@@ -315,12 +315,12 @@ export class SessionManagerTests extends AITestClass {
             useFakeTimers: true,
             test: () => {
                 var sessionPrefix = newId();
-                var config = {
+                var config = createDynamicConfig({
                     namePrefix: sessionPrefix,
                     sessionExpirationMs: 5000,
                     sessionRenewalMs: 24 * 60 * 60 * 1000,
                     cookieDomain: undefined
-                };
+                }).cfg;
 
                 // Simulate 100ms as when zero the cookie values are deemed to be invalid
                 this.clock.tick(100);

--- a/extensions/applicationinsights-properties-js/Tests/Unit/src/properties.tests.ts
+++ b/extensions/applicationinsights-properties-js/Tests/Unit/src/properties.tests.ts
@@ -130,7 +130,6 @@ export class PropertiesTests extends AITestClass {
                 let extConfig =  core.config.extensionConfig[id];
 
                 let exceptedDefaultConfig = {
-                    instrumentationKey: "instrumentation_key",
                     accountId: null,
                     sessionRenewalMs: 30 * 60 * 1000,
                     samplingPercentage: 100,
@@ -166,7 +165,6 @@ export class PropertiesTests extends AITestClass {
                 const channel = new TestChannelPlugin();
                 const properties = new PropertiesPlugin();
                 let exceptedDefaultConfig = {
-                    instrumentationKey: "key1",
                     accountId: "id1",
                     sessionRenewalMs: 30 * 60 * 101,
                     samplingPercentage: 90,
@@ -280,7 +278,6 @@ export class PropertiesTests extends AITestClass {
               
                 // change config
                 let newConfig = {
-                    instrumentationKey: "key2",
                     accountId: "id2",
                     sessionRenewalMs: 30 * 60 * 102,
                     samplingPercentage: 90,
@@ -375,7 +372,228 @@ export class PropertiesTests extends AITestClass {
                 core.getCookieMgr().del("ai_session" + "postfix2");
             }
         });
+
+        this.testCase({
+            name: "Properties Configuration: config can be set from root dynamically and updated as a new single object",
+            useFakeTimers: true,
+            test: () => {
+                const core = new AppInsightsCore();
+                core.setCookieMgr(createCookieMgr({
+                    cookieCfg: {
+                        setCookie: (name: string, value: string) => this._setCookie(name, value),
+                        getCookie: (name: string) => this._getCookie(name),
+                        delCookie: (name: string) => this._delCookie(name)
+                    }
+                }, core.logger))
+                const channel = new TestChannelPlugin();
+                const properties = new PropertiesPlugin();
+                let exceptedDefaultConfig = {
+                    accountId: "id1",
+                    sessionRenewalMs: 30 * 60 * 101,
+                    samplingPercentage: 90,
+                    sessionExpirationMs: 24 * 60 * 60 * 101,
+                    cookieDomain: "domain1",
+                    sdkExtension: "ext1",
+                    isBrowserLinkTrackingEnabled: false,
+                    appId: "id1",
+                    getSessionId: "session1",
+                    namePrefix: "prefix1",
+                    sessionCookiePostfix: "postfix1",
+                    userCookiePostfix: "usercookie1",
+                    idLength: 26,
+                    getNewId: (idLength?: number) => {
+                        return "" + (idLength || 0);
+                    }
+                } as IPropertiesConfig;
+                let id = properties.identifier;
+                const config = {
+                    instrumentationKey: "instrumentation_key",
+                    extensionConfig: {
+                        [id]: exceptedDefaultConfig
+                    }
+                };
+                this.onDone(() => {
+                    core.unload(false);
+                });
+                let appBuild = "build";
+                let deviceId = "newDeviceId";
+                let locId = "locId";
+                let parentId = "parentId";
+                let seId = "sessionId";
+                let cookie = "";
+                let cookieValue = ""
+                const cookieStub: SinonStub = this.sandbox.stub(core.getCookieMgr(), "set").callsFake((cookieName, value, maxAge, domain, path) => {
+                    cookie = cookieName;
+                    cookieValue = value;
+                });
+
+                // Initialize
+                core.initialize(config, [channel, properties]);
+                let extConfig = properties["_extConfig"];
+                Assert.deepEqual(extConfig, exceptedDefaultConfig, "intial config is set");
+
+                // check inital context
+                let propCtx = properties.context;
+                let appId = propCtx.appId();
+                Assert.equal(appId, null, "appId should be null");
+
+                let application = propCtx.application;
+                Assert.equal(application.build, null, "application build should be null by default");
+               
+                let device = propCtx.device;
+                Assert.equal(device.id, "browser", "device id should not be null");
+              
+                let location = propCtx.location;
+                Assert.ok(location, "location should not be null");
+               
+                let trace = propCtx.telemetryTrace;
+                let traceId = trace.traceID;
+                Assert.ok(trace, "trace should not be null");
+                Assert.ok(trace.name, "trace name should not be null");
+                Assert.ok(traceId, "trace id should not be null");
+                Assert.ok(!trace.parentID, "trace parent should be null");
+                
+                let user = propCtx.user;
+                Assert.deepEqual(user.config, exceptedDefaultConfig, "user config should be updated");
+
+                let internalSdkVer = propCtx.internal.sdkVersion;
+                Assert.ok(internalSdkVer.indexOf("ext1") > -1, "sdk ext prefix should be used");
+
+                let session = propCtx.session;
+                Assert.ok(session, "session should not be null");
+
+                let sessionMgr = propCtx.sessionManager;
+                Assert.ok(sessionMgr.automaticSession, "session mgr should not be null");
+             
+                let os = propCtx.os;
+                Assert.equal(os, null, "os should be null");
+            
+                let web = propCtx.web;
+                Assert.equal(web, null, "web should be null");
+
+                let sessionId = propCtx.getSessionId();
+                Assert.equal(sessionId, null, "session Id should be null");
+                
+                // change properities here to make sure we won't overwrite them after config change
+                device.id = deviceId;
+                location.ip = locId;
+                trace.parentID = parentId;
+                application.build = appBuild;
+                session.id = seId;
+                sessionMgr.automaticSession.id = seId;
+                Assert.equal(propCtx.getSessionId(), seId, "session Id should be updated test1");
+                let sessionPrefix = "ai_session" + "postfix1";
+                sessionMgr.backup();
+                let sessionStorage = utlGetLocalStorage(core.logger, sessionPrefix);
+                Assert.ok(sessionStorage.indexOf(seId) > -1, "sessionStorage should be set based on session id test1");
+
+                sessionMgr.update();
+                Assert.ok(cookieStub.called, "cookie set test1");
+                Assert.equal(sessionPrefix, cookie, "cookie name is set test1");
+                Assert.ok(cookieValue.indexOf(seId) > -1, "cookie value is set test1");
+                this.clock.tick(20);
+                sessionMgr.update();
+                Assert.equal(sessionMgr.automaticSession.id, seId, "session id should be same test1");
+                this.clock.tick(24 * 60 * 60 * 101 - 20);
+                sessionMgr.update();
+                Assert.equal(sessionMgr.automaticSession.id, "26", "session id should be renewed test1");
+                Assert.ok(cookieValue.indexOf("26|") > -1,"cookie value is reset test1");
+              
+                // change config
+                let newConfig = {
+                    accountId: "id2",
+                    sessionRenewalMs: 30 * 60 * 102,
+                    samplingPercentage: 90,
+                    sessionExpirationMs: 24 * 60 * 60 * 102,
+                    cookieDomain: "domain2",
+                    sdkExtension: "ext2",
+                    isBrowserLinkTrackingEnabled: true,
+                    appId: "id2",
+                    getSessionId: "session2",
+                    namePrefix: "prefix2",
+                    sessionCookiePostfix: "postfix2",
+                    userCookiePostfix: "usercookie2",
+                    idLength: 26,
+                    getNewId: (idLength?: number) => {
+                        return "" + (idLength || 0) + 1;
+                    }
+                } as IPropertiesConfig;
+
+                core.config.extensionConfig =  core.config.extensionConfig?  core.config.extensionConfig : {};
+                core.config.extensionConfig[id] = newConfig;
+                this.clock.tick(1);
+
+                // properties that should be updated
+                extConfig = properties["_extConfig"];
+                Assert.deepEqual(extConfig, newConfig, "extConfig should be updated");
+                propCtx = properties.context;
+
+                user = propCtx.user;
+                Assert.deepEqual(user.config, newConfig, "user config should be updated");
+
+                internalSdkVer = propCtx.internal.sdkVersion;
+                Assert.ok(internalSdkVer.indexOf("ext2") > -1, "sdk ext prefix should be used and updated");
+
+                sessionMgr = propCtx.sessionManager;
+                Assert.ok(sessionMgr.automaticSession, "session mgr should not be null");
+                sessionPrefix = "ai_session" + "postfix2";
+                sessionMgr.backup();
+                sessionStorage = utlGetLocalStorage(core.logger, sessionPrefix);
+                Assert.ok(sessionStorage.indexOf("26") > -1, "sessionStorage should be updated based on session id test2");
+                Assert.ok(cookieValue.indexOf("26|") > -1, "cookie should not be updated test2");
+                Assert.equal(sessionMgr.automaticSession.id, "26", "session id should not be renewed test2");
+                
+                this.clock.tick(60000);
+                sessionMgr.update();
+                Assert.ok(cookieStub.called, "cookie set test3");
+                Assert.equal(sessionPrefix, cookie, "cookie name is set test3");
+                Assert.equal(sessionMgr.automaticSession.id, "26", "session id should not be renewed test3");
+                Assert.ok(cookieValue.indexOf("26|") > -1, "cookie value should use previous session id test3");
+                Assert.equal(sessionMgr.automaticSession.id, "26", "session id should not be renewed test4");
+                this.clock.tick(24 * 60 * 60 * 102);
+                sessionMgr.update();
+                Assert.ok(cookieStub.called, "cookie set test5");
+                Assert.equal(sessionPrefix, cookie, "cookie name is set test5");
+                Assert.ok(cookieValue.indexOf("261|") > -1, "cookie value is renewed test6");
+                Assert.equal(sessionMgr.automaticSession.id, "261", "session id should be renewed test6");
+
+                //properties that should not be updated
+                appId = propCtx.appId();
+                Assert.equal(appId, null, "appId should be null");
+
+                application = propCtx.application;
+                Assert.equal(application.build, appBuild, "application build should not be updated");
+
+                device = propCtx.device;
+                Assert.equal(device.id, deviceId, "device id should not be updated");
+
+                location = propCtx.location;
+                Assert.equal(location.ip, locId, "location should not be updated");
+
+                trace = propCtx.telemetryTrace;
+                Assert.ok(trace, "trace should not be null");
+                Assert.ok(trace.name, "trace name should not be null");
+                Assert.equal(trace.traceID, traceId, "trace id should be same with previous one");
+                Assert.equal(trace.parentID, parentId, "trace parent should not be updated");
+             
+                session = propCtx.session;
+                Assert.equal(session.id, seId, "session should not be updated");
+                
+                os = propCtx.os;
+                Assert.equal(os, null,"os should not be updated");
+
+                sessionId = propCtx.getSessionId();
+                Assert.equal(sessionId, seId, "session Id should not be updated");
+                
+                if (utlCanUseLocalStorage()) {
+                    window.localStorage.clear();
+                }
+                core.getCookieMgr().del("ai_session" + "postfix1");
+                core.getCookieMgr().del("ai_session" + "postfix2");
+            }
+        });
     }
+
 
     private addDeviceTests() {
         this.testCase({
@@ -962,7 +1180,6 @@ export class PropertiesTests extends AITestClass {
 
     private getTelemetryConfig(): IPropertiesConfig {
         return {
-            instrumentationKey: "",
             accountId: "",
             sessionRenewalMs: 1000,
             samplingPercentage: 0,

--- a/extensions/applicationinsights-properties-js/src/Context/Internal.ts
+++ b/extensions/applicationinsights-properties-js/src/Context/Internal.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { IInternal } from "@microsoft/applicationinsights-common";
-import { onConfigChange } from "@microsoft/applicationinsights-core-js";
+import { IUnloadHookContainer, onConfigChange } from "@microsoft/applicationinsights-core-js";
 import { IPropertiesConfig } from "../Interfaces/IPropertiesConfig";
 
 const Version = "2.8.5";
@@ -37,11 +37,13 @@ export class Internal implements IInternal {
     /**
      * Constructs a new instance of the internal telemetry data class.
      */
-    constructor(config: IPropertiesConfig) {
+    constructor(config: IPropertiesConfig, unloadHookContainer?: IUnloadHookContainer) {
         
-        onConfigChange((config), () => {
+        let unloadHook = onConfigChange((config), () => {
             let prefix =  config.sdkExtension;
             this.sdkVersion = (prefix ? prefix + "_" : "") + "javascript:" + Version;
         });
+
+        unloadHookContainer && unloadHookContainer.add(unloadHook);
     }
 }

--- a/extensions/applicationinsights-properties-js/src/Context/User.ts
+++ b/extensions/applicationinsights-properties-js/src/Context/User.ts
@@ -4,8 +4,8 @@
 import dynamicProto from "@microsoft/dynamicproto-js";
 import { IUserContext, utlRemoveStorage } from "@microsoft/applicationinsights-common";
 import {
-    IAppInsightsCore, ICookieMgr, _eInternalMessageId, _throwInternal, eLoggingSeverity, newId, onConfigChange, safeGetCookieMgr,
-    safeGetLogger, toISOString
+    IAppInsightsCore, ICookieMgr, IUnloadHookContainer, _eInternalMessageId, _throwInternal, eLoggingSeverity, newId, onConfigChange,
+    safeGetCookieMgr, safeGetLogger, toISOString
 } from "@microsoft/applicationinsights-core-js";
 import { objDefineProp } from "@nevware21/ts-utils";
 import { IPropertiesConfig } from "../Interfaces/IPropertiesConfig";
@@ -69,7 +69,7 @@ export class User implements IUserContext {
      */
     public isUserCookieSet = false;
 
-    constructor(config: IPropertiesConfig, core: IAppInsightsCore) {
+    constructor(config: IPropertiesConfig, core: IAppInsightsCore, unloadHookContainer?: IUnloadHookContainer) {
         let _logger = safeGetLogger(core);
         let _cookieManager: ICookieMgr = safeGetCookieMgr(core);
         let _storageNamePrefix: string;
@@ -82,7 +82,7 @@ export class User implements IUserContext {
                 get: () => config
             });
 
-            onConfigChange(config, () => {
+            let unloadHook = onConfigChange(config, () => {
 
                 const userCookiePostfix = config.userCookiePostfix || "";
                 _storageNamePrefix = User.userCookieName + userCookiePostfix;
@@ -130,6 +130,8 @@ export class User implements IUserContext {
                     }
                 }
             });
+
+            unloadHookContainer && unloadHookContainer.add(unloadHook);
 
             function _generateNewId() {
                 let theConfig = (config || {}) as IPropertiesConfig;

--- a/extensions/applicationinsights-properties-js/src/Interfaces/IPropertiesConfig.ts
+++ b/extensions/applicationinsights-properties-js/src/Interfaces/IPropertiesConfig.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 export interface IPropertiesConfig {
-    readonly instrumentationKey: string;
     readonly accountId: string;
     readonly sessionRenewalMs: number;
     readonly samplingPercentage: number;

--- a/extensions/applicationinsights-properties-js/src/TelemetryContext.ts
+++ b/extensions/applicationinsights-properties-js/src/TelemetryContext.ts
@@ -9,8 +9,8 @@ import {
     PageView
 } from "@microsoft/applicationinsights-common";
 import {
-    IAppInsightsCore, IDistributedTraceContext, IProcessTelemetryContext, ITelemetryItem, _InternalLogMessage, getSetValue, hasWindow,
-    isNullOrUndefined, isString, objKeys, setValue
+    IAppInsightsCore, IDistributedTraceContext, IProcessTelemetryContext, ITelemetryItem, IUnloadHookContainer, _InternalLogMessage,
+    getSetValue, hasWindow, isNullOrUndefined, isString, objKeys, setValue
 } from "@microsoft/applicationinsights-core-js";
 import { Application } from "./Context/Application";
 import { Device } from "./Context/Device";
@@ -50,19 +50,19 @@ export class TelemetryContext implements IPropTelemetryContext {
     public appId: () => string;
     public getSessionId: () => string;
 
-    constructor(core: IAppInsightsCore, defaultConfig: IPropertiesConfig, previousTraceCtx?: IDistributedTraceContext) {
+    constructor(core: IAppInsightsCore, defaultConfig: IPropertiesConfig, previousTraceCtx?: IDistributedTraceContext, unloadHookContainer?: IUnloadHookContainer) {
         let logger = core.logger
 
         dynamicProto(TelemetryContext, this, (_self) => {
             _self.appId = _nullResult;
             _self.getSessionId = _nullResult;
             _self.application = new Application();
-            _self.internal = new Internal(defaultConfig);
+            _self.internal = new Internal(defaultConfig, unloadHookContainer);
             if (hasWindow()) {
-                _self.sessionManager = new _SessionManager(defaultConfig, core);
+                _self.sessionManager = new _SessionManager(defaultConfig, core, unloadHookContainer);
                 _self.device = new Device();
                 _self.location = new Location();
-                _self.user = new User(defaultConfig, core);
+                _self.user = new User(defaultConfig, core, unloadHookContainer);
 
                 let traceId: string;
                 let parentId: string;

--- a/shared/AppInsightsCore/src/Config/DynamicConfig.ts
+++ b/shared/AppInsightsCore/src/Config/DynamicConfig.ts
@@ -73,6 +73,16 @@ function _createDynamicHandler<T extends IConfiguration>(logger: IDiagnosticLogg
         theState.use(null, configHandler);
     }
 
+    function _ref<C>(target: C, name: string) {
+        // Make sure it's dynamic and mark as referenced with it's current value
+        return _setDynamicProperty(theState, target, name, target[name], true);
+    }
+
+    function _rdOnly<C>(target: C, name: string) {
+        // Make sure it's dynamic and mark as readonly with it's current value
+        return _setDynamicProperty(theState, target, name, target[name], false, true);
+    }
+
     function _applyDefaults<C>(theConfig: C, defaultValues: IConfigDefaults<C, T>): C {
         if (defaultValues) {
             // Resolve/apply the defaults
@@ -93,6 +103,8 @@ function _createDynamicHandler<T extends IConfiguration>(logger: IDiagnosticLogg
         set: _setValue,
         setDf: _applyDefaults,
         watch: _watch,
+        ref: _ref,
+        rdOnly: _rdOnly,
         _block: _block
     };
 

--- a/shared/AppInsightsCore/src/Config/DynamicState.ts
+++ b/shared/AppInsightsCore/src/Config/DynamicState.ts
@@ -11,26 +11,10 @@ import { _IDynamicConfigHandlerState } from "./_IDynamicConfigHandlerState";
 const symPrefix = "[[ai_";
 const symPostfix = "]]";
 
-/**
- * @internal
- * @ignore
- */
-interface _IWaitingHandlers<T> {
-    /**
-     * The handler to be re-executed
-     */
-    h: IWatcherHandler<T>;
-
-    /**
-     * The detail objects that caused this handler to be re-executed, each property has a detail instance
-     * but may be the same handler
-     */
-    //d: _IDynamicDetail<T>[];
-}
-
 export function _createState<T>(cfgHandler: _IInternalDynamicConfigHandler<T>): _IDynamicConfigHandlerState<T> {
     let dynamicPropertySymbol = newSymbol(symPrefix + "get" + cfgHandler.uid + symPostfix);
     let dynamicPropertyReadOnly = newSymbol(symPrefix + "ro" + cfgHandler.uid + symPostfix);
+    let dynamicPropertyReferenced = newSymbol(symPrefix + "rf" + cfgHandler.uid + symPostfix);
     let dynamicPropertyDetail = newSymbol(symPrefix + "dtl" + cfgHandler.uid + symPostfix);
     let _waitingHandlers: IWatcherHandler<T>[] = null;
     let _watcherTimer: ITimerHandler = null;
@@ -52,7 +36,9 @@ export function _createState<T>(cfgHandler: _IInternalDynamicConfigHandler<T>): 
             callback({
                 cfg: cfgHandler.cfg,
                 set: cfgHandler.set.bind(cfgHandler),
-                setDf: cfgHandler.setDf.bind(cfgHandler)
+                setDf: cfgHandler.setDf.bind(cfgHandler),
+                ref: cfgHandler.ref.bind(cfgHandler),
+                rdOnly: cfgHandler.rdOnly.bind(cfgHandler)
             });
         } catch(e) {
             let logger = cfgHandler.logger;
@@ -156,6 +142,7 @@ export function _createState<T>(cfgHandler: _IInternalDynamicConfigHandler<T>): 
     theState = {
         prop: dynamicPropertySymbol,
         ro: dynamicPropertyReadOnly,
+        rf: dynamicPropertyReferenced,
         hdlr: cfgHandler,
         add: _addWatcher,
         notify: _notifyWatchers,

--- a/shared/AppInsightsCore/src/Config/IDynamicConfigHandler.ts
+++ b/shared/AppInsightsCore/src/Config/IDynamicConfigHandler.ts
@@ -49,6 +49,22 @@ export interface IDynamicConfigHandler<T extends IConfiguration> {
      * @param defaultValues - The default values to apply to the config
      */
     setDf: <C>(theConfig: C, defaultValues: IConfigDefaults<C, T>) => C;
+
+    /**
+     * Set this named property of the target as referenced, which will cause any object or array instances
+     * to be updated in-place rather than being entirely replaced. All other values will continue to be replaced.
+     * @returns The referenced properties current value
+     */
+    ref: <C, V = any>(target: C, name: string) => V;
+
+    /**
+     * Set this named property of the target as read-only, which will block this single named property from
+     * ever being changed for the target instance.
+     * This does NOT freeze or seal the instance, it just stops the direct re-assignment of the named property,
+     * if the value is a non-primitive (ie. an object or array) it's properties will still be mutable.
+     * @returns The referenced properties current value
+     */
+    rdOnly: <C, V = any>(target: C, name: string) => V;
 }
 
 /**

--- a/shared/AppInsightsCore/src/Config/IDynamicWatcher.ts
+++ b/shared/AppInsightsCore/src/Config/IDynamicWatcher.ts
@@ -26,6 +26,22 @@ export interface IWatchDetails<T extends IConfiguration> {
      * @param defaultValues - The default values to apply to the config
      */
     setDf: <C>(theConfig: C, defaultValues: IConfigDefaults<C>) => C;
+
+    /**
+     * Set this named property of the target as referenced, which will cause any object or array instance
+     * to be updated in-place rather than being entirely replaced. All other values will continue to be replaced.
+     * @returns The referenced properties current value
+     */
+    ref: <C, V = any>(target: C, name: string) => V;
+
+    /**
+     * Set this named property of the target as read-only, which will block this single named property from
+     * ever being changed for the target instance.
+     * This does NOT freeze or seal the instance, it just stops the direct re-assignment of the named property,
+     * if the value is a non-primitive (ie. an object or array) it's properties will still be mutable.
+     * @returns The referenced properties current value
+     */
+    rdOnly: <C, V = any>(target: C, name: string) => V;
 }
 
 export type WatcherFunction<T extends IConfiguration> = (details: IWatchDetails<T>) => void;

--- a/shared/AppInsightsCore/src/Config/_IDynamicConfigHandlerState.ts
+++ b/shared/AppInsightsCore/src/Config/_IDynamicConfigHandlerState.ts
@@ -20,8 +20,9 @@ export interface _IDynamicGetter {
  * Interface for the global dynamic config handler
  */
 export interface _IDynamicConfigHandlerState<T> {
-    prop: symbol;
-    ro: symbol;
+    prop: symbol;   // Identify that this is a dynamic property
+    ro: symbol;     // Identify that this property is read-only
+    rf: symbol;     // Identify that this property is referenced and should be updated in-place
     
     /**
      * Link to the handler

--- a/shared/AppInsightsCore/src/JavaScriptSDK/ProcessTelemetryContext.ts
+++ b/shared/AppInsightsCore/src/JavaScriptSDK/ProcessTelemetryContext.ts
@@ -162,19 +162,22 @@ function _createInternalContext<T extends IBaseProcessingContext>(telemetryChain
                 extCfg = {};
             }
 
-            // Always set the value so that it's created as a dynamic config element (if not already)
-            dynamicHandler.set(cfg, STR_EXTENSION_CONFIG, extCfg);  // Note: it is valid for the "value" to be undefined
-            extCfg = cfg.extensionConfig;
-        
+            // Always set the value so that the property always exists
+            cfg[STR_EXTENSION_CONFIG] = extCfg;     // Note: it is valid for the "value" to be undefined
+
+            // Calling `ref()` has a side effect of causing the referenced property to become dynamic  (if not already)
+            extCfg = dynamicHandler.ref(cfg, STR_EXTENSION_CONFIG);
             if (extCfg) {
                 idCfg = extCfg[identifier];
                 if (!idCfg && createIfMissing) {
                     idCfg = {} as T;
                 }
 
-                // Always set the value so that it's created as a dynamic config element (if not already)
-                dynamicHandler.set(extCfg, identifier, idCfg);
-                idCfg = extCfg[identifier];
+                // Always set the value so that the property always exists
+                extCfg[identifier] = idCfg;         // Note: it is valid for the "value" to be undefined
+
+                // Calling `ref()` has a side effect of causing the referenced property to become dynamic  (if not already)
+                idCfg = dynamicHandler.ref(extCfg, identifier);
             }
         }
 

--- a/shared/AppInsightsCore/src/JavaScriptSDK/UnloadHandlerContainer.ts
+++ b/shared/AppInsightsCore/src/JavaScriptSDK/UnloadHandlerContainer.ts
@@ -14,7 +14,7 @@ export interface IUnloadHandlerContainer {
     run: (itemCtx: IProcessTelemetryUnloadContext, unloadState: ITelemetryUnloadState) => void
 }
 
-export function createUnloadHandlerContainer() {
+export function createUnloadHandlerContainer(): IUnloadHandlerContainer {
     let handlers: UnloadHandler[] = [];
 
     function _addHandler(handler: UnloadHandler) {

--- a/shared/AppInsightsCore/src/JavaScriptSDK/UnloadHookContainer.ts
+++ b/shared/AppInsightsCore/src/JavaScriptSDK/UnloadHookContainer.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { arrAppend, arrForEach, dumpObj } from "@nevware21/ts-utils";
+import { eLoggingSeverity, _eInternalMessageId } from "../JavaScriptSDK.Enums/LoggingEnums";
+import { IDiagnosticLogger } from "../JavaScriptSDK.Interfaces/IDiagnosticLogger";
+import { ILegacyUnloadHook, IUnloadHook } from "../JavaScriptSDK.Interfaces/IUnloadHook";
+import { _throwInternal } from "./DiagnosticLogger";
+
+/**
+ * Interface which identifiesAdd this hook so that it is automatically removed during unloading
+ * @param hooks - The single hook or an array of IInstrumentHook objects
+ */
+export interface IUnloadHookContainer {
+    add: (hooks: IUnloadHook | IUnloadHook[] | Iterator<IUnloadHook> | ILegacyUnloadHook | ILegacyUnloadHook[] | Iterator<ILegacyUnloadHook>) => void;
+    run: (logger?: IDiagnosticLogger) => void;
+}
+
+/**
+ * Create a IUnloadHookContainer which can be used to remember unload hook functions to be executed during the component unloading
+ * process.
+ * @returns A new IUnloadHookContainer instance
+ */
+export function createUnloadHookContainer(): IUnloadHookContainer {
+    let _hooks: Array<ILegacyUnloadHook | IUnloadHook> = [];
+
+    function _doUnload(logger: IDiagnosticLogger) {
+        let oldHooks = _hooks;
+        _hooks = [];
+
+        // Remove all registered unload hooks
+        arrForEach(oldHooks, (fn) => {
+            // allow either rm or remove callback function
+            try{
+                ((fn as IUnloadHook).rm || (fn as ILegacyUnloadHook).remove).call(fn);
+            } catch (e) {
+                _throwInternal(logger, eLoggingSeverity.WARNING, _eInternalMessageId.PluginException, "Unloading:" + dumpObj(e));
+            }
+        });
+    }
+
+    function _addHook(hooks: IUnloadHook | IUnloadHook[] | Iterator<IUnloadHook> | ILegacyUnloadHook | ILegacyUnloadHook[] | Iterator<ILegacyUnloadHook>) {
+        if (hooks) {
+            arrAppend(_hooks, hooks);
+        }
+    }
+
+    return {
+        run: _doUnload,
+        add: _addHook
+    };
+}

--- a/shared/AppInsightsCore/src/applicationinsights-core-js.ts
+++ b/shared/AppInsightsCore/src/applicationinsights-core-js.ts
@@ -80,6 +80,7 @@ export { getDebugListener, getDebugExt } from "./JavaScriptSDK/DbgExtensionUtils
 export { TelemetryInitializerFunction, ITelemetryInitializerHandler, ITelemetryInitializerContainer } from "./JavaScriptSDK.Interfaces/ITelemetryInitializers";
 export { createUniqueNamespace } from "./JavaScriptSDK/DataCacheHelper";
 export { UnloadHandler, IUnloadHandlerContainer, createUnloadHandlerContainer } from "./JavaScriptSDK/UnloadHandlerContainer";
+export { IUnloadHookContainer, createUnloadHookContainer } from "./JavaScriptSDK/UnloadHookContainer";
 export { ITelemetryUpdateState } from "./JavaScriptSDK.Interfaces/ITelemetryUpdateState";
 export { ITelemetryUnloadState } from "./JavaScriptSDK.Interfaces/ITelemetryUnloadState";
 export { IDistributedTraceContext } from "./JavaScriptSDK.Interfaces/IDistributedTraceContext";


### PR DESCRIPTION
- Add ability to tag Dynamic Config properties as referenced to support updating extensionConfig in-place with a new object instance
- Add IUnloadHookContainer to allow passing extension level unload hook container to sub-components