### PR TITLE
fix(security): pin tar >=7.5.16 to remediate CVE-2026-53655

### DIFF
--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/pnpm-config.schema.json",
   "globalOverrides": {
     "minimatch": ">=3.1.5",
-    "tar": ">=7.5.13",
+    "tar": ">=7.5.16",
     "glob": ">=7.2.3",
     "lodash": ">=4.18.1",
     "postcss": ">=8.5.14",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "overrides": {
         "basic-ftp": ">=5.2.0",
         "form-data": "^2.5.5",
-        "tar": "^7.5.13",
+        "tar": ">=7.5.16",
         "glob": "^7.2.3",
         "lodash": "^4.18.1",
         "minimatch": "^3.1.5"


### PR DESCRIPTION
Bump the tar floor from ^7.5.13/>=7.5.13 to >=7.5.16 in the root npm 'overrides' and the Rush pnpm globalOverrides so installs resolve a patched tar (>=7.5.16). Mitigates the node-tar PAX size override file-smuggling vulnerability (GHSA-vmf3-w455-68vh).