### PR TITLE
Improve OsPlugin reliability: proactive OS retrieval, unload handling, and session caching

### DIFF
--- a/.aiAutoMinify.json
+++ b/.aiAutoMinify.json
@@ -26,6 +26,7 @@
                 "TelemetryUnloadReason",
                 "TelemetryUpdateReason",
                 "eTraceHeadersMode",
+                "eUrlRedactionOptions",
                 "eValueKind",
                 "EventLatencyValue",
                 "eEventPropertyType",

--- a/extensions/applicationinsights-osplugin-js/Tests/Unit/src/OsPluginTest.ts
+++ b/extensions/applicationinsights-osplugin-js/Tests/Unit/src/OsPluginTest.ts
@@ -6,12 +6,30 @@ import { Assert, AITestClass } from '@microsoft/ai-test-framework';
 import { IOSPluginConfiguration, OsPlugin } from '../../../src/applicationinsights-osplugin-js';
 import { createAsyncPromise, ResolvePromiseHandler, RejectPromiseHandler } from "@nevware21/ts-async";
 import {getWindow, AppInsightsCore, IChannelControls, ITelemetryPlugin,
-    IConfiguration, ITelemetryItem} from "@microsoft/applicationinsights-core-js";
+    IConfiguration, ITelemetryItem, __getRegisteredEvents} from "@microsoft/applicationinsights-core-js";
 
 const defaultmaxTimeout = 5000;
 const _platformVersion =  {"brands":[{"brand":"Chromium","version":"122"}, 
 {"brand":"Microsoft Edge","version":"122"}],"mobile":false,"platform":"Windows",
-"platformVersion":"15.0.0"}
+"platformVersion":"15.0.0"};
+
+interface ITestConfig extends IConfiguration {
+    endpointUrl?: string;
+    disableFlushOnUnload?: boolean;
+    isStorageUseDisabled?: boolean;
+}
+
+interface IOsState {
+    platform?: string | null;
+    platformVersion?: number | null;
+}
+
+interface IDbgTargets {
+    osState: IOsState;
+    queue: Array<{ item: ITelemetryItem }>;
+    hasPendingTimeout: boolean;
+}
+
 interface CustomNavigator extends Navigator {
     userAgentData?: {
         getHighEntropyValues?: (args: any[]) => Promise<any>;
@@ -20,10 +38,9 @@ interface CustomNavigator extends Navigator {
 
 export class OsPluginTest extends AITestClass {
 
-    private _config;
+    private _config: ITestConfig;
     private _plugin: OsPlugin;
     private _core: AppInsightsCore;
-    private _channelExtension: IChannelControls;
     private _osConfig: IOSPluginConfiguration = {
         maxTimeout: 6000, // set a big number to avoid timeout for test
         mergeOsNameVersion: false
@@ -63,6 +80,73 @@ export class OsPluginTest extends AITestClass {
 
     }
 
+    private _getDbgTargets(): IDbgTargets {
+        let dbgTargets = (this._plugin as any)["_getDbgPlgTargets"]();
+
+        return {
+            osState: dbgTargets[0],
+            queue: dbgTargets[1],
+            hasPendingTimeout: dbgTargets[2]
+        };
+    }
+
+    private _resolveHighEntropy(result: any) {
+        Assert.ok(!!this._resolvedGetHighEntrophyPromise, "expected getHighEntropyValues() to be pending");
+        this._resolvedGetHighEntrophyPromise!(result);
+    }
+
+    private _rejectHighEntropy(error: Error) {
+        Assert.ok(!!this._rejectedGetHighEntrophyPromise, "expected getHighEntropyValues() to be pending");
+        this._rejectedGetHighEntrophyPromise!(error);
+    }
+
+    private _createTestEvent(): ITelemetryItem {
+        return {
+            name: 'testEvent',
+            baseType: 'testBaseType',
+            baseData: {}
+        } as ITelemetryItem;
+    }
+
+    private _createPageHideEvent(): Event {
+        if (typeof Event !== "undefined") {
+            return new Event("pagehide");
+        }
+
+        let doc = document as any;
+        let evt = doc.createEvent("Event");
+        evt.initEvent("pagehide", true, true);
+        return evt;
+    }
+
+    private _getRegisteredUnloadState() {
+        let window = getWindow();
+        let unloadPresent = false;
+        let pageHidePresent = false;
+        let visibilityChangePresent = false;
+
+        let theEvents = __getRegisteredEvents(window);
+        theEvents.forEach((theEvent) => {
+            if (theEvent.name.startsWith("unload")) {
+                unloadPresent = true;
+            }
+
+            if (theEvent.name.startsWith("pagehide")) {
+                pageHidePresent = true;
+            }
+
+            if (theEvent.name.startsWith("visibilitychange")) {
+                visibilityChangePresent = true;
+            }
+        });
+
+        return {
+            unloadPresent: unloadPresent,
+            pageHidePresent: pageHidePresent,
+            visibilityChangePresent: visibilityChangePresent
+        };
+    }
+
     public testFinishedCleanup(): void {
         let window = getWindow();
         let sessionStorage = window.sessionStorage;
@@ -83,7 +167,23 @@ export class OsPluginTest extends AITestClass {
                 config.extensionConfig[this._plugin.identifier] = this._osConfig;
                 this._core.initialize(config, [plugin, this._testChannelPlugin]);
                 this.clock.tick(100);
-                Assert.deepEqual(this._osConfig.maxTimeout, this._core.config.extensionConfig[this._plugin.identifier].maxTimeout, "maxTimeout should be changed");
+                Assert.deepEqual(this._osConfig.maxTimeout, this._core.config.extensionConfig![this._plugin.identifier].maxTimeout, "maxTimeout should be changed");
+            }
+        });
+
+        this.testCase({
+            name: "OsPlugin: initialize starts OS retrieval before first telemetry",
+            useFakeTimers: true,
+            test: () => {
+                let config = this._config;
+                config.extensionConfig = config.extensionConfig || {};
+                config.extensionConfig[this._plugin.identifier] = this._osConfig;
+
+                this._core.initialize(config, [this._plugin, this._testChannelPlugin]);
+
+                let dbgTargets = this._getDbgTargets();
+                Assert.equal(dbgTargets.hasPendingTimeout, true, "OS retrieval timer should start during initialize");
+                Assert.equal(dbgTargets.queue.length, 0, "No telemetry should be queued before track() is called");
             }
         });
 
@@ -95,18 +195,14 @@ export class OsPluginTest extends AITestClass {
                 let plugin = this._plugin;
                 config.extensionConfig = this._config.extensionConfig || {};
                 this._core.initialize(config, [plugin, this._testChannelPlugin]);
-                let event = {
-                    name: 'testEvent',
-                    baseType: 'testBaseType',
-                    baseData: {}
-                };
+                let event = this._createTestEvent();
                 this._core.track(event);
                 Assert.equal(this._channelSpy.called, false);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[2], true);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1].length, 1);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1][0].item.name, event.name);
