### PR TITLE
Drop correlation header to be passed on the dependency

### DIFF
--- a/extensions/applicationinsights-dependencies-js/src/DependencyListener.ts
+++ b/extensions/applicationinsights-dependencies-js/src/DependencyListener.ts
@@ -63,7 +63,7 @@ export interface IDependencyListenerDetails {
 /**
  * The function that will get called when the ajax request is about to occur.
  */
-export declare type DependencyListenerFunction = (dependencyDetails: IDependencyListenerDetails) => void;
+export declare type DependencyListenerFunction = (dependencyDetails: IDependencyListenerDetails) => boolean | void;
 
 export interface IDependencyHandler {
     remove(): void;
@@ -74,7 +74,7 @@ export interface IDependencyListenerHandler extends IDependencyHandler {
 export interface IDependencyListenerContainer {
     /**
      * Add an ajax listener which is called just prior to the request being sent and before the correlation headers are added, to allow you
-     * to access the headers and modify the values used to generate the distributed tracing correlation headers. (added in v2.8.4)
+     * to access the headers and modify the values used to generate the distributed tracing correlation headers or drop the correlation. (added in v2.8.4)
      * @param dependencyListener - The Telemetry Initializer function
      * @returns - A IDependencyListenerHandler to enable the initializer to be removed
      */

--- a/extensions/applicationinsights-dependencies-js/src/DependencyListener.ts
+++ b/extensions/applicationinsights-dependencies-js/src/DependencyListener.ts
@@ -73,8 +73,9 @@ export interface IDependencyListenerHandler extends IDependencyHandler {
 
 export interface IDependencyListenerContainer {
     /**
-     * Add an ajax listener which is called just prior to the request being sent and before the correlation headers are added, to allow you
-     * to access the headers and modify the values used to generate the distributed tracing correlation headers or drop the correlation. (added in v2.8.4)
+     * Add an ajax listener which is called just prior to the request being sent and before the correlation headers are added.
+     * This allows you to access the headers and modify the values used to generate the distributed tracing correlation headers (added in v2.8.4),
+     * or to drop the correlation (added in v3.3.7).
      * @param dependencyListener - The Telemetry Initializer function
      * @returns - A IDependencyListenerHandler to enable the initializer to be removed
      */

--- a/extensions/applicationinsights-dependencies-js/src/ajax.ts
+++ b/extensions/applicationinsights-dependencies-js/src/ajax.ts
@@ -410,10 +410,8 @@ export class AjaxMonitor extends BaseTelemetryPlugin implements IDependenciesPlu
             _self.includeCorrelationHeaders = (ajaxData: ajaxRecord, input?: Request | string, init?: RequestInit, xhr?: XMLHttpRequestInstrumented): any => {
                 // Test Hook to allow the overriding of the location host
                 let currentWindowHost = _self["_currentWindowHost"] || _currentWindowHost;
-
-                let canBeProcessed = _processDependencyListeners(_dependencyListeners, _self.core, ajaxData, xhr, input, init);
-
-                if (canBeProcessed === true) {
+                
+                if (_processDependencyListeners(_dependencyListeners, _self.core, ajaxData, xhr, input, init)) {
                     if (input || input === "") { // Fetch
                         if (correlationIdCanIncludeCorrelationHeader(_extensionConfig, ajaxData.getAbsoluteUrl(), currentWindowHost)) {
                             if (!init) {


### PR DESCRIPTION
I want to add the possibility to drop the enrichment of the correlation header using the dependencyListenerFunction like it is done for the dependencyInitializerFunction. In this way we can drop events that are not relevant for the current instance of the SDK especially in case of multiple instances with microservices.

This resolves #2505 