### PR TITLE
Bump Rush 5.178.1 and pnpm 10.34.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     },
     "homepage": "https://github.com/microsoft/ApplicationInsights-JS#readme",
     "devDependencies": {
-        "@microsoft/rush": "5.175.1",
+        "@microsoft/rush": "5.178.1",
         "@nevware21/grunt-eslint-ts": "^0.5.2",
         "@nevware21/grunt-ts-plugin": "^0.5.2",
         "@rollup/plugin-commonjs": "^24.0.0",

--- a/rush.json
+++ b/rush.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush.schema.json",
-  "pnpmVersion": "9.15.9",
-  "rushVersion": "5.175.1",
+  "pnpmVersion": "10.34.5",
+  "rushVersion": "5.178.1",
   "projectFolderMaxDepth": 4,
   "projects": [
     {


### PR DESCRIPTION
Updates the Rush engine and pnpm to pull in patched transitive dependencies (tar, brace-expansion, ip-address) that are bundled with the newer pnpm 10 / Rush 5.178.1 toolchain.

- rush.json: pnpmVersion 9.15.9 -> 10.34.5, rushVersion 5.175.1 -> 5.178.1

- package.json: @microsoft/rush devDependency 5.175.1 -> 5.178.1