### PR TITLE
fix(otel): propagate promise rejection from startActiveSpan async callback 

### DIFF
--- a/channels/applicationinsights-channel-js/Tests/Unit/src/Sample.tests.ts
+++ b/channels/applicationinsights-channel-js/Tests/Unit/src/Sample.tests.ts
@@ -117,7 +117,7 @@ export class SampleTests extends AITestClass {
 
                 // setup
                 const errorRange = 5;
-                const totalItems = 1000;
+                const totalItems = 10000;
                 const ids = [];
                 for (let i = 0; i < totalItems; ++i) {
                     ids.push(newId());
@@ -136,7 +136,7 @@ export class SampleTests extends AITestClass {
                     // Assert
                     const actualSampleRate = 100 * countOfSampledItems / totalItems;
                     QUnit.assert.ok(Math.abs(actualSampleRate - sampleRate) < errorRange,
-                        "Actual sampling (" + actualSampleRate + ") does not fall into +-2% range from expected rate (" + sampleRate + ")");
+                        "Actual sampling (" + actualSampleRate + ") does not fall into +-" + errorRange + "% range from expected rate (" + sampleRate + ")");
                 });
             }
         });

--- a/shared/AppInsightsCore/Tests/Unit/src/trace/span.Tests.ts
+++ b/shared/AppInsightsCore/Tests/Unit/src/trace/span.Tests.ts
@@ -1,6 +1,6 @@
 import { Assert, AITestClass } from "@microsoft/ai-test-framework";
 import { getDeferred, ICachedValue, isNullOrUndefined, mathMin, objDefine, perfNow, strSubstr } from "@nevware21/ts-utils";
-import { createPromise, doAwait } from "@nevware21/ts-async";
+import { createRejectedPromise, doAwait } from "@nevware21/ts-async";
 import { createSpan } from "../../../../src/otel/api/trace/span";
 import { createOTelApi } from "../../../../src/otel/api/OTelApi";
 import { IOTelSpanCtx } from "../../../../src/interfaces/otel/trace/IOTelSpanCtx";
@@ -1046,6 +1046,7 @@ export class SpanTests extends AITestClass {
                 const otelApi = createOTelApi({ host: core });
                 const tracer = otelApi.trace.getTracer("test-tracer");
                 const initialActiveSpan = core.getActiveSpan();
+                const expectedError = new Error("boom");
 
                 let spanInsideCallback: IReadableSpan | null = null;
 
@@ -1053,31 +1054,22 @@ export class SpanTests extends AITestClass {
                 // returned promise to reject rather than silently resolve with undefined.
                 const result = tracer.startActiveSpan("reject-operation", (span) => {
                     spanInsideCallback = span;
-                    return createPromise((_resolve, reject) => {
-                        reject(new Error("boom"));
-                    });
+                    return createRejectedPromise(expectedError);
                 });
 
                 // Assert - the returned value must be a rejecting promise
-                return createPromise<void>((resolve, reject) => {
-                    doAwait(
-                        result,
-                        (value) => {
-                            reject(new Error("Expected the returned promise to reject, but it resolved with: " + value));
-                        },
-                        (reason: any) => {
-                            try {
-                                Assert.equal(reason && reason.message, "boom", "Rejection reason should be propagated to the caller");
-                                Assert.ok(spanInsideCallback, "Span should have been created");
-                                Assert.ok(spanInsideCallback!.ended, "Span should be ended even after rejection");
-                                Assert.equal(core.getActiveSpan(), initialActiveSpan, "Active span should be restored after rejection");
-                                resolve();
-                            } catch (e) {
-                                reject(e);
-                            }
-                        }
-                    );
-                });
+                return doAwait(
+                    result,
+                    () => {
+                        Assert.ok(false, "Expected the returned promise to reject, but it resolved");
+                    },
+                    (reason: any) => {
+                        Assert.equal(reason, expectedError, "Rejection reason should be propagated to the caller");
+                        Assert.ok(spanInsideCallback, "Span should have been created");
+                        Assert.ok(spanInsideCallback!.ended, "Span should be ended even after rejection");
+                        Assert.equal(core.getActiveSpan(), initialActiveSpan, "Active span should be restored after rejection");
+                    }
+                );
             }
         });
 

--- a/shared/AppInsightsCore/Tests/Unit/src/trace/span.Tests.ts
+++ b/shared/AppInsightsCore/Tests/Unit/src/trace/span.Tests.ts
@@ -1,5 +1,6 @@
 import { Assert, AITestClass } from "@microsoft/ai-test-framework";
 import { getDeferred, ICachedValue, isNullOrUndefined, mathMin, objDefine, perfNow, strSubstr } from "@nevware21/ts-utils";
