### PR TITLE
Potential fix for code scanning alert no. 2273: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ 16, 18, 20 ]
+        node-version: [ 18, 20, 22, 24 ]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@
 
 name: Node.js CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, master, beta, Release2.7, release-3.0 ]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,7 +2,12 @@
 
 > Note: ES3/IE8 compatibility will be removed in the future v3.x.x releases (scheduled for mid-late 2022), so if you need to retain ES3 compatibility you will need to remain on the 2.x.x versions of the SDK or your runtime will need install polyfill's to your ES3 environment before loading / initializing the SDK.
 
-<!-- ## Unreleased Changes -->
+## Unreleased Changes
+
+### CI / Tooling
+
+- **Dropped Node.js 16 from CI matrix**: Node.js 16 is End-of-Life and several dependencies (e.g. `puppeteer`, `@pnpm/error`) now require Node.js 18 or later. The CI pipeline no longer runs against Node.js 16.
+- **Added Node.js 22 and 24 to CI matrix**: The CI pipeline now tests against Node.js 18, 20, 22, and 24.
 
 ## 3.4.1 (April 7th, 2026)
 


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/ApplicationInsights-JS/security/code-scanning/2273](https://github.com/microsoft/ApplicationInsights-JS/security/code-scanning/2273)

Add an explicit `permissions` block at the workflow root so it applies to all jobs (currently just `build`) without changing workflow behavior. The minimal required permission for this CI flow is `contents: read`, which supports `actions/checkout` and read-only repository access.

Edit `.github/workflows/ci.yml` near the top-level keys, immediately after `name` (or before `jobs`), and add:

```yml
permissions:
  contents: read
```

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
