### PR TITLE
Potential fix for code scanning alert no. 4240: Semicolon insertion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ 16, 18, 20 ]
+        node-version: [ 18, 20, 22, 24 ]
 
     steps:
     - uses: actions/checkout@v4

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,7 +2,12 @@
 
 > Note: ES3/IE8 compatibility will be removed in the future v3.x.x releases (scheduled for mid-late 2022), so if you need to retain ES3 compatibility you will need to remain on the 2.x.x versions of the SDK or your runtime will need install polyfill's to your ES3 environment before loading / initializing the SDK.
 
-<!-- ## Unreleased Changes -->
+## Unreleased Changes
+
+### CI / Tooling
+
+- **Dropped Node.js 16 from CI matrix**: Node.js 16 is End-of-Life and several dependencies (e.g. `puppeteer`, `@pnpm/error`) now require Node.js 18 or later. The CI pipeline no longer runs against Node.js 16.
+- **Added Node.js 22 and 24 to CI matrix**: The CI pipeline now tests against Node.js 18, 20, 22, and 24.
 
 ## 3.4.1 (April 7th, 2026)
 

--- a/channels/applicationinsights-channel-js/src/Sender.ts
+++ b/channels/applicationinsights-channel-js/src/Sender.ts
@@ -1014,7 +1014,7 @@ export class Sender extends BaseTelemetryPlugin implements IChannelControls {
                     // }
 
                     return _getOnComplete(payload, status, headers, response);
-                }
+                };
                 let payloadData = _getPayload(payload);
                 // if (payloadData) {
                 //     payloadData.statsBeatData = {startTime: dateNow()};

--- a/shared/AppInsightsCore/src/diagnostics/DiagnosticLogger.ts
+++ b/shared/AppInsightsCore/src/diagnostics/DiagnosticLogger.ts
@@ -167,7 +167,7 @@ export class DiagnosticLogger implements IDiagnosticLogger {
                         _debugExtMsg("throw" + (severity === eLoggingSeverity.CRITICAL ? "Critical" : "Warning"), message);
                     }
                 }
-            }
+            };
 
             _self.debugToConsole = (message: string) => {
                 _logToConsole("debug", message);


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/ApplicationInsights-JS/security/code-scanning/4240](https://github.com/microsoft/ApplicationInsights-JS/security/code-scanning/4240)

Add an explicit semicolon after the `onComplete` arrow-function assignment in `_doSend` in `channels/applicationinsights-channel-js/src/Sender.ts`.

- General fix: when assigning function expressions/arrow functions to variables, terminate the assignment with `;` explicitly rather than relying on ASI.
- Specific fix: change line 1017 from `}` to `};` in the `_doSend(...)` function.
- No imports, new methods, or new definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
