### PR TITLE
Click Analytics - Fix capturning of HTML events

### DIFF
--- a/extensions/applicationinsights-clickanalytics-js/src/handlers/AutoCaptureHandler.ts
+++ b/extensions/applicationinsights-clickanalytics-js/src/handlers/AutoCaptureHandler.ts
@@ -7,7 +7,7 @@ import {
     IDiagnosticLogger, IProcessTelemetryUnloadContext, ITelemetryUnloadState, IUnloadHook, createUniqueNamespace, eventOff, eventOn,
     getDocument, getWindow, isNullOrUndefined, mergeEvtNamespace, onConfigChange
 } from "@microsoft/applicationinsights-core-js";
-import { arrMap, strTrim } from "@nevware21/ts-utils";
+import { arrIncludes, arrMap, strTrim } from "@nevware21/ts-utils";
 import { ClickAnalyticsPlugin } from "../ClickAnalyticsPlugin";
 import { ActionType } from "../Enums";
 import { IAutoCaptureHandler, IClickAnalyticsConfiguration, IPageActionOverrideValues } from "../Interfaces/Datamodel";
@@ -59,7 +59,7 @@ export class AutoCaptureHandler implements IAutoCaptureHandler {
                     _self._pageAction.capturePageAction(element, overrideValues, customProperties, isRightClick);
                 }
             }
-        
+
             // Process click event
             function _processClick(clickEvent: any) {
                 let win = getWindow();
@@ -68,7 +68,7 @@ export class AutoCaptureHandler implements IAutoCaptureHandler {
                 }
                 if (clickEvent) {
                     let element = clickEvent.srcElement || clickEvent.target;
-        
+
                     // populate overrideValues
                     var overrideValues: IPageActionOverrideValues = {
                         clickCoordinateX: clickEvent.pageX,
@@ -88,15 +88,15 @@ export class AutoCaptureHandler implements IAutoCaptureHandler {
                     } else {
                         return;
                     }
-        
+
                     while (element && element.tagName) {
                         // control property will be available for <label> elements with 'for' attribute, only use it when is a
                         // valid JSLL capture element to avoid infinite loops
-                        if (element.control && _clickCaptureElements[element.control.tagName.toUpperCase()]) {
+                        if (element.control && arrIncludes(_clickCaptureElements, element.control.tagName.toUpperCase())) {
                             element = element.control;
                         }
                         const tagNameUpperCased = element.tagName.toUpperCase();
-                        if (!_clickCaptureElements[tagNameUpperCased]) {
+                        if (!arrIncludes(_clickCaptureElements, tagNameUpperCased)) {
                             element = element.parentElement || element.parentNode;
                             continue;
                         } else {


### PR DESCRIPTION
Changes made in https://github.com/microsoft/ApplicationInsights-JS/pull/2504 (b5a24d524bc0cae3c48c7010d88cef5f982449c8) appear to have introduced an issue when evaluating if events have come from known HTML objects. This appears to be due to a new array which had previously been an object still being indexed by its values. As a result these events are not being processed.

This change is to fix that by looking for the value in the array.