### PR TITLE
Potential fix for code scanning alert no. 5940: Unused variable, import, function or class

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,4 +1,3 @@
-const { default: replace } = require("@rollup/plugin-replace");
 
 module.exports = function (grunt) {
 


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/ApplicationInsights-JS/security/code-scanning/5940](https://github.com/microsoft/ApplicationInsights-JS/security/code-scanning/5940)

General fix: remove the unused declared program element (variable/import/function/class) when it is not referenced.

Best fix here: in `gruntfile.js`, delete the unused import on line 1:
- Remove `const { default: replace } = require("@rollup/plugin-replace");`
No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