+                Assert.equal(this._getDbgTargets().hasPendingTimeout, true);
+                Assert.equal(this._getDbgTargets().queue.length, 1);
+                Assert.equal(this._getDbgTargets().queue[0].item.name, event.name);
                 this.clock.tick(defaultmaxTimeout);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1].length, 0);
+                Assert.equal(this._getDbgTargets().queue.length, 0);
                 Assert.equal(this._channelSpy.called, true);
             }
         });
@@ -120,20 +216,16 @@ export class OsPluginTest extends AITestClass {
                 config.extensionConfig = this._config.extensionConfig || {};
                 config.extensionConfig[this._plugin.identifier] = this._osConfig;
                 this._core.initialize(config, [plugin, this._testChannelPlugin]);
-                let event = {
-                    name: 'testEvent',
-                    baseType: 'testBaseType',
-                    baseData: {}
-                };
+                let event = this._createTestEvent();
                 this._core.track(event);
                 Assert.equal(this._channelSpy.called, false);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[2], true);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1].length, 1);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1][0].item.name, event.name);
-                this._resolvedGetHighEntrophyPromise(_platformVersion);
+                Assert.equal(this._getDbgTargets().hasPendingTimeout, true);
+                Assert.equal(this._getDbgTargets().queue.length, 1);
+                Assert.equal(this._getDbgTargets().queue[0].item.name, event.name);
+                this._resolveHighEntropy(_platformVersion);
                 this.clock.tick(1);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1].length, 0);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[2], false);
+                Assert.equal(this._getDbgTargets().queue.length, 0);
+                Assert.equal(this._getDbgTargets().hasPendingTimeout, false);
                 Assert.equal(this._channelSpy.called, true);
                 let telemetry = this._channelSpy.getCall(0).args[0];
                 console.log("telemetry", JSON.stringify(telemetry));
@@ -152,19 +244,15 @@ export class OsPluginTest extends AITestClass {
                 config.extensionConfig = this._config.extensionConfig || {};
                 config.extensionConfig[this._plugin.identifier] = this._osConfig;
                 this._core.initialize(config, [plugin, this._testChannelPlugin]);
-                let event = {
-                    name: 'testEvent',
-                    baseType: 'testBaseType',
-                    baseData: {}
-                };
+                let event = this._createTestEvent();
                 this._core.track(event);
                 Assert.equal(this._channelSpy.called, false);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[2], true);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1].length, 1);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1][0].item.name, event.name);
-                this._rejectedGetHighEntrophyPromise(new Error("error"));
+                Assert.equal(this._getDbgTargets().hasPendingTimeout, true);
+                Assert.equal(this._getDbgTargets().queue.length, 1);
+                Assert.equal(this._getDbgTargets().queue[0].item.name, event.name);
+                this._rejectHighEntropy(new Error("error"));
                 this.clock.tick(1);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1].length, 0);
+                Assert.equal(this._getDbgTargets().queue.length, 0);
             }
         });
 
@@ -177,27 +265,98 @@ export class OsPluginTest extends AITestClass {
                 config.extensionConfig = this._config.extensionConfig || {};
                 config.extensionConfig[this._plugin.identifier] = {
                     maxTimeout: 1000
-                };;
-                this._core.initialize(config, [plugin, this._testChannelPlugin]);
-                let event = {
-                    name: 'testEvent',
-                    baseType: 'testBaseType',
-                    baseData: {}
                 };
+                this._core.initialize(config, [plugin, this._testChannelPlugin]);
+                let event = this._createTestEvent();
                 this._core.track(event);
                 Assert.equal(this._channelSpy.called, false);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[2], true);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1].length, 1);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1][0].item.name, event.name);
+                Assert.equal(this._getDbgTargets().hasPendingTimeout, true);
+                Assert.equal(this._getDbgTargets().queue.length, 1);
+                Assert.equal(this._getDbgTargets().queue[0].item.name, event.name);
                 this.clock.tick(500);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1].length, 1);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[2], true);
+                Assert.equal(this._getDbgTargets().queue.length, 1);
+                Assert.equal(this._getDbgTargets().hasPendingTimeout, true);
                 this.clock.tick(500);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1].length, 0);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[2], false);
+                Assert.equal(this._getDbgTargets().queue.length, 0);
+                Assert.equal(this._getDbgTargets().hasPendingTimeout, false);
                 Assert.equal(this._channelSpy.called, true);
                 let telemetry = this._channelSpy.getCall(0).args[0];
                 Assert.equal(JSON.stringify(telemetry).includes("osVer"), false, "timeout would not get os version");
