### PR TITLE
fix(test): stabilize flaky SpanLifeCycle custom endTime test

### DIFF
--- a/AISKU/Tests/Unit/src/SpanLifeCycle.Tests.ts
+++ b/AISKU/Tests/Unit/src/SpanLifeCycle.Tests.ts
@@ -570,7 +570,16 @@ export class SpanLifeCycleTests extends AITestClass {
             test: () => {
                 // Arrange
                 const span = this._ai.startSpan("endtime-custom");
-                const customEndTime = Date.now();
+
+                // Derive the custom end time from the span's own start time so the
+                // round-trip comparison stays within the same time domain the SDK
+                // uses internally (perf timeOrigin based). Using Date.now() directly
+                // is unreliable on some CI hosts where the system wall clock can drift
+                // slightly behind the span start time, which causes end() to clamp the
+                // duration to zero (endTime === startTime) and fail the tolerance check.
+                const startTime = span?.startTime;
+                const startMs = startTime ? (startTime[0] * 1000 + startTime[1] / 1000000) : Date.now();
+                const customEndTime = startMs + 1000; // 1 second after the span start
 
                 // Act
                 span?.end(customEndTime);


### PR DESCRIPTION
The "EndTime: custom endTime is respected" test used Date.now() as the custom span end time and asserted the recorded endTime round-tripped within 10ms. The span start time is derived from performance.timeOrigin + performance.now(), not Date.now(). On loaded/virtualized CI hosts (observed on the Windows build container, Node 20) the system wall clock can drift slightly behind the span's perf-based start time. When Date.now() lands before the span start, span.end() clamps the duration to zero and sets endTime === startTime, so the round-trip difference exceeds the 10ms tolerance and the test intermittently fails (763 tests, 1 failed).

Derive the custom end time from the span's own startTime so the comparison stays within the same time domain the SDK uses internally. This guarantees end > start (no zero-duration clamping) and keeps the value in the epoch range for an exact millisToHrTime round-trip, making the assertion deterministic.