+import { createPromise, doAwait } from "@nevware21/ts-async";
 import { createSpan } from "../../../../src/otel/api/trace/span";
 import { createOTelApi } from "../../../../src/otel/api/OTelApi";
 import { IOTelSpanCtx } from "../../../../src/interfaces/otel/trace/IOTelSpanCtx";
@@ -1033,6 +1034,49 @@ export class SpanTests extends AITestClass {
                     // Verify active span is restored after async callback completes
                     const activeSpanAfterCallback = core.getActiveSpan();
                     Assert.equal(activeSpanAfterCallback, initialActiveSpan, "Active span should be restored after async callback");
+                });
+            }
+        });
+
+        this.testCase({
+            name: "Tracer.startActiveSpan: should propagate rejection from async callback (issue #2749)",
+            test: () => {
+                // Arrange
+                const core = this._setupCore();
+                const otelApi = createOTelApi({ host: core });
+                const tracer = otelApi.trace.getTracer("test-tracer");
+                const initialActiveSpan = core.getActiveSpan();
+
+                let spanInsideCallback: IReadableSpan | null = null;
+
+                // Act - a callback that returns a rejected promise should cause the
+                // returned promise to reject rather than silently resolve with undefined.
+                const result = tracer.startActiveSpan("reject-operation", (span) => {
+                    spanInsideCallback = span;
+                    return createPromise((_resolve, reject) => {
+                        reject(new Error("boom"));
+                    });
+                });
+
+                // Assert - the returned value must be a rejecting promise
+                return createPromise<void>((resolve, reject) => {
+                    doAwait(
+                        result,
+                        (value) => {
+                            reject(new Error("Expected the returned promise to reject, but it resolved with: " + value));
+                        },
+                        (reason: any) => {
+                            try {
+                                Assert.equal(reason && reason.message, "boom", "Rejection reason should be propagated to the caller");
+                                Assert.ok(spanInsideCallback, "Span should have been created");
+                                Assert.ok(spanInsideCallback!.ended, "Span should be ended even after rejection");
+                                Assert.equal(core.getActiveSpan(), initialActiveSpan, "Active span should be restored after rejection");
+                                resolve();
+                            } catch (e) {
+                                reject(e);
+                            }
+                        }
+                    );
                 });
             }
         });

--- a/shared/AppInsightsCore/src/otel/api/trace/utils.ts
+++ b/shared/AppInsightsCore/src/otel/api/trace/utils.ts
@@ -215,20 +215,22 @@ export function startActiveSpan<T extends ITraceHost, F extends (this: ThisParam
             useAsync = true;
 
             return doAwait(result,
-                (value) => value,
+                (value) => {
+                    if (span) {
+                        span.end();
+                    }
+
+                    return value;
+                },
                 (reason) => {
                     if (span) {
                         span.setStatus({ code: reason ? eOTelSpanStatusCode.ERROR : eOTelSpanStatusCode.OK, message: reason ? reason.message || reason : undefined });
+                        span.end();
                     }
 
                     // Re-throw the rejection so the returned promise rejects rather than
                     // silently resolving with undefined (see issue #2749).
                     throw reason;
-                },
-                () => {
-                    if (span) {
-                        span.end();
-                    }
                 }) as ReturnType<F>;
         }
 

--- a/shared/AppInsightsCore/src/otel/api/trace/utils.ts
+++ b/shared/AppInsightsCore/src/otel/api/trace/utils.ts
@@ -220,6 +220,10 @@ export function startActiveSpan<T extends ITraceHost, F extends (this: ThisParam
                     if (span) {
                         span.setStatus({ code: reason ? eOTelSpanStatusCode.ERROR : eOTelSpanStatusCode.OK, message: reason ? reason.message || reason : undefined });
                     }
+
+                    // Re-throw the rejection so the returned promise rejects rather than
+                    // silently resolving with undefined (see issue #2749).
+                    throw reason;
                 },
                 () => {
                     if (span) {


### PR DESCRIPTION

startActiveSpan swallowed rejections from async callbacks: the doAwait reject handler set the span status but never re-threw the reason, so the returned promise resolved with undefined instead of rejecting.

Re-throw the rejection reason so the returned promise rejects, matching the synchronous catch path. Adds a regression test covering rejection propagation, span end, and active-span restoration.

Fixes #2749