### PR TITLE
add negative isArray check to _isConfigDefaults

### DIFF
--- a/shared/AppInsightsCore/src/Config/ConfigDefaults.ts
+++ b/shared/AppInsightsCore/src/Config/ConfigDefaults.ts
@@ -8,7 +8,7 @@ import { IConfigCheckFn, IConfigDefaultCheck, IConfigDefaults, IConfigSetFn } fr
 import { IDynamicConfigHandler } from "./IDynamicConfigHandler";
 
 function _isConfigDefaults<C, T>(value: any): value is IConfigDefaultCheck<C, C[keyof C], T> {
-    return (value && isObject(value) && (value.isVal || value.fb || objHasOwn(value, "v") || objHasOwn(value, "mrg") || objHasOwn(value, "ref") || value.set));
+    return (value && isObject(value) && !isArray(value) && (value.isVal || value.fb || objHasOwn(value, "v") || objHasOwn(value, "mrg") || objHasOwn(value, "ref") || value.set));
 }
 
 function _getDefault<C, T>(dynamicHandler: IDynamicConfigHandler<T>, theConfig: C, cfgDefaults: IConfigDefaultCheck<C, C[keyof C], T>): C[keyof C] | IConfigDefaults<C[keyof C], C> {


### PR DESCRIPTION
We've encountered an issue where a customer had monkey patched Arrays to have a `set` method (as well as a few more methods) and this caused issues with the default config values, as `_isConfigDefaults` returned `true` instead of `false` for array values. We could also move it to only invalidate the `set` branch, but this fix felt safe enough to me.

Hopefully this fix is acceptable.