### PR TITLE
Fix TypeError in Click Analytics Data Collector

### DIFF
--- a/extensions/applicationinsights-clickanalytics-js/src/DataCollector.ts
+++ b/extensions/applicationinsights-clickanalytics-js/src/DataCollector.ts
@@ -21,7 +21,7 @@ export function getImageHref(element: HTMLImageElement): string {
     var temp = element;
     if (temp) {
         var parent = findClosestAnchor(temp as Element);
-        if ((parent as any).length === 1) {
+        if (parent && (parent as any).length === 1) {
             const firstParent = parent[0];
             if (firstParent.href) {
                 return firstParent.href;


### PR DESCRIPTION
When clicking on an Image tag that does not have a parent Anchor tag, a type error is thrown in the `getImageHref` function:

```
Uncaught TypeError: Cannot read properties of null (reading 'length')
```

The change ensures that `parent` is defined before checking the length property.