+            }
+        });
+
+        this.testCase({
+            name: "OsPlugin: pagehide releases queued telemetry before timeout",
+            useFakeTimers: true,
+            test: () => {
+                let config = this._config;
+                config.extensionConfig = config.extensionConfig || {};
+                config.extensionConfig[this._plugin.identifier] = this._osConfig;
+
+                this._core.initialize(config, [this._plugin, this._testChannelPlugin]);
+
+                let registeredEvents = this._getRegisteredUnloadState();
+
+                Assert.ok(registeredEvents.unloadPresent, "unload listener should be registered while OS lookup is pending");
+                Assert.ok(registeredEvents.pageHidePresent, "pagehide listener should be registered while OS lookup is pending");
+                Assert.ok(registeredEvents.visibilityChangePresent, "visibilitychange listener should be registered while OS lookup is pending");
+
+                let event = this._createTestEvent();
+                this._core.track(event);
+                Assert.equal(this._channelSpy.called, false, "event should remain queued before pagehide");
+                Assert.equal(this._getDbgTargets().queue.length, 1, "one event should be queued");
+
+                let window = getWindow();
+                window.dispatchEvent(this._createPageHideEvent());
+
+                Assert.equal(this._getDbgTargets().queue.length, 0, "queue should be released on pagehide");
+                Assert.equal(this._channelSpy.called, true, "queued event should be sent on pagehide");
+            }
+        });
+
+        this.testCase({
+            name: "OsPlugin: event handlers are removed after getHighEntropyValues resolves",
+            useFakeTimers: true,
+            test: () => {
+                let config = this._config;
+                config.extensionConfig = config.extensionConfig || {};
+                config.extensionConfig[this._plugin.identifier] = this._osConfig;
+
+                this._core.initialize(config, [this._plugin, this._testChannelPlugin]);
+
+                let registeredEvents = this._getRegisteredUnloadState();
+                Assert.ok(registeredEvents.unloadPresent, "unload listener should be registered before OS lookup completes");
+                Assert.ok(registeredEvents.pageHidePresent, "pagehide listener should be registered before OS lookup completes");
+                Assert.ok(registeredEvents.visibilityChangePresent, "visibilitychange listener should be registered before OS lookup completes");
+
+                this._core.track(this._createTestEvent());
+                this._resolveHighEntropy(_platformVersion);
+                this.clock.tick(1);
+
+                registeredEvents = this._getRegisteredUnloadState();
+                Assert.ok(!registeredEvents.unloadPresent, "unload listener should be removed after OS lookup completes");
+                Assert.ok(!registeredEvents.pageHidePresent, "pagehide listener should be removed after OS lookup completes");
+                Assert.ok(!registeredEvents.visibilityChangePresent, "visibilitychange listener should be removed after OS lookup completes");
+            }
+        });
+
+        this.testCase({
+            name: "OsPlugin: disableFlushOnUnload does not register unload listeners",
+            useFakeTimers: true,
+            test: () => {
+                let config = this._config;
+                config.disableFlushOnUnload = true;
+                config.extensionConfig = config.extensionConfig || {};
+                config.extensionConfig[this._plugin.identifier] = this._osConfig;
+
+                this._core.initialize(config, [this._plugin, this._testChannelPlugin]);
+
+                let registeredEvents = this._getRegisteredUnloadState();
+
+                Assert.ok(!registeredEvents.unloadPresent, "unload listener should not be registered when disableFlushOnUnload is true");
+                Assert.ok(!registeredEvents.pageHidePresent, "pagehide listener should not be registered when disableFlushOnUnload is true");
+                Assert.ok(!registeredEvents.visibilityChangePresent, "visibilitychange listener should not be registered when disableFlushOnUnload is true");
+                Assert.equal(this._getDbgTargets().hasPendingTimeout, true, "OS lookup should still start when unload flushing is disabled");
             }
         });
 
@@ -211,36 +370,102 @@ export class OsPluginTest extends AITestClass {
                 config.extensionConfig[this._plugin.identifier] = {
                     maxTimeout: 1000,
                     mergeOsNameVersion: false
-                };;
-                this._core.initialize(config, [plugin, this._testChannelPlugin]);
-                let event = {
-                    name: 'testEvent',
-                    baseType: 'testBaseType',
-                    baseData: {}
                 };
+                this._core.initialize(config, [plugin, this._testChannelPlugin]);
+                let event = this._createTestEvent();
                 this._core.track(event);
                 Assert.equal(this._channelSpy.called, false);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[2], true);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1].length, 1);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1][0].item.name, event.name);
+                Assert.equal(this._getDbgTargets().hasPendingTimeout, true);
+                Assert.equal(this._getDbgTargets().queue.length, 1);
+                Assert.equal(this._getDbgTargets().queue[0].item.name, event.name);
                 this.clock.tick(1200);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1].length, 0);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[2], false);
+                Assert.equal(this._getDbgTargets().queue.length, 0);
+                Assert.equal(this._getDbgTargets().hasPendingTimeout, false);
                 Assert.equal(this._channelSpy.called, true);
                 let telemetry = this._channelSpy.getCall(0).args[0];
                 Assert.equal(JSON.stringify(telemetry).includes("osVer"), false, "timeout would not get os version");
 
                 // send another event
                 this._core.track(event);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[2], false);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1].length, 0);
-                this._resolvedGetHighEntrophyPromise(_platformVersion);
+                Assert.equal(this._getDbgTargets().hasPendingTimeout, false);
+                Assert.equal(this._getDbgTargets().queue.length, 0);
+                this._resolveHighEntropy(_platformVersion);
                 this.clock.tick(1);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1].length, 0);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[2], false);
+                Assert.equal(this._getDbgTargets().queue.length, 0);
+                Assert.equal(this._getDbgTargets().hasPendingTimeout, false);
                 Assert.equal(this._channelSpy.called, true);
                 telemetry = this._channelSpy.getCall(0).args[0];
                 Assert.equal(JSON.stringify(telemetry).includes("osVer"), false, "second event should not attempt to get os version");
