### PR TITLE
[main] Add example of how to use stopTrackEvent #2209

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,28 @@ appInsights.trackEvent({
 });
 ```
 
+```js
+appInsights.startTrackEvent("event name"); 
+appInsights.stopTrackEvent("event name", {
+  prop1: 3.14, 
+  prop2: 'string',
+  prop3: {nested:"objects are okay too"}
+  }
+)
+```
+If you wish to organize customer properties into separate sections based on properties and measurements for better visualization on the Azure Portal, consider using the following code:
+
+```js
+appInsights.startTrackEvent("event name"); 
+appInsights.stopTrackEvent("event name", {
+  stringProp1: 'string',
+  stringProp2: {nested:"objects are okay too"}
+  },
+  {numProp1: 3.15, numProp2: 90000}
+)
+```
+
+
 ### Setting Up Autocollection
 
 All autocollection is ON by default. The full version of the Application Insights Javascript SDK auto collects:


### PR DESCRIPTION
based on local experiment, 
appInsights.stopTrackEvent("test",{property: {p1:3, p2:4}}) 
appInsights.stopTrackEvent("test3", {prop1: 1, prop2: "string", prop3: 4});
 appInsights.stopTrackEvent("test4", {prop1: 1, prop2: "string", prop3: {t:"k"}}); appInsights.stopTrackPage("testtest","url", {"a":"apple", b:3})
appInsights.stopTrackPage("test9","url", {"a":"apple", b:"TEST"})
could all work, and the properties are shown in azure portal
