### PR TITLE
Add `metadata` configuration object to TelemetryItem, for use in `.track(...)` function to enable customizing  event property truncation threshold

### DIFF
--- a/channels/applicationinsights-channel-js/src/EnvelopeCreator.ts
+++ b/channels/applicationinsights-channel-js/src/EnvelopeCreator.ts
@@ -222,7 +222,7 @@ export function EventEnvelopeCreator(logger: IDiagnosticLogger, telemetryItem: I
         _convertPropsUndefinedToCustomDefinedValue(customProperties, customUndefinedValue);
     }
     const eventName = telemetryItem[strBaseData].name;
-    const eventData = new Event(logger, eventName, customProperties, customMeasurements);
+    const eventData = new Event(logger, eventName, customProperties, customMeasurements, telemetryItem.metadata["maxLength"]);
     const data = new Data<Event>(Event.dataType, eventData);
     return _createEnvelope<Event>(logger, Event.envelopeType, telemetryItem, data);
 }

--- a/shared/AppInsightsCommon/Tests/Unit/src/AppInsightsCommon.tests.ts
+++ b/shared/AppInsightsCommon/Tests/Unit/src/AppInsightsCommon.tests.ts
@@ -1,7 +1,7 @@
 import { strRepeat } from "@nevware21/ts-utils";
 import { Assert, AITestClass } from "@microsoft/ai-test-framework";
 import {  DiagnosticLogger } from "@microsoft/applicationinsights-core-js";