+            }
+        });
+
+        this.testCase({
+            name: "OsPlugin: cached OS is used immediately during initialize",
+            useFakeTimers: true,
+            test: () => {
+                let window = getWindow();
+                let sessionStorage = window.sessionStorage;
+                sessionStorage.setItem("ai_osplugin", JSON.stringify({ platform: "Android", platformVersion: 14 }));
+
+                let config = this._config;
+                config.extensionConfig = config.extensionConfig || {};
+                config.extensionConfig[this._plugin.identifier] = {
+                    maxTimeout: 1000,
+                    mergeOsNameVersion: false
+                };
+
+                this._core.initialize(config, [this._plugin, this._testChannelPlugin]);
+
+                let registeredEvents = this._getRegisteredUnloadState();
+                Assert.ok(!registeredEvents.unloadPresent, "cached OS should not register unload listeners");
+                Assert.ok(!registeredEvents.pageHidePresent, "cached OS should not register pagehide listeners");
+                Assert.ok(!registeredEvents.visibilityChangePresent, "cached OS should not register visibilitychange listeners");
+
+                let dbgTargets = this._getDbgTargets();
+                Assert.equal(dbgTargets.hasPendingTimeout, false, "cached OS should avoid startup lookup");
+                Assert.deepEqual(dbgTargets.osState.platform, "Android", "cached platform should be loaded");
+                Assert.deepEqual(dbgTargets.osState.platformVersion, 14, "cached platform version should be loaded");
+
+                this._core.track(this._createTestEvent());
+
+                Assert.equal(this._channelSpy.called, true, "event should be sent immediately from cached OS");
+                let telemetry = this._channelSpy.getCall(0).args[0];
+                Assert.deepEqual(telemetry.ext.os.os, "Android", "cached OS should be applied to telemetry");
+                Assert.deepEqual(telemetry.ext.os.osVer, 14, "cached OS version should be applied to telemetry");
+            }
+        });
+
+        this.testCase({
+            name: "OsPlugin: storage disabled ignores cached OS and does not overwrite session storage",
+            useFakeTimers: true,
+            test: () => {
+                let window = getWindow();
+                let sessionStorage = window.sessionStorage;
+                sessionStorage.setItem("ai_osplugin", JSON.stringify({ platform: "CachedOS", platformVersion: 99 }));
+
+                let config = this._config;
+                config.isStorageUseDisabled = true;
+                config.extensionConfig = config.extensionConfig || {};
+                config.extensionConfig[this._plugin.identifier] = {
+                    maxTimeout: 1000,
+                    mergeOsNameVersion: false
+                };
+
+                this._core.initialize(config, [this._plugin, this._testChannelPlugin]);
+                this._core.track(this._createTestEvent());
+
+                Assert.equal(this._channelSpy.called, false, "cached OS should not be used when storage is disabled");
+                Assert.equal(this._getDbgTargets().hasPendingTimeout, true, "OS lookup should still start when storage is disabled");
+                Assert.equal(this._getDbgTargets().queue.length, 1, "event should remain queued until lookup resolves");
+
+                this._resolveHighEntropy(_platformVersion);
+                this.clock.tick(1);
+
+                Assert.equal(this._channelSpy.called, true, "queued event should be released after lookup resolves");
+                let telemetry = this._channelSpy.getCall(0).args[0];
+                Assert.deepEqual(telemetry.ext.os.os, _platformVersion.platform, "navigator OS should be applied");
+                Assert.deepEqual(telemetry.ext.os.osVer, 11, "navigator OS version should be applied");
+                Assert.equal(sessionStorage.getItem("ai_osplugin"), JSON.stringify({ platform: "CachedOS", platformVersion: 99 }), "storage-disabled mode should not overwrite session storage");
             }
         });
 
@@ -260,31 +485,27 @@ export class OsPluginTest extends AITestClass {
                     mergeOsNameVersion: false
                 };
                 this._core.initialize(config, [plugin, this._testChannelPlugin]);
-                let event = {
-                    name: 'testEvent',
-                    baseType: 'testBaseType',
-                    baseData: {}
-                };
+                let event = this._createTestEvent();
                 this._core.track(event);
                 Assert.equal(this._channelSpy.called, false);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[2], true);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1].length, 1);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1][0].item.name, event.name);
-                this._resolvedGetHighEntrophyPromise(_platformVersion);
+                Assert.equal(this._getDbgTargets().hasPendingTimeout, true);
+                Assert.equal(this._getDbgTargets().queue.length, 1);
+                Assert.equal(this._getDbgTargets().queue[0].item.name, event.name);
+                this._resolveHighEntropy(_platformVersion);
                 this.clock.tick(1);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1].length, 0);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[2], false);
+                Assert.equal(this._getDbgTargets().queue.length, 0);
+                Assert.equal(this._getDbgTargets().hasPendingTimeout, false);
                 Assert.equal(this._channelSpy.called, true);
                 let telemetry = this._channelSpy.getCall(0).args[0];
                 Assert.deepEqual(telemetry.ext.os.os, _platformVersion.platform, "OS should be changed");
                 Assert.deepEqual(telemetry.ext.os.osVer, 11, "windows 11 is detected");
-                let storedOs = JSON.parse(sessionStorage.getItem("ai_osplugin"));
+                let storedOs = JSON.parse(sessionStorage.getItem("ai_osplugin") || "{}");
                 QUnit.assert.equal(storedOs.platform, _platformVersion.platform, "os is stored in session storage");
                 QUnit.assert.equal(storedOs.platformVersion, 11, "os ver is stored in session storage");
                 // send another event
                 this._core.track(event);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[2], false);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1].length, 0);
+                Assert.equal(this._getDbgTargets().hasPendingTimeout, false);
+                Assert.equal(this._getDbgTargets().queue.length, 0);
                 Assert.equal(this._channelSpy.called, true);
                 telemetry = this._channelSpy.getCall(0).args[0];
                 Assert.equal(JSON.stringify(telemetry).includes("osVer"), true, "before timeout, get os version");
@@ -309,30 +530,26 @@ export class OsPluginTest extends AITestClass {
                     mergeOsNameVersion: true
                 };
                 this._core.initialize(config, [plugin, this._testChannelPlugin]);
-                let event = {
-                    name: 'testEvent',
-                    baseType: 'testBaseType',
-                    baseData: {}
-                };
+                let event = this._createTestEvent();
                 this._core.track(event);
                 Assert.equal(this._channelSpy.called, false);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[2], true);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1].length, 1);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1][0].item.name, event.name);
-                this._resolvedGetHighEntrophyPromise(_platformVersion);
+                Assert.equal(this._getDbgTargets().hasPendingTimeout, true);
+                Assert.equal(this._getDbgTargets().queue.length, 1);
+                Assert.equal(this._getDbgTargets().queue[0].item.name, event.name);
+                this._resolveHighEntropy(_platformVersion);
                 this.clock.tick(1);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1].length, 0);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[2], false);
+                Assert.equal(this._getDbgTargets().queue.length, 0);
+                Assert.equal(this._getDbgTargets().hasPendingTimeout, false);
                 Assert.equal(this._channelSpy.called, true);
                 let telemetry = this._channelSpy.getCall(0).args[0];
                 Assert.deepEqual(telemetry.ext.os.osVer, "Windows11", "windows 11 is detected");
