### PR TITLE
[main] set script attribut to avoid race condition when multiple sdks are inited #2355

### DIFF
--- a/AISKU/src/Init.ts
+++ b/AISKU/src/Init.ts
@@ -68,6 +68,9 @@ try {
     if (typeof window !== strUndefined) {
         var _window = window;
         aiName = _window["appInsightsSDK"] || "appInsights";
+        if (document.currentScript) {
+            aiName = document.currentScript.getAttribute("data-ai-name") || aiName;
+        }
         if (typeof JSON !== strUndefined) {
             // get snippet or initialize to an empty object
 

--- a/tools/applicationinsights-web-snippet/src/snippet.ts
+++ b/tools/applicationinsights-web-snippet/src/snippet.ts
@@ -258,6 +258,7 @@ declare var cfg:ISnippetConfig;
             const _createScript = (src: string) => {
                 let scriptElement : HTMLElement = doc.createElement(scriptText);
                 (scriptElement as any)["src"] = src;
+                (scriptElement as any).setAttribute("data-ai-name", aiName);
                 // Allocate Cross origin only if defined and available
                 let crossOrigin = cfg[strCrossOrigin];
                 if ((crossOrigin || crossOrigin === "") && scriptElement[strCrossOrigin] != strUndefined) {


### PR DESCRIPTION
related to issue #2355 
  tests locally and works using the new script as following:
<script type="text/javascript" >
!(function (cfg)......
  src: "http://localhost:9001/AISKU/browser/es5/ai.3.2.1.js",
    name: "appInsights2", // Global SDK Instance name defaults to "appInsights" when not supplied
  });
 </script>