### PR TITLE
[main] use proper URL for tracking when fetch is passed an empty string

### DIFF
--- a/extensions/applicationinsights-dependencies-js/Tests/Unit/src/ajax.tests.ts
+++ b/extensions/applicationinsights-dependencies-js/Tests/Unit/src/ajax.tests.ts
@@ -1670,6 +1670,7 @@ export class AjaxTests extends AITestClass {
                     Assert.equal(1, dependencyFields.length, "trackDependencyDataInternal was called");
                     Assert.ok(dependencyFields[0].dependency.startTime, "startTime was specified before trackDependencyDataInternal was called");
                     Assert.equal(undefined, dependencyFields[0].sysProperties, "no system properties");
+                    Assert.equal(window.location.href.split("#")[0], dependencyFields[0].dependency.target, "Target is captured.");
 
                     // Assert that the HTTP method was preserved
                     Assert.equal(1, fetchCalls.length);
@@ -1732,11 +1733,16 @@ export class AjaxTests extends AITestClass {
                     Assert.ok(dependencyFields[0].dependency.startTime, "startTime was specified before trackDependencyDataInternal was called");
                     Assert.equal(expectedTraceId, dependencyFields[0].sysProperties!.trace.traceID, "system properties traceId");
                     Assert.equal(expectedSpanId, dependencyFields[0].sysProperties!.trace.parentID, "system properties spanId");
+                    Assert.equal(window.location.href.split("#")[0], dependencyFields[0].dependency.target, "Target is captured.");
 
                     // Assert that the HTTP method was preserved
                     Assert.equal(1, fetchCalls.length);
                     Assert.notEqual(undefined, fetchCalls[0].init, "Has init param");
                     Assert.equal("post", fetchCalls[0].init?.method, "Has post method");
+                    let headers:Headers = fetchCalls[0].init.headers as Headers;
+                    Assert.notEqual(undefined, headers, "has headers");
+                    Assert.equal(true, headers.has(RequestHeaders.requestIdHeader), "AI header should be present"); // AI
+                    Assert.equal(true, headers.has(RequestHeaders.traceParentHeader), "W3c header should be present"); // W3C
 
                     testContext.testDone();
                 }, () => {

--- a/extensions/applicationinsights-dependencies-js/src/ajax.ts
+++ b/extensions/applicationinsights-dependencies-js/src/ajax.ts
@@ -15,7 +15,7 @@ import {
     dumpObj, eLoggingSeverity, eventOn, generateW3CId, getExceptionName, getGlobal, getIEVersion, getLocation, getPerformance, isFunction,
     isNullOrUndefined, isString, isXhrSupported, mergeEvtNamespace, onConfigChange, strPrototype, strTrim
 } from "@microsoft/applicationinsights-core-js";
-import { isWebWorker, objFreeze, scheduleTimeout, strIndexOf, strSubstr, strSubstring } from "@nevware21/ts-utils";
+import { isWebWorker, objFreeze, scheduleTimeout, strIndexOf, strSplit, strSubstr, strSubstring } from "@nevware21/ts-utils";
 import { DependencyInitializerFunction, IDependencyInitializerDetails, IDependencyInitializerHandler } from "./DependencyInitializer";
 import {
     DependencyListenerFunction, IDependencyHandler, IDependencyListenerContainer, IDependencyListenerDetails, IDependencyListenerHandler
@@ -1184,14 +1184,20 @@ export class AjaxMonitor extends BaseTelemetryPlugin implements IDependenciesPlu
                 ajaxData.requestSentTime = dateTimeUtilsNow();
                 ajaxData.errorStatusText = _enableAjaxErrorStatusText;
 
+                let requestUrl: string;
                 if (input instanceof Request) {
-                    ajaxData.requestUrl = input ? input.url : "";
-                } else if (input === "" ) {
-                    const location = getLocation();
-                    ajaxData.requestUrl = location?.href?.split("#")[0] || input;
+                    requestUrl = (input||{}).url || "";
                 } else {
-                    ajaxData.requestUrl = input;
+                    requestUrl = input;
                 }
+                if (requestUrl === "" ) {
+                    const location = getLocation();
+                    if (location && location.href) {
+                        requestUrl = strSplit(location.href, "#")[0];
+                    }
+                }
+
+                ajaxData.requestUrl = requestUrl;
 
                 let method = "GET";
                 if (init && init.method) {

--- a/extensions/applicationinsights-dependencies-js/src/ajax.ts
+++ b/extensions/applicationinsights-dependencies-js/src/ajax.ts
@@ -1186,8 +1186,9 @@ export class AjaxMonitor extends BaseTelemetryPlugin implements IDependenciesPlu
 
                 if (input instanceof Request) {
                     ajaxData.requestUrl = input ? input.url : "";
-                } else if (input === "") {
-                    ajaxData.requestUrl = window.location.href.split("#")[0];
+                } else if (input === "" ) {
+                    const location = getLocation();
+                    ajaxData.requestUrl = location?.href?.split("#")[0] || input;
                 } else {
                     ajaxData.requestUrl = input;
                 }

--- a/extensions/applicationinsights-dependencies-js/src/ajax.ts
+++ b/extensions/applicationinsights-dependencies-js/src/ajax.ts
@@ -1186,6 +1186,8 @@ export class AjaxMonitor extends BaseTelemetryPlugin implements IDependenciesPlu
 
                 if (input instanceof Request) {
                     ajaxData.requestUrl = input ? input.url : "";
+                } else if (input === "") {
+                    ajaxData.requestUrl = window.location.href.split("#")[0];
                 } else {
                     ajaxData.requestUrl = input;
                 }


### PR DESCRIPTION
This allows AI to track the dependency and sets the Traceparent header on the request to the server (if otherwise allowed).

`Traceparent` is now set
![image](https://github.com/microsoft/ApplicationInsights-JS/assets/3874909/84d28c56-9341-46bb-b434-0b55f869d47f)

Fully-populated dependency is sent to ApplicationInsights
![image](https://github.com/microsoft/ApplicationInsights-JS/assets/3874909/e978192f-104c-4aab-83f7-e51c00135bef)
![image](https://github.com/microsoft/ApplicationInsights-JS/assets/3874909/bb8463fe-e494-490e-91ca-ab0d915b725a)

Data is displayed in Application Insights
![image](https://github.com/microsoft/ApplicationInsights-JS/assets/3874909/d7a4e0cc-3c4d-48fc-ba46-10a35dc4b56e)

Fixes #2164 