-                let storedOs = JSON.parse(sessionStorage.getItem("ai_osplugin"));
+                let storedOs = JSON.parse(sessionStorage.getItem("ai_osplugin") || "{}");
                 QUnit.assert.equal(storedOs.platform, _platformVersion.platform, "os is stored in session storage");
                 QUnit.assert.equal(storedOs.platformVersion, 11, "os ver is stored in session storage");
                 // send another event
                 this._core.track(event);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[2], false);
-                Assert.equal(this._plugin["_getDbgPlgTargets"]()[1].length, 0);
+                Assert.equal(this._getDbgTargets().hasPendingTimeout, false);
+                Assert.equal(this._getDbgTargets().queue.length, 0);
                 Assert.equal(this._channelSpy.called, true);
                 telemetry = this._channelSpy.getCall(0).args[0];
                 Assert.equal(JSON.stringify(telemetry).includes("osVer"), true, "before timeout, get os version");

--- a/extensions/applicationinsights-osplugin-js/src/OsPlugin.ts
+++ b/extensions/applicationinsights-osplugin-js/src/OsPlugin.ts
@@ -6,29 +6,33 @@
 import dynamicProto from "@microsoft/dynamicproto-js";
 import {
     BaseTelemetryPlugin, Extensions, IAppInsightsCore, IConfig, IConfigDefaults, IConfiguration, IPlugin, IProcessTelemetryContext,
-    IProcessTelemetryUnloadContext, ITelemetryItem, ITelemetryUnloadState, _eInternalMessageId, _throwInternal, addPageHideEventListener,
+    IProcessTelemetryUnloadContext, ITelemetryItem, ITelemetryUnloadState, Undefined, _eInternalMessageId, _throwInternal, addPageHideEventListener,
     addPageUnloadEventListener, arrForEach, createProcessTelemetryContext, createUniqueNamespace, eLoggingSeverity, getSetValue,
-    mergeEvtNamespace, onConfigChange, removePageHideEventListener, removePageUnloadEventListener, setValue, utlCanUseSessionStorage,
+    mergeEvtNamespace, onConfigChange, removePageHideEventListener, removePageUnloadEventListener, safeGetLogger, setValue,
     utlGetSessionStorage, utlSetSessionStorage
 } from "@microsoft/applicationinsights-core-js";
 import { IPromise, doAwaitResponse } from "@nevware21/ts-async";
-import { ITimerHandler, isString, objDeepFreeze, scheduleTimeout } from "@nevware21/ts-utils";
+import { ITimerHandler, asString, fnCall, getNavigator, isString, objDeepFreeze, scheduleTimeout } from "@nevware21/ts-utils";
 import { IOSPluginConfiguration } from "./DataModels";
 
 const defaultMaxTimeout = 200;
 const strExt = "ext";
+
 interface platformVersionInterface {
     platform?: string,
     platformVersion?: string
 }
+
 interface UserAgentHighEntropyData {
     platformVersion: platformVersionInterface
 }
