### PR TITLE
Potential fix for code scanning alert no. 5402: Semicolon insertion

### DIFF
--- a/shared/AppInsightsCore/src/diagnostics/DiagnosticLogger.ts
+++ b/shared/AppInsightsCore/src/diagnostics/DiagnosticLogger.ts
@@ -167,7 +167,7 @@ export class DiagnosticLogger implements IDiagnosticLogger {
                         _debugExtMsg("throw" + (severity === eLoggingSeverity.CRITICAL ? "Critical" : "Warning"), message);
                     }
                 }
-            }
+            };
 
             _self.debugToConsole = (message: string) => {
                 _logToConsole("debug", message);


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/ApplicationInsights-JS/security/code-scanning/5402](https://github.com/microsoft/ApplicationInsights-JS/security/code-scanning/5402)

Add an explicit semicolon after the `_self.throwInternal = (...) => { ... }` assignment in `shared/AppInsightsCore/src/diagnostics/DiagnosticLogger.ts` (the block ending at current line 170).

Best fix without changing functionality:
- Change the closing `}` of that assignment statement to `};`.
- Do not alter logic, imports, or surrounding methods.

No new methods/imports/definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