-import { dataSanitizeInput, dataSanitizeKey, dataSanitizeMessage, dataSanitizeProperties DataSanitizerValues, dataSanitizeString } from "../../../src/Telemetry/Common/DataSanitizer";
+import { dataSanitizeInput, dataSanitizeKey, dataSanitizeMessage, dataSanitizeProperties, DataSanitizerValues, dataSanitizeString } from "../../../src/Telemetry/Common/DataSanitizer";
 
 
 export class ApplicationInsightsTests extends AITestClass {

--- a/shared/AppInsightsCommon/Tests/Unit/src/AppInsightsCommon.tests.ts
+++ b/shared/AppInsightsCommon/Tests/Unit/src/AppInsightsCommon.tests.ts
@@ -35,7 +35,7 @@ export class ApplicationInsightsTests extends AITestClass {
         });
 
         this.testCase({
-            name: 'DataSanitizerTests: property sanitizer respects max length.',
+            name: 'DataSanitizerTests: property sanitizer respects default truncation limit.',
             test: () => {
                 // const define
                 const MAX_PROPERTY_LENGTH = DataSanitizerValues.MAX_PROPERTY_LENGTH;
@@ -52,7 +52,7 @@ export class ApplicationInsightsTests extends AITestClass {
         })
 
         this.testCase({
-            name: 'DataSanitizerTests: property sanitizer respects max length.',
+            name: 'DataSanitizerTests: property sanitizer respects max length parameter being passed in.',
             test: () => {
                 // const define
                 const customMaxLength = 5;

--- a/shared/AppInsightsCommon/Tests/Unit/src/AppInsightsCommon.tests.ts
+++ b/shared/AppInsightsCommon/Tests/Unit/src/AppInsightsCommon.tests.ts
@@ -35,6 +35,40 @@ export class ApplicationInsightsTests extends AITestClass {
         });
 
         this.testCase({
+            name: 'DataSanitizerTests: property sanitizer respects max length.',
+            test: () => {
+                // const define
+                const MAX_PROPERTY_LENGTH = DataSanitizerValues.MAX_PROPERTY_LENGTH;
+
+                // use cases
+                const messageShort: String = "hi";
+                const messageLong = strRepeat("abc", MAX_PROPERTY_LENGTH + 1);
+                
+                // Assert
+                Assert.equal(messageShort.length, dataSanitizeProperties(this.logger, messageShort).length);
+                Assert.notEqual(messageLong.length, dataSanitizeProperties(this.logger, messageLong).length);
+                Assert.equal(MAX_PROPERTY_LENGTH, dataSanitizeProperties(this.logger, messageLong).length);
+            }
+        })
+
+        this.testCase({
+            name: 'DataSanitizerTests: property sanitizer respects max length.',
+            test: () => {
+                // const define
+                const customMaxLength = 5;
+
+                // use cases
+                const messageShort: String = "hi";
+                const messageLong = strRepeat("abc",  customMaxLength + 1);
+
+                // Assert
+                Assert.equal(messageShort.length, dataSanitizeProperties(this.logger, messageShort, customMaxLength).length);
+                Assert.notEqual(messageLong.length, dataSanitizeProperties(this.logger, messageLong, customMaxLength).length);
+                Assert.equal(customMaxLength, dataSanitizeProperties(this.logger, messageLong, customMaxLength).length);
+            }
+        })
+
+        this.testCase({
             name: 'DataSanitizerTests: throwInternal function is called correctly in sanitizeMessage function',
             test: () => {
                 // const define

--- a/shared/AppInsightsCommon/Tests/Unit/src/AppInsightsCommon.tests.ts
+++ b/shared/AppInsightsCommon/Tests/Unit/src/AppInsightsCommon.tests.ts
@@ -1,7 +1,7 @@
 import { strRepeat } from "@nevware21/ts-utils";
 import { Assert, AITestClass } from "@microsoft/ai-test-framework";
 import {  DiagnosticLogger } from "@microsoft/applicationinsights-core-js";
-import { dataSanitizeInput, dataSanitizeKey, dataSanitizeMessage, DataSanitizerValues, dataSanitizeString } from "../../../src/Telemetry/Common/DataSanitizer";
+import { dataSanitizeInput, dataSanitizeKey, dataSanitizeMessage, dataSanitizeProperties DataSanitizerValues, dataSanitizeString } from "../../../src/Telemetry/Common/DataSanitizer";
 
 
 export class ApplicationInsightsTests extends AITestClass {
@@ -74,7 +74,7 @@ export class ApplicationInsightsTests extends AITestClass {
                 // const define
                 const loggerStub = this.sandbox.stub(this.logger , "throwInternal");
                 const MAX_MESSAGE_LENGTH = DataSanitizerValues.MAX_MESSAGE_LENGTH;
-                
+
                 // use cases
                 const messageShort: String = "hi";
                 const messageLong = strRepeat("a", MAX_MESSAGE_LENGTH + 2);

--- a/shared/AppInsightsCommon/Tests/Unit/src/AppInsightsCommon.tests.ts
+++ b/shared/AppInsightsCommon/Tests/Unit/src/AppInsightsCommon.tests.ts
@@ -38,14 +38,14 @@ export class ApplicationInsightsTests extends AITestClass {
             name: 'DataSanitizerTests: property sanitizer respects default truncation limit.',
             test: () => {
                 // const define
-                const MAX_PROPERTY_LENGTH = DataSanitizerValues.MAX_PROPERTY_LENGTH;
+                const MAX_PROPERTY_LENGTH: number = DataSanitizerValues.MAX_PROPERTY_LENGTH;
 
                 // use cases
-                const messageShort: String = "hi";
-                const messageLong = strRepeat("abc", MAX_PROPERTY_LENGTH + 1);
+                const messageShort: string = "hi";
+                const messageLong: string = strRepeat("abc", MAX_PROPERTY_LENGTH + 1);
                 const testProperties = {
-                    "prop1": messageLong,
-                    "prop2": messageShort
+                    messageLong,
+                    messageShort
                 }
 
                 // Assert
@@ -62,11 +62,11 @@ export class ApplicationInsightsTests extends AITestClass {
                 const customMaxLength = 5;
 
                 // use cases
-                const messageShort: String = "hi";
-                const messageLong = strRepeat("abc",  customMaxLength + 1);
+                const messageShort: string = "hi";
+                const messageLong: string = strRepeat("abc",  customMaxLength + 1);
                 const testProperties = {
-                    "prop1": messageLong,
-                    "prop2": messageShort
+                    messageLong,
+                    messageShort
                 }
 
                 // Assert

--- a/shared/AppInsightsCommon/Tests/Unit/src/AppInsightsCommon.tests.ts
+++ b/shared/AppInsightsCommon/Tests/Unit/src/AppInsightsCommon.tests.ts
@@ -43,28 +43,36 @@ export class ApplicationInsightsTests extends AITestClass {
                 // use cases
                 const messageShort: String = "hi";
                 const messageLong = strRepeat("abc", MAX_PROPERTY_LENGTH + 1);
-                
+                const testProperties = {
+                    "prop1": messageLong,
+                    "prop2": messageShort
+                }
+
                 // Assert
-                Assert.equal(messageShort.length, dataSanitizeProperties(this.logger, messageShort).length);
-                Assert.notEqual(messageLong.length, dataSanitizeProperties(this.logger, messageLong).length);
-                Assert.equal(MAX_PROPERTY_LENGTH, dataSanitizeProperties(this.logger, messageLong).length);
+                Assert.equal(messageShort.length, dataSanitizeProperties(this.logger, testProperties).messageShort.length);
+                Assert.notEqual(messageLong.length, dataSanitizeProperties(this.logger, testProperties).messageLong.length);
+                Assert.equal(MAX_PROPERTY_LENGTH, dataSanitizeProperties(this.logger, testProperties).messageLong.length);
             }
         })
 
         this.testCase({
             name: 'DataSanitizerTests: property sanitizer respects max length parameter being passed in.',
             test: () => {
-                // const define
+                // const define     
                 const customMaxLength = 5;
 
                 // use cases
                 const messageShort: String = "hi";
                 const messageLong = strRepeat("abc",  customMaxLength + 1);
+                const testProperties = {
+                    "prop1": messageLong,
+                    "prop2": messageShort
+                }
 
                 // Assert
-                Assert.equal(messageShort.length, dataSanitizeProperties(this.logger, messageShort, customMaxLength).length);
-                Assert.notEqual(messageLong.length, dataSanitizeProperties(this.logger, messageLong, customMaxLength).length);
-                Assert.equal(customMaxLength, dataSanitizeProperties(this.logger, messageLong, customMaxLength).length);
+                Assert.equal(messageShort.length, dataSanitizeProperties(this.logger, testProperties, customMaxLength).messageShort.length);
+                Assert.notEqual(messageLong.length, dataSanitizeProperties(this.logger, testProperties, customMaxLength).messageLong.length);
+                Assert.equal(customMaxLength, dataSanitizeProperties(this.logger, testProperties, customMaxLength).messageLong.length);
             }
         })
 
@@ -173,7 +181,7 @@ export class ApplicationInsightsTests extends AITestClass {
 
                 // const define
                 const MAX_STRING_LENGTH = DataSanitizerValues.MAX_STRING_LENGTH;
-               
+
                 // use cases
                 const strShort: String = "hi";
                 const strLong = strRepeat("a", MAX_STRING_LENGTH + 2);
@@ -196,7 +204,7 @@ export class ApplicationInsightsTests extends AITestClass {
             test: () => {
                 // const define
                 const MAX_NAME_LENGTH = DataSanitizerValues.MAX_NAME_LENGTH;
-               
+
                 // use cases
                 const nameShort: String = "hi";
                 const nameLong = strRepeat("a", MAX_NAME_LENGTH + 2);

--- a/shared/AppInsightsCommon/src/Telemetry/Common/DataSanitizer.ts
+++ b/shared/AppInsightsCommon/src/Telemetry/Common/DataSanitizer.ts
@@ -134,7 +134,7 @@ export function dataSanitizeException(logger: IDiagnosticLogger, exception: any)
     return exceptionTrunc || exception;
 }
 
-export function dataSanitizeProperties(logger: IDiagnosticLogger, properties: any, maxLength = Number(DataSanitizerValues.MAX_PROPERTY_LENGTH)) {
+export function dataSanitizeProperties(logger: IDiagnosticLogger, properties: any, maxLength: number = DataSanitizerValues.MAX_PROPERTY_LENGTH) {
     if (properties) {
         const tempProps = {};
         objForEachKey(properties, (prop, value) => {

--- a/shared/AppInsightsCommon/src/Telemetry/Common/DataSanitizer.ts
+++ b/shared/AppInsightsCommon/src/Telemetry/Common/DataSanitizer.ts
@@ -134,7 +134,7 @@ export function dataSanitizeException(logger: IDiagnosticLogger, exception: any)
     return exceptionTrunc || exception;
 }
 
-export function dataSanitizeProperties(logger: IDiagnosticLogger, properties: any) {
+export function dataSanitizeProperties(logger: IDiagnosticLogger, properties: any, maxLength = Number(DataSanitizerValues.MAX_PROPERTY_LENGTH)) {
     if (properties) {
         const tempProps = {};
         objForEachKey(properties, (prop, value) => {
@@ -146,7 +146,7 @@ export function dataSanitizeProperties(logger: IDiagnosticLogger, properties: an
                     _throwInternal(logger,eLoggingSeverity.WARNING, _eInternalMessageId.CannotSerializeObjectNonSerializable, "custom property is not valid", { exception: e}, true);
                 }
             }
-            value = dataSanitizeString(logger, value, DataSanitizerValues.MAX_PROPERTY_LENGTH);
+            value = dataSanitizeString(logger, value, maxLength);
             prop = dataSanitizeKeyAndAddUniqueness(logger, prop, tempProps);
             tempProps[prop] = value;
         });

--- a/shared/AppInsightsCommon/src/Telemetry/Event.ts
+++ b/shared/AppInsightsCommon/src/Telemetry/Event.ts
@@ -42,11 +42,11 @@ export class Event implements IEventData, ISerializable {
     /**
      * Constructs a new instance of the EventTelemetry object
      */
-    constructor(logger: IDiagnosticLogger, name: string, properties?: any, measurements?: any) {
+    constructor(logger: IDiagnosticLogger, name: string, properties?: any, measurements?: any, maxLength?: number) {
         let _self = this;
         _self.ver = 2;
         _self.name = dataSanitizeString(logger, name) || strNotSpecified;
-        _self.properties = dataSanitizeProperties(logger, properties);
+        _self.properties = dataSanitizeProperties(logger, properties, maxLength);
         _self.measurements = dataSanitizeMeasurements(logger, measurements);
     }
 }

--- a/shared/AppInsightsCore/src/JavaScriptSDK.Interfaces/ITelemetryItem.ts
+++ b/shared/AppInsightsCore/src/JavaScriptSDK.Interfaces/ITelemetryItem.ts
@@ -51,6 +51,11 @@ export interface ITelemetryItem {
      */
     baseData?: { [key: string]: any };
 
+    /**
+     * Custom metadata
+     */
+    metadata?: { [key: string]: any };
+
 }
 
 export interface Tags {


### PR DESCRIPTION
> [!NOTE]
> This is an early POC and draft. I'm looking for feedback and working through the best way to approach this addition.

References https://github.com/microsoft/ApplicationInsights-JS/issues/2383

## Todo
- [ ] Implement sanitization options for all event types, not just `Event`.
    - [ ] `Dependency`
    - [ ] `Exception`
    - [ ] `Metric`
    - [ ] `PageView`
    - [ ] `Trace`
    - [ ] `PageViewPerformance`
- [ ] Add integration test around calling the `.track` function with `metadata` passed in, and having the `maxLength` configuration be respected.
- [ ] Update public facing `README.md` docs with addition of configuration object and instructions and recommendations for how to use it.

## Nice-To-Haves / Next Iteration Goals
- It would be nice to have this configuration set when instantiating the `ApplicationInsights` client, and not passed every time you call the `.track` function. I'm limited by my understanding of the codebase at present, but I will look to attempt to add this in future iterations / PRs.

## Summary
Enables customization for `properties` bag value truncation through a new `metadata` configuration object, passed through the `.track(...)` function.

Additions:
- Add `maxLength` configuration to sanitizer.
- Add `metadata` dictionary object to house user configurations when calling `.track(...)` function.

## Context
We're using the `ApplicationsInsights-web-basic` npm package to make requests for an internal service that mimics the behavior of the ApplicationInsights managed service, sans the property size limit. We'd like to make it so you can configure the max length before truncation.

## Use
You should now be able to pass a `metadata` object within your `TelemetryItem` when calling `.track(...)` via the ApplicationInsights client 👇🏾

```javascript
let properties = [/* list of properties */]
let measurements = [/* list of measurements */]

let client = new ApplicationInsights({
            /* ... Other configuration properties ... */
            instrumentationKey: someKey,
            endpointUrl: someCustomUrl
            },
 });

this.client.track({
            name,
            tags: this.tags,
            data: {...properties, ...measurements},
            baseType: 'EventData',
            baseData: {name, properties, measurements},
            metadata: {
               "maxLength": 12000
           }
 });
```

## Notes
This can be leveraged in the future for passing down custom configurations that can be used to override hard coded constants. 