-interface ModernNavigator {
+
+interface ModernNavigator extends Navigator {
     userAgentData?: {
       getHighEntropyValues?: (fields: ["platformVersion"]) => IPromise<UserAgentHighEntropyData>;
     };
-  }
+}
+
 const defaultOSConfig: IConfigDefaults<IOSPluginConfiguration> = objDeepFreeze({
     maxTimeout: defaultMaxTimeout,
     mergeOsNameVersion: undefined
@@ -41,28 +45,26 @@ interface IDelayedEvent {
 
 export class OsPlugin extends BaseTelemetryPlugin {
     public identifier = "OsPlugin";
-    public priority = 195;
+    public priority = 195;              // Note: we want this to run after the AnalyticsPlugin so that it correctly sets whether we are allowed to use session storage
     public version = "#version#";
 
     constructor() {
         super();
         let _core: IAppInsightsCore;
         let _ocConfig: IOSPluginConfiguration;
-        let _getOSInProgress: boolean;
-        let _getOSTimeout: ITimerHandler;
-        let _maxTimeout: number;
+        let _getOSTimeout: ITimerHandler | null;
 
-        let _platformVersionResponse: platformVersionInterface;
-        let _retrieveFullVersion: boolean;
+        let _fetchedFullVersion: boolean;
         let _mergeOsNameVersion: boolean;
 
         let _eventQueue: IDelayedEvent[];
         let _evtNamespace: string | string[];
-        let _excludePageUnloadEvents: string[];
+        let _excludePageUnloadEvents: string[] | null;
+        let _disableFlushOnUnload: boolean;
+        let _addedUnloadEvents: boolean;
 
-        let _os: string;
-        let _osVer: number;
-        let _firstAttempt: boolean;
+        let _os: string | undefined | null;
+        let _osVer: number | undefined | null;
     
         dynamicProto(OsPlugin, this, (_self, _base) => {
 
@@ -73,130 +75,192 @@ export class OsPlugin extends BaseTelemetryPlugin {
                 _core = core;
                 super.initialize(coreConfig, core, extensions);
                 let identifier = _self.identifier;
+
                 _evtNamespace = mergeEvtNamespace(createUniqueNamespace(identifier), core.evtNamespace && core.evtNamespace());
-                if (utlCanUseSessionStorage) {
-                    try {
-                        _platformVersionResponse = JSON.parse(utlGetSessionStorage(core.logger, "ai_osplugin"));
-                    } catch (error) {
-                        // do nothing
-                    }
-                }
-                if(_platformVersionResponse){
-                    _retrieveFullVersion = true;
-                    _osVer = parseInt(_platformVersionResponse.platformVersion);
-                    _os = _platformVersionResponse.platform;
-                }
+                _fetchedFullVersion = _fetchCachedOSVersion(coreConfig);
+
                 _self._addHook(onConfigChange(coreConfig, (details)=> {
                     let coreConfig = details.cfg;
                     let ctx = createProcessTelemetryContext(null, coreConfig, core);
+
                     _ocConfig = ctx.getExtCfg<IOSPluginConfiguration>(identifier, defaultOSConfig);
-                    _maxTimeout = _ocConfig.maxTimeout;
-                    if (_ocConfig.mergeOsNameVersion !== undefined){
+
+                    if (_ocConfig.mergeOsNameVersion !== undefined) {
                         _mergeOsNameVersion = _ocConfig.mergeOsNameVersion;
                     } else if (core.getPlugin("Sender").plugin){
                         _mergeOsNameVersion = true;
                     } else {
                         _mergeOsNameVersion = false;
                     }
-                  
-                    let excludePageUnloadEvents = coreConfig.disablePageUnloadEvents || [];
 
-                    if (_excludePageUnloadEvents && _excludePageUnloadEvents !== excludePageUnloadEvents) {
-                        removePageUnloadEventListener(null, _evtNamespace);
-                        removePageHideEventListener(null, _evtNamespace);
+                    let excludePageUnloadEvents = coreConfig.disablePageUnloadEvents || [];
+                    let disableFlushOnUnload = coreConfig.disableFlushOnUnload || false;
+                    let removeEvents = _excludePageUnloadEvents && _excludePageUnloadEvents !== excludePageUnloadEvents;
+
+                    if (_disableFlushOnUnload !== disableFlushOnUnload) {
+                        removeEvents = true;
+                    }
+
+                    if (removeEvents && _addedUnloadEvents) {
+                        _removeUnloadHandlers();
                         _excludePageUnloadEvents = null;
                     }
-                   
-                    if (!_excludePageUnloadEvents) {
-                        // If page is closed release queue
-                        addPageUnloadEventListener(_doUnload, excludePageUnloadEvents, _evtNamespace);
-                        addPageHideEventListener(_doUnload, excludePageUnloadEvents, _evtNamespace);
+                
+                    if (!_excludePageUnloadEvents && !disableFlushOnUnload) {
+                        _addUnloadHandlers(excludePageUnloadEvents);
                     }
+
                     _excludePageUnloadEvents = excludePageUnloadEvents;
+                    _disableFlushOnUnload = disableFlushOnUnload;
                 }));
-                function _doUnload() {
-                    _releaseEventQueue();
+
+                // Automatically start retrieving OS version without waiting for the first telemetry event
+                if (!_fetchedFullVersion) {
+                    // Start Requesting OS version process
+                    _startRetrieveOsVersion(_ocConfig.maxTimeout as number);
                 }
             };
         
             _self.processTelemetry = (event: ITelemetryItem, itemCtx?: IProcessTelemetryContext) => {
                 itemCtx = _self._getTelCtx(itemCtx);
 
-                if (!_retrieveFullVersion && !_getOSInProgress && _firstAttempt) {
-                    // Start Requesting OS version process
-                    _getOSInProgress = true;
-                    startRetrieveOsVersion();
-                    _firstAttempt = false;
-                }
-        
-                if (_getOSInProgress) {
+                if (_getOSTimeout) {
+                    // We have a timer waiting for the OS version to be retrieved, queue the event
                     _eventQueue.push({
                         ctx: itemCtx,
                         item: event
                     });
                 } else {
-                    updateTeleItemWithOs(event);
+                    _updateTeleItemWithOs(event);
                     _self.processNext(event, itemCtx);
                 }
             };
 
             _self._doTeardown = (unloadCtx?: IProcessTelemetryUnloadContext, unloadState?: ITelemetryUnloadState) => {
                 _completeOsRetrieve();
-                removePageUnloadEventListener(null, _evtNamespace);
-                removePageHideEventListener(null, _evtNamespace);
+                _removeUnloadHandlers();
+
                 // Just register to remove all events associated with this namespace
                 _initDefaults();
             };
 
-        
-            /**
-             * Wait for the response from the browser for the OS version and store info in the session storage
-             */
-            function startRetrieveOsVersion() {
-                // Timeout request if it takes more than 5 seconds (by default)
-                 
-                _getOSTimeout = scheduleTimeout(() => {
-                    _completeOsRetrieve();
-                }, _maxTimeout);
+            function _fetchCachedOSVersion(coreConfig: IConfiguration & IConfig) {
+                let fetched = false;
 
-                if (navigator.userAgent) {
-                    const getHighEntropyValues = (navigator as ModernNavigator).userAgentData?.getHighEntropyValues;
-                    if (getHighEntropyValues) {
-                        doAwaitResponse((navigator as ModernNavigator).userAgentData.getHighEntropyValues(["platformVersion"]), (response:any) => {
-                            if (!response.rejected) {
-                                _platformVersionResponse = response.value;
-                                _retrieveFullVersion = true;
-                                if (_platformVersionResponse.platformVersion && _platformVersionResponse.platform) {
-                                    _os = _platformVersionResponse.platform;
-                                    _osVer = parseInt(_platformVersionResponse.platformVersion);
-                                    if (_os === "Windows"){
-                                        if (_osVer == 0){
-                                            _osVer = 8;
-                                        } else if (_osVer < 13){
-                                            _osVer = 10;
-                                        } else{
-                                            _osVer = 11;
-                                        }
-                                    }
-                                    utlSetSessionStorage(_core.logger, "ai_osplugin", JSON.stringify({platform: _os, platformVersion: _osVer}));
+                // Special case check for if the runtime doesn't include the AnalyticsPlugin
+                if(coreConfig.isStorageUseDisabled !== true) {
+                    try {
+                        let platformVersionResponse: platformVersionInterface = JSON.parse(utlGetSessionStorage(safeGetLogger(_core), "ai_osplugin")) as platformVersionInterface;
+                        if (platformVersionResponse) {
+                            _os = platformVersionResponse.platform;
+                            if (platformVersionResponse.platformVersion) {
+                                let ver = parseInt(platformVersionResponse.platformVersion);
+                                if (!isNaN(ver)) {
+                                    _osVer = ver;
                                 }
-                            } else {
-                                _throwInternal(_core.logger,
-                                    eLoggingSeverity.CRITICAL,
-                                    _eInternalMessageId.PluginException,
-                                    "Could not retrieve operating system: " + response.reason);
                             }
-                            _completeOsRetrieve();
-                        });
+
+                            fetched = !!(_os && _osVer);
+                        }
+                    } catch (error) {
+                        // do nothing
+                    }
+                }
+
+                return fetched;
+            }
+
+            function _storeCachedOSVersion(coreConfig: IConfiguration & IConfig) {
+                // Special case check for if the runtime doesn't include the AnalyticsPlugin
+                if(coreConfig.isStorageUseDisabled !== true) {
+                    try {
+                        utlSetSessionStorage(safeGetLogger(_core), "ai_osplugin", JSON.stringify({platform: _os, platformVersion: _osVer}));
+                    } catch (error) {
+                        // do nothing
                     }
                 }
             }
 
-            function updateTeleItemWithOs(event: ITelemetryItem) {
-                if (_retrieveFullVersion){
-                    let extOS = getSetValue(getSetValue(event, strExt), Extensions.OSExt);
+            function _addUnloadHandlers(excludePageUnloadEvents?: string[]) {
+                function _unloading() {
+                    _releaseEventQueue();
+                    _removeUnloadHandlers();
+                }
+
+                // Only try and add unload handlers if we haven't already fetched the OS version
+                if (!_addedUnloadEvents && !_fetchedFullVersion) {
+                    // If page is closed release queue
+                    addPageUnloadEventListener(_unloading, excludePageUnloadEvents, _evtNamespace);
+                    addPageHideEventListener(_unloading, excludePageUnloadEvents, _evtNamespace);
+                    _addedUnloadEvents = true;
+                }
+            }
+
+            function _removeUnloadHandlers() {
+                if (_addedUnloadEvents) {
+                    removePageUnloadEventListener(null, _evtNamespace);
+                    removePageHideEventListener(null, _evtNamespace);
+                    _addedUnloadEvents = false;
+                }
+            }
+
+            /**
+             * Wait for the response from the browser for the OS version and store info in the session storage
+             */
+            function _startRetrieveOsVersion(maxTimeout: number) {
+                if (_core && !_getOSTimeout) {
+                    let nav: ModernNavigator | undefined = getNavigator() as ModernNavigator | undefined;
+                    let userAgentData = (nav || {}).userAgentData;
+                    if (userAgentData) {
+                        const getHighEntropyValues = userAgentData.getHighEntropyValues;
+                        if (getHighEntropyValues) {
+                            // Timeout request if it takes more than 200 milliseconds (by default)
+                            _getOSTimeout = scheduleTimeout(() => {
+                                _completeOsRetrieve();
+                            }, maxTimeout);
+
+                            doAwaitResponse(fnCall(getHighEntropyValues, userAgentData, ["platformVersion"]), (response: any) => {
+                                // Always mark as fetched regardless of success or failure
+                                _fetchedFullVersion = true;
+                                try {
+                                    if (!response.rejected) {
+                                        let platformVersionResponse = response.value;
+                                        if (platformVersionResponse.platformVersion && platformVersionResponse.platform) {
+                                            _os = platformVersionResponse.platform;
+                                            _osVer = parseInt(platformVersionResponse.platformVersion);
+                                            if (_os === "Windows" && !isNaN(_osVer)) {
+                                                if (_osVer == 0){
+                                                    _osVer = 8;
+                                                } else if (_osVer < 13){
+                                                    _osVer = 10;
+                                                } else{
+                                                    _osVer = 11;
+                                                }
+                                            }
+
+                                            _storeCachedOSVersion((_core || {}).config as IConfig);
+                                        }
+                                    } else {
+                                        _throwInternal(safeGetLogger(_core),
+                                            eLoggingSeverity.CRITICAL,
+                                            _eInternalMessageId.PluginException,
+                                            "Could not retrieve operating system: " + response.reason);
+                                    }
+                                } finally {
+                                    _completeOsRetrieve();
+                                }
+                            });
+                        }
+                    }
+                }
+            }
+
+            function _updateTeleItemWithOs(event: ITelemetryItem) {
+                if (_fetchedFullVersion && (_os || _osVer)) {
+                    let extOS: any = getSetValue(getSetValue(event, strExt) as any, Extensions.OSExt);
                     if (_mergeOsNameVersion){
-                        setValue(extOS, "osVer", _os + _osVer, isString);
+                        let mergedOS = (_os || "") + (_osVer ? asString(_osVer) : "");
+                        setValue(extOS, "osVer", mergedOS, isString);
                     } else {
                         setValue(extOS, "osVer", _osVer);
                         setValue(extOS, "os", _os, isString);
@@ -210,8 +274,10 @@ export class OsPlugin extends BaseTelemetryPlugin {
             function _completeOsRetrieve() {
                 if (_getOSTimeout) {
                     _getOSTimeout.cancel();
+                    _getOSTimeout = null;
                 }
-                _getOSInProgress = false;
+
+                _removeUnloadHandlers();
                 _releaseEventQueue();
             }
         
@@ -220,7 +286,7 @@ export class OsPlugin extends BaseTelemetryPlugin {
             */
             function _releaseEventQueue() {
                 arrForEach(_eventQueue, (evt) => {
-                    updateTeleItemWithOs(evt.item);
+                    _updateTeleItemWithOs(evt.item);
                     _self.processNext(evt.item, evt.ctx);
                 });
                 _eventQueue = [];
@@ -229,17 +295,18 @@ export class OsPlugin extends BaseTelemetryPlugin {
             function _initDefaults() {
                 _core = null;
                 _ocConfig = null;
-                _getOSInProgress = false;
                 _getOSTimeout = null;
-                _maxTimeout = null;
-                _retrieveFullVersion = false;
                 _eventQueue = [];
-                _firstAttempt = true;
+                _os = null;
+                _osVer = null;
+                _fetchedFullVersion = false;
+                _addedUnloadEvents = false;
+                _excludePageUnloadEvents = null;
             }
             
             // Special internal method to allow the DebugPlugin to hook embedded objects
             _self["_getDbgPlgTargets"] = () => {
-                return [_platformVersionResponse, _eventQueue, _getOSInProgress];
+                return [ { platform: _os, platformVersion: _osVer }, _eventQueue, !!_getOSTimeout];
             };
         });
     }

--- a/shared/AppInsightsCore/Tests/Unit/src/ai/ThrottleMgr.tests.ts
+++ b/shared/AppInsightsCore/Tests/Unit/src/ai/ThrottleMgr.tests.ts
@@ -44,6 +44,41 @@ const compareDates = (date1: Date, date: string | Date, expectedSame: boolean = 
     Assert.equal(isSame, expectedSame, "checking that the dates where as expected");
 }
 
+const getUtcDaysInMonth = (year: number, month: number) => {
+    return daysInMonth[month] + (month === 1 && isLeapYear(year) ? 1 : 0);
+}
+
+const createUtcDate = (year: number, month: number, day: number) => {
+    return new Date(Date.UTC(year, month, day, 12, 0, 0, 0));
+}
+
+const createUtcDateMonthsAgo = (monthsAgo: number) => {
+    let now = new Date();
+    let year = now.getUTCFullYear();
+    let month = now.getUTCMonth() - monthsAgo;
+    let day = now.getUTCDate();
+
+    while (month < 0) {
+        month += 12;
+        year -= 1;
+    }
+
+    day = Math.min(day, getUtcDaysInMonth(year, month));
+    return createUtcDate(year, month, day);
+}
+
+const createUtcDateDaysAgo = (daysAgo: number) => {
+    let now = new Date();
+    return new Date(Date.UTC(
+        now.getUTCFullYear(),
+        now.getUTCMonth(),
+        now.getUTCDate() - daysAgo,
+        now.getUTCHours(),
+        now.getUTCMinutes(),
+        now.getUTCSeconds(),
+        now.getUTCMilliseconds()));
+}
+
 export class ThrottleMgrTest extends AITestClass {
     private _core: IAppInsightsCore<IConfiguration & IConfig>;
     private _msgKey: number;
@@ -758,19 +793,7 @@ export class ThrottleMgrTest extends AITestClass {
         this.testCase({
             name: "ThrottleMgrTest: should not trigger throttle when month interval requirements are not meet",
             test: () => {
-                let date = new Date();
-                let month = date.getUTCMonth();
-                let year = date.getUTCFullYear();
-                if (month == 0) {
-                    date.setUTCFullYear(year-1);
-                    date.setUTCMonth(11);
-                } else {
-                    let dayOfMonth = date.getDate();
-                    if (dayOfMonth > (daysInMonth[month - 1] + (month === 2 ? (isLeapYear(year - 1) ? 1 : 0 ) : 0 ))) {
-                        date.setDate(daysInMonth[month - 1] + (month === 2 ? (isLeapYear(year - 1) ? 1 : 0 ) : 0 ));
-                    }
-                    date.setUTCMonth(month-1);
-                }
+                let date = createUtcDateMonthsAgo(1);
                 let storageObj = {
                     date: date,
                     count: 0
@@ -807,21 +830,7 @@ export class ThrottleMgrTest extends AITestClass {
         this.testCase({
             name: "ThrottleMgrTest: should not trigger throttle when year and month interval requirements are not meet",
             test: () => {
-                let date = new Date();
-                let month = date.getUTCMonth();
-                let year = date.getUTCFullYear();
-             
-                if (month == 0) {
-                    date.setUTCFullYear(year-2);
-                    date.setUTCMonth(11);
-                } else {
-                    date.setUTCFullYear(year-1);
-                    let dayOfMonth = date.getDate();
-                    if (dayOfMonth > (daysInMonth[month - 1] + (month === 2 ? (isLeapYear(year - 1) ? 1 : 0 ) : 0 ))) {
-                        date.setDate(daysInMonth[month - 1] + (month === 2 ? (isLeapYear(year - 1) ? 1 : 0 ) : 0 ));
-                    }
-                    date.setUTCMonth(month-1);
-                }
+                let date = createUtcDateMonthsAgo(13);
                 let storageObj = {
                     date: date,
                     count: 0
@@ -859,17 +868,7 @@ export class ThrottleMgrTest extends AITestClass {
         this.testCase({
             name: "ThrottleMgrTest: should not trigger throttle when day interval requirements are not meet",
             test: () => {
-                let date = new Date();
-                let curDate = date.getUTCDate();
-                let curMonth = date.getUTCMonth();
-                if (curDate === 1) {
-                    curMonth -= 1;
-                    curDate = 28;
-                } else {
-                    curDate -= 1;
-                }
-                date.setUTCDate(curDate);
-                date.setUTCMonth(curMonth);
+                let date = createUtcDateDaysAgo(1);
                 let storageObj = {
                     date: date,
                     count: 0

--- a/shared/AppInsightsCore/src/diagnostics/DiagnosticLogger.ts
+++ b/shared/AppInsightsCore/src/diagnostics/DiagnosticLogger.ts
@@ -97,7 +97,7 @@ export class _InternalLogMessage{
 
 /*#__NO_SIDE_EFFECTS__*/
 export function safeGetLogger(core: IAppInsightsCore, config?: IConfiguration): IDiagnosticLogger {
-    return (core || {} as any).logger || new DiagnosticLogger(config);
+    return (core || {} as any).logger || new DiagnosticLogger(config || (core || {}).config);
 }
   
 export class DiagnosticLogger implements IDiagnosticLogger {

--- a/shared/AppInsightsCore/src/enums/ai/UrlRedactionOptions.ts
+++ b/shared/AppInsightsCore/src/enums/ai/UrlRedactionOptions.ts
@@ -73,7 +73,7 @@ export const UrlRedactionOptions = (/* @__PURE__ */ createEnumStyle<typeof eUrlR
     /**
      * This will only redact the query parameter in the default set of query parameters to redact. It will not redact username and password.
      */
-    queryParamsOnly: eUrlRedactionOptions.queryParamsOnly,
+    queryParamsOnly: eUrlRedactionOptions.queryParamsOnly
 
 }));
 


### PR DESCRIPTION
- Refactor OsPlugin to start OS version retrieval during initialize() instead of waiting for the first telemetry event, reducing latency for the initial tracked events
- Add page unload/pagehide/visibilitychange event handlers to flush the queued telemetry when the page is being unloaded before the OS lookup completes
- Respect disableFlushOnUnload config to skip registering unload handlers when disabled
- Properly clean up unload event handlers after OS version is resolved
- Improve session storage caching: validate cached OS data on load and guard writes behind isStorageUseDisabled config check
- Use safeGetLogger and getNavigator() instead of direct navigator/core.logger access for safer operation when core may not be fully initialized
- Fix safeGetLogger to fall back to core.config when no explicit config is provided