### PR TITLE
Potential fix for code scanning alert no. 5401: Unused variable, import, function or class

### DIFF
--- a/extensions/applicationinsights-properties-js/src/PropertiesPlugin.ts
+++ b/extensions/applicationinsights-properties-js/src/PropertiesPlugin.ts
@@ -7,7 +7,7 @@ import dynamicProto from "@microsoft/dynamicproto-js";
 import {
     BaseTelemetryPlugin, BreezeChannelIdentifier, IAppInsightsCore, IConfig, IConfigDefaults, IConfiguration, IPlugin,
     IProcessTelemetryContext, IProcessTelemetryUnloadContext, IPropertiesPlugin, ITelemetryItem, ITelemetryPluginChain,
-    ITelemetryUnloadState, PageView, PageViewEnvelopeType, PropertiesPluginIdentifier, _InternalLogMessage, _eInternalMessageId,
+    ITelemetryUnloadState, PageViewEnvelopeType, PropertiesPluginIdentifier, _InternalLogMessage, _eInternalMessageId,
     _logInternalMessage, createProcessTelemetryContext, eLoggingSeverity, getNavigator, getSetValue, isNullOrUndefined, onConfigChange,
     utlSetStoragePrefix
 } from "@microsoft/applicationinsights-core-js";


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/ApplicationInsights-JS/security/code-scanning/5401](https://github.com/microsoft/ApplicationInsights-JS/security/code-scanning/5401)

Remove the unused `PageView` symbol from the named import list in `extensions/applicationinsights-properties-js/src/PropertiesPlugin.ts`.

- General fix: for unused import findings, delete only the unused imported identifier while keeping the module import and all used identifiers intact.
- Best minimal change here: in the `@microsoft/applicationinsights-core-js` import block (around lines 8–11), remove `PageView` and keep `PageViewEnvelopeType` (and all others) unchanged.
- No new methods, definitions